### PR TITLE
Implement P1 requirements: session control, agent task kanban, full chat experience

### DIFF
--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -60,6 +60,16 @@
 		FD03671AAB65C52CE827D3DA /* AgentBoardCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; };
 		FD05A98C162D7CC536D93096 /* AgentBoardApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC92FF930020DC82D470A002 /* AgentBoardApp.swift */; };
 		FF4D3F1289548330CC170576 /* ChatStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F925ACBB136730BD7852D8B /* ChatStoreTests.swift */; };
+		9DC2916084960BEE07E99619 /* IssueDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D77987A4B5EF331BFE0D6C4 /* IssueDetailSheet.swift */; };
+		44333869C41059CA9A61BE1E /* IssueDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D77987A4B5EF331BFE0D6C4 /* IssueDetailSheet.swift */; };
+		694FF6EB3E7133E1B2B3ADE4 /* CreateIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67254F36AB36239879066768 /* CreateIssueSheet.swift */; };
+		1C53BF2A7A3755291B5CB130 /* CreateIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67254F36AB36239879066768 /* CreateIssueSheet.swift */; };
+		435C19C402D46C4B78ABDBAF /* SessionDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C3446E73730D8F5DD72B9E /* SessionDetailSheet.swift */; };
+		9A65E68F9ABCC90496A8A8AF /* SessionDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C3446E73730D8F5DD72B9E /* SessionDetailSheet.swift */; };
+		E4EAE906B382CA1E384E6186 /* TaskDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202FA8107E1B25BAF3537746 /* TaskDetailSheet.swift */; };
+		A4EC72CA9DB97B026D0ABB8A /* TaskDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202FA8107E1B25BAF3537746 /* TaskDetailSheet.swift */; };
+		2A5AE5CC8A832C10AB9D626E /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311049C18C4B545AAF87D548 /* MarkdownText.swift */; };
+		06817AD5564D505308B3B6E8 /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311049C18C4B545AAF87D548 /* MarkdownText.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -188,6 +198,11 @@
 		F6FDDFF5030B377E6973E969 /* ChatScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScreen.swift; sourceTree = "<group>"; };
 		F876603AEC9BE7B94289CA01 /* SettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStore.swift; sourceTree = "<group>"; };
 		FFA60A5A5B633630F99A562B /* GitHubWorkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubWorkService.swift; sourceTree = "<group>"; };
+		8D77987A4B5EF331BFE0D6C4 /* IssueDetailSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailSheet.swift; sourceTree = "<group>"; };
+		67254F36AB36239879066768 /* CreateIssueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateIssueSheet.swift; sourceTree = "<group>"; };
+		E0C3446E73730D8F5DD72B9E /* SessionDetailSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDetailSheet.swift; sourceTree = "<group>"; };
+		202FA8107E1B25BAF3537746 /* TaskDetailSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailSheet.swift; sourceTree = "<group>"; };
+		311049C18C4B545AAF87D548 /* MarkdownText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownText.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -326,6 +341,10 @@
 				33A654F28E691A722E5B4F02 /* SessionsScreen.swift */,
 				D7A095E80382BA922486329A /* SettingsScreen.swift */,
 				6D876290D32059BAB65A9F02 /* WorkScreen.swift */,
+				8D77987A4B5EF331BFE0D6C4 /* IssueDetailSheet.swift */,
+				67254F36AB36239879066768 /* CreateIssueSheet.swift */,
+				E0C3446E73730D8F5DD72B9E /* SessionDetailSheet.swift */,
+				202FA8107E1B25BAF3537746 /* TaskDetailSheet.swift */,
 			);
 			path = Screens;
 			sourceTree = "<group>";
@@ -375,6 +394,7 @@
 			children = (
 				34D736CF52ACD4E2BD9D3ADC /* BoardChrome.swift */,
 				1A169A5D550028B6D20B397D /* DomainPills.swift */,
+				311049C18C4B545AAF87D548 /* MarkdownText.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -638,6 +658,11 @@
 				27A53DE53D6AC0A8E55FBC88 /* SessionsScreen.swift in Sources */,
 				6D00DE9CB56AACF6C1A4C803 /* SettingsScreen.swift in Sources */,
 				6CECA83E59FDE511B3849448 /* WorkScreen.swift in Sources */,
+				9DC2916084960BEE07E99619 /* IssueDetailSheet.swift in Sources */,
+				694FF6EB3E7133E1B2B3ADE4 /* CreateIssueSheet.swift in Sources */,
+				435C19C402D46C4B78ABDBAF /* SessionDetailSheet.swift in Sources */,
+				E4EAE906B382CA1E384E6186 /* TaskDetailSheet.swift in Sources */,
+				2A5AE5CC8A832C10AB9D626E /* MarkdownText.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -696,6 +721,11 @@
 				00D375A5EA8AC4E04D19445A /* SessionsScreen.swift in Sources */,
 				DB87AF9AF4B7456FBDD3F011 /* SettingsScreen.swift in Sources */,
 				8E7838693E07455607245B77 /* WorkScreen.swift in Sources */,
+				44333869C41059CA9A61BE1E /* IssueDetailSheet.swift in Sources */,
+				1C53BF2A7A3755291B5CB130 /* CreateIssueSheet.swift in Sources */,
+				9A65E68F9ABCC90496A8A8AF /* SessionDetailSheet.swift in Sources */,
+				A4EC72CA9DB97B026D0ABB8A /* TaskDetailSheet.swift in Sources */,
+				06817AD5564D505308B3B6E8 /* MarkdownText.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AgentBoard/DesktopRootView.swift
+++ b/AgentBoard/DesktopRootView.swift
@@ -6,9 +6,25 @@ struct DesktopRootView: View {
 
     var body: some View {
         NavigationSplitView {
-            List(AppDestination.allCases, selection: Bindable(appModel).selectedDestination) { destination in
-                Label(destination.title, systemImage: destination.systemImage)
-                    .tag(destination)
+            List(selection: Bindable(appModel).selectedDestination) {
+                Section("Workspace") {
+                    Label(AppDestination.chat.title, systemImage: AppDestination.chat.systemImage)
+                        .tag(AppDestination.chat)
+                    Label(AppDestination.work.title, systemImage: AppDestination.work.systemImage)
+                        .tag(AppDestination.work)
+                }
+
+                Section("Runtime") {
+                    Label(AppDestination.agents.title, systemImage: AppDestination.agents.systemImage)
+                        .tag(AppDestination.agents)
+                    Label(AppDestination.sessions.title, systemImage: AppDestination.sessions.systemImage)
+                        .tag(AppDestination.sessions)
+                }
+
+                Section {
+                    Label(AppDestination.settings.title, systemImage: AppDestination.settings.systemImage)
+                        .tag(AppDestination.settings)
+                }
             }
             .navigationTitle("AgentBoard")
             .scrollContentBackground(.hidden)
@@ -16,6 +32,10 @@ struct DesktopRootView: View {
             destinationView(for: appModel.selectedDestination)
         }
         .toolbar {
+            ToolbarItem(placement: .status) {
+                connectionStatusChip
+            }
+
             ToolbarItem(placement: .primaryAction) {
                 Button {
                     Task { await appModel.refreshAll() }
@@ -23,6 +43,26 @@ struct DesktopRootView: View {
                     Label("Refresh", systemImage: "arrow.clockwise")
                 }
             }
+        }
+    }
+
+    private var connectionStatusChip: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(connectionDotColor)
+                .frame(width: 8, height: 8)
+            Text(appModel.chatStore.connectionState.title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var connectionDotColor: Color {
+        switch appModel.chatStore.connectionState {
+        case .connected: BoardPalette.mint
+        case .connecting, .reconnecting: BoardPalette.gold
+        case .failed: BoardPalette.coral
+        case .disconnected: BoardPalette.cobalt
         }
     }
 

--- a/AgentBoardCompanionKit/CompanionLocalProbe.swift
+++ b/AgentBoardCompanionKit/CompanionLocalProbe.swift
@@ -64,6 +64,7 @@ public actor CompanionLocalProbe {
             lastSeenAt: now,
             pid: process.pid,
             tmuxSession: matchedPane?.sessionName,
+            tmuxPaneID: matchedPane?.paneID,
             lastOutput: output
         )
     }
@@ -137,16 +138,16 @@ public actor CompanionLocalProbe {
     }
 
     public func captureOutput(for session: AgentSession) -> String? {
-        if let tmuxSession = session.tmuxSession {
-            return shell("/usr/bin/tmux", ["capture-pane", "-t", tmuxSession, "-p", "-S", "-200"])
-                .flatMap { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : $0 }
-        }
-        return nil
+        let target = session.tmuxPaneID ?? session.tmuxSession
+        guard let target else { return nil }
+        return shell("/usr/bin/env", ["tmux", "capture-pane", "-t", target, "-p", "-S", "-200"])
+            .flatMap { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : $0 }
     }
 
     public func nudge(session: AgentSession) -> Bool {
-        if let tmuxSession = session.tmuxSession {
-            return shell("/usr/bin/tmux", ["send-keys", "-t", tmuxSession, "", "Enter"]) != nil
+        let target = session.tmuxPaneID ?? session.tmuxSession
+        if let target {
+            return shell("/usr/bin/env", ["tmux", "send-keys", "-t", target, "", "Enter"]) != nil
         }
         if let pid = session.pid {
             return kill(Int32(pid), SIGCONT) == 0
@@ -156,7 +157,7 @@ public actor CompanionLocalProbe {
 
     public func stop(session: AgentSession) -> Bool {
         if let tmuxSession = session.tmuxSession {
-            return shell("/usr/bin/tmux", ["kill-session", "-t", tmuxSession]) != nil
+            return shell("/usr/bin/env", ["tmux", "kill-session", "-t", tmuxSession]) != nil
         }
         if let pid = session.pid {
             return kill(Int32(pid), SIGTERM) == 0
@@ -172,8 +173,8 @@ public actor CompanionLocalProbe {
 
     private func listTmuxPanes() -> [TmuxPane] {
         guard let output = shell(
-            "/usr/bin/tmux",
-            ["list-panes", "-a", "-F", "#{pane_pid} #{session_name} #{pane_id}"]
+            "/usr/bin/env",
+            ["tmux", "list-panes", "-a", "-F", "#{pane_pid} #{session_name} #{pane_id}"]
         ) else {
             return []
         }
@@ -195,7 +196,7 @@ public actor CompanionLocalProbe {
     }
 
     private func capturePane(paneID: String) -> String? {
-        shell("/usr/bin/tmux", ["capture-pane", "-t", paneID, "-p", "-S", "-200"])
+        shell("/usr/bin/env", ["tmux", "capture-pane", "-t", paneID, "-p", "-S", "-200"])
             .flatMap { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : $0 }
     }
 

--- a/AgentBoardCompanionKit/CompanionLocalProbe.swift
+++ b/AgentBoardCompanionKit/CompanionLocalProbe.swift
@@ -29,95 +29,111 @@ public actor CompanionLocalProbe {
     public func snapshot(tasks: [AgentTask]) -> CompanionProbeSnapshot {
         let now = Date()
         let machineName = Host.current().localizedName ?? "Local Machine"
-        let processes = runningProcesses()
         let tmuxPanes = listTmuxPanes()
-
-        let sessions = processes.compactMap { process -> AgentSession? in
-            guard let signature = signatures.first(where: { process.commandLine.contains($0.keyword) }) else {
-                return nil
-            }
-
-            let linkedTask = tasks.first {
-                $0.sessionID == "proc-\(process.pid)" ||
-                    $0.assignedAgent.compare(signature.name, options: .caseInsensitive) == .orderedSame
-            }
-
-            let matchedPane = tmuxPanes.first { $0.pid == process.pid }
-            let output = matchedPane.flatMap { capturePane(paneID: $0.paneID) }
-
-            return AgentSession(
-                id: "proc-\(process.pid)",
-                source: machineName,
-                status: .running,
-                linkedTaskID: linkedTask?.id,
-                workItem: linkedTask?.workItem,
-                model: linkedTask == nil ? nil : "hermes-agent",
-                startedAt: now,
-                lastSeenAt: now,
-                pid: process.pid,
-                tmuxSession: matchedPane?.sessionName,
-                lastOutput: output
-            )
+        let sessions = runningProcesses().compactMap {
+            makeSession(process: $0, tasks: tasks, tmuxPanes: tmuxPanes, now: now, machineName: machineName)
         }
+        let summaries = makeSummaries(sessions: sessions, tasks: tasks, now: now, machineName: machineName)
+        return CompanionProbeSnapshot(sessions: sessions, agents: summaries)
+    }
 
+    private func makeSession(
+        process: (pid: Int, commandLine: String),
+        tasks: [AgentTask],
+        tmuxPanes: [TmuxPane],
+        now: Date,
+        machineName: String
+    ) -> AgentSession? {
+        guard let signature = signatures.first(where: { process.commandLine.contains($0.keyword) }) else {
+            return nil
+        }
+        let linkedTask = tasks.first {
+            $0.sessionID == "proc-\(process.pid)" ||
+                $0.assignedAgent.compare(signature.name, options: .caseInsensitive) == .orderedSame
+        }
+        let matchedPane = tmuxPanes.first { $0.pid == process.pid }
+        let output = matchedPane.flatMap { capturePane(paneID: $0.paneID) }
+        return AgentSession(
+            id: "proc-\(process.pid)",
+            source: machineName,
+            status: .running,
+            linkedTaskID: linkedTask?.id,
+            workItem: linkedTask?.workItem,
+            model: linkedTask == nil ? nil : "hermes-agent",
+            startedAt: now,
+            lastSeenAt: now,
+            pid: process.pid,
+            tmuxSession: matchedPane?.sessionName,
+            lastOutput: output
+        )
+    }
+
+    private func makeSummaries(
+        sessions: [AgentSession],
+        tasks: [AgentTask],
+        now: Date,
+        machineName: String
+    ) -> [AgentSummary] {
         let agentNames = Set(
             sessions.map { inferredAgentName(from: $0.linkedTaskID, tasks: tasks, fallback: $0.id) } +
                 tasks.map(\.assignedAgent)
         )
-
-        let summaries = agentNames
+        return agentNames
             .filter { !$0.isEmpty }
-            .map { agentName -> AgentSummary in
-                let activeTasks = tasks.filter {
-                    $0.assignedAgent.compare(agentName, options: .caseInsensitive) == .orderedSame &&
-                        $0.status != .done
-                }
-                let activeSessions = sessions.filter { session in
-                    if let linkedTaskID = session.linkedTaskID,
-                       let task = tasks.first(where: { $0.id == linkedTaskID }) {
-                        return task.assignedAgent.compare(agentName, options: .caseInsensitive) == .orderedSame
-                    }
-                    return session.id.lowercased().contains(agentName.lowercased())
-                }
-
-                let health: AgentHealthStatus = if !activeSessions.isEmpty {
-                    .online
-                } else if !activeTasks.isEmpty {
-                    .idle
-                } else {
-                    .offline
-                }
-
-                let activity: String
-                if !activeSessions.isEmpty {
-                    activity =
-                        "\(activeSessions.count) live process\(activeSessions.count == 1 ? "" : "es") running on \(machineName)."
-                } else if !activeTasks.isEmpty {
-                    activity = "\(activeTasks.count) task\(activeTasks.count == 1 ? "" : "s") queued."
-                } else {
-                    activity = "No live processes detected."
-                }
-
-                return AgentSummary(
-                    id: agentName
-                        .lowercased()
-                        .replacingOccurrences(of: " ", with: "-"),
-                    name: agentName,
-                    health: health,
-                    activeTaskCount: activeTasks.count,
-                    activeSessionCount: activeSessions.count,
-                    recentActivity: activity,
-                    updatedAt: now
-                )
+            .map { makeSummary(agentName: $0, sessions: sessions, tasks: tasks, now: now, machineName: machineName) }
+            .sorted {
+                if $0.activeSessionCount != $1.activeSessionCount { return $0.activeSessionCount > $1.activeSessionCount }
+                return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
             }
-            .sorted { lhs, rhs in
-                if lhs.activeSessionCount != rhs.activeSessionCount {
-                    return lhs.activeSessionCount > rhs.activeSessionCount
-                }
-                return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
-            }
+    }
 
-        return CompanionProbeSnapshot(sessions: sessions, agents: summaries)
+    private func makeSummary(
+        agentName: String,
+        sessions: [AgentSession],
+        tasks: [AgentTask],
+        now: Date,
+        machineName: String
+    ) -> AgentSummary {
+        let activeTasks = tasks.filter {
+            $0.assignedAgent.compare(agentName, options: .caseInsensitive) == .orderedSame && $0.status != .done
+        }
+        let activeSessions = sessions.filter { sessionMatchesAgent($0, agentName: agentName, tasks: tasks) }
+        let health = agentHealth(sessions: activeSessions, tasks: activeTasks)
+        return AgentSummary(
+            id: agentName.lowercased().replacingOccurrences(of: " ", with: "-"),
+            name: agentName,
+            health: health,
+            activeTaskCount: activeTasks.count,
+            activeSessionCount: activeSessions.count,
+            recentActivity: agentActivity(sessions: activeSessions, tasks: activeTasks, machineName: machineName),
+            updatedAt: now
+        )
+    }
+
+    private func sessionMatchesAgent(_ session: AgentSession, agentName: String, tasks: [AgentTask]) -> Bool {
+        if let linkedTaskID = session.linkedTaskID,
+           let task = tasks.first(where: { $0.id == linkedTaskID }) {
+            return task.assignedAgent.compare(agentName, options: .caseInsensitive) == .orderedSame
+        }
+        return session.id.lowercased().contains(agentName.lowercased())
+    }
+
+    private func agentHealth(sessions: [AgentSession], tasks: [AgentTask]) -> AgentHealthStatus {
+        if !sessions.isEmpty { return .online }
+        if !tasks.isEmpty { return .idle }
+        return .offline
+    }
+
+    private func agentActivity(sessions: [AgentSession], tasks: [AgentTask], machineName: String) -> String {
+        if !sessions.isEmpty {
+            let count = sessions.count
+            return "\(count) live process\(count == 1 ? "" : "es") running on \(machineName)."
+        }
+        if !tasks.isEmpty {
+            let count = tasks.count
+            return "\(count) task\(count == 1 ? "" : "s") queued."
+        }
+        return "No live processes detected."
     }
 
     public func captureOutput(for session: AgentSession) -> String? {

--- a/AgentBoardCompanionKit/CompanionLocalProbe.swift
+++ b/AgentBoardCompanionKit/CompanionLocalProbe.swift
@@ -30,6 +30,7 @@ public actor CompanionLocalProbe {
         let now = Date()
         let machineName = Host.current().localizedName ?? "Local Machine"
         let processes = runningProcesses()
+        let tmuxPanes = listTmuxPanes()
 
         let sessions = processes.compactMap { process -> AgentSession? in
             guard let signature = signatures.first(where: { process.commandLine.contains($0.keyword) }) else {
@@ -41,6 +42,9 @@ public actor CompanionLocalProbe {
                     $0.assignedAgent.compare(signature.name, options: .caseInsensitive) == .orderedSame
             }
 
+            let matchedPane = tmuxPanes.first { $0.pid == process.pid }
+            let output = matchedPane.flatMap { capturePane(paneID: $0.paneID) }
+
             return AgentSession(
                 id: "proc-\(process.pid)",
                 source: machineName,
@@ -49,7 +53,10 @@ public actor CompanionLocalProbe {
                 workItem: linkedTask?.workItem,
                 model: linkedTask == nil ? nil : "hermes-agent",
                 startedAt: now,
-                lastSeenAt: now
+                lastSeenAt: now,
+                pid: process.pid,
+                tmuxSession: matchedPane?.sessionName,
+                lastOutput: output
             )
         }
 
@@ -70,7 +77,6 @@ public actor CompanionLocalProbe {
                        let task = tasks.first(where: { $0.id == linkedTaskID }) {
                         return task.assignedAgent.compare(agentName, options: .caseInsensitive) == .orderedSame
                     }
-
                     return session.id.lowercased().contains(agentName.lowercased())
                 }
 
@@ -84,7 +90,8 @@ public actor CompanionLocalProbe {
 
                 let activity: String
                 if !activeSessions.isEmpty {
-                    activity = "\(activeSessions.count) live process\(activeSessions.count == 1 ? "" : "es") running on \(machineName)."
+                    activity =
+                        "\(activeSessions.count) live process\(activeSessions.count == 1 ? "" : "es") running on \(machineName)."
                 } else if !activeTasks.isEmpty {
                     activity = "\(activeTasks.count) task\(activeTasks.count == 1 ? "" : "s") queued."
                 } else {
@@ -113,12 +120,74 @@ public actor CompanionLocalProbe {
         return CompanionProbeSnapshot(sessions: sessions, agents: summaries)
     }
 
+    public func captureOutput(for session: AgentSession) -> String? {
+        if let tmuxSession = session.tmuxSession {
+            return shell("/usr/bin/tmux", ["capture-pane", "-t", tmuxSession, "-p", "-S", "-200"])
+                .flatMap { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : $0 }
+        }
+        return nil
+    }
+
+    public func nudge(session: AgentSession) -> Bool {
+        if let tmuxSession = session.tmuxSession {
+            return shell("/usr/bin/tmux", ["send-keys", "-t", tmuxSession, "", "Enter"]) != nil
+        }
+        if let pid = session.pid {
+            return kill(Int32(pid), SIGCONT) == 0
+        }
+        return false
+    }
+
+    public func stop(session: AgentSession) -> Bool {
+        if let tmuxSession = session.tmuxSession {
+            return shell("/usr/bin/tmux", ["kill-session", "-t", tmuxSession]) != nil
+        }
+        if let pid = session.pid {
+            return kill(Int32(pid), SIGTERM) == 0
+        }
+        return false
+    }
+
+    private struct TmuxPane: Sendable {
+        let pid: Int
+        let sessionName: String
+        let paneID: String
+    }
+
+    private func listTmuxPanes() -> [TmuxPane] {
+        guard let output = shell(
+            "/usr/bin/tmux",
+            ["list-panes", "-a", "-F", "#{pane_pid} #{session_name} #{pane_id}"]
+        ) else {
+            return []
+        }
+
+        return output
+            .split(separator: "\n")
+            .compactMap { line -> TmuxPane? in
+                let parts = line.split(separator: " ", maxSplits: 2)
+                guard parts.count == 3,
+                      let pid = Int(parts[0]) else {
+                    return nil
+                }
+                return TmuxPane(
+                    pid: pid,
+                    sessionName: String(parts[1]),
+                    paneID: String(parts[2])
+                )
+            }
+    }
+
+    private func capturePane(paneID: String) -> String? {
+        shell("/usr/bin/tmux", ["capture-pane", "-t", paneID, "-p", "-S", "-200"])
+            .flatMap { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : $0 }
+    }
+
     private func inferredAgentName(from linkedTaskID: String?, tasks: [AgentTask], fallback: String) -> String {
         if let linkedTaskID,
            let task = tasks.first(where: { $0.id == linkedTaskID }) {
             return task.assignedAgent
         }
-
         return signatures.first(where: { fallback.lowercased().contains($0.keyword) })?.name ?? ""
     }
 
@@ -157,5 +226,27 @@ public actor CompanionLocalProbe {
             .filter { process in
                 signatures.contains { process.commandLine.contains($0.keyword) }
             }
+    }
+
+    @discardableResult
+    private func shell(_ executable: String, _ arguments: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+
+        let output = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = output
+        process.standardError = errorPipe
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+
+        guard let data = try? output.fileHandleForReading.readToEnd() else { return nil }
+        return String(data: data, encoding: .utf8)
     }
 }

--- a/AgentBoardCompanionKit/CompanionSQLiteStore.swift
+++ b/AgentBoardCompanionKit/CompanionSQLiteStore.swift
@@ -116,6 +116,7 @@ public actor CompanionSQLiteStore {
         let sessionMigrations = [
             "ALTER TABLE sessions ADD COLUMN pid INTEGER;",
             "ALTER TABLE sessions ADD COLUMN tmux_session TEXT;",
+            "ALTER TABLE sessions ADD COLUMN tmux_pane_id TEXT;",
             "ALTER TABLE sessions ADD COLUMN last_output TEXT;"
         ]
         for sql in sessionMigrations {
@@ -224,9 +225,9 @@ public actor CompanionSQLiteStore {
                 """
                 INSERT INTO sessions (
                     id, source, status, linked_task_id, repo_owner, repo_name, issue_number,
-                    model, started_at, last_seen_at, pid, tmux_session, last_output
+                    model, started_at, last_seen_at, pid, tmux_session, tmux_pane_id, last_output
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
                 """
             )
             defer { sqlite3_finalize(statement) }
@@ -251,7 +252,8 @@ public actor CompanionSQLiteStore {
                 sqlite3_bind_null(statement, 11)
             }
             bind(session.tmuxSession, to: 12, in: statement)
-            bind(session.lastOutput, to: 13, in: statement)
+            bind(session.tmuxPaneID, to: 13, in: statement)
+            bind(session.lastOutput, to: 14, in: statement)
 
             guard sqlite3_step(statement) == SQLITE_DONE else {
                 throw StoreError.stepFailed(Self.sqliteMessage(handle.raw))
@@ -263,7 +265,7 @@ public actor CompanionSQLiteStore {
         let statement = try prepare(
             """
             SELECT id, source, status, linked_task_id, repo_owner, repo_name, issue_number,
-                   model, started_at, last_seen_at, pid, tmux_session, last_output
+                   model, started_at, last_seen_at, pid, tmux_session, tmux_pane_id, last_output
             FROM sessions
             ORDER BY last_seen_at DESC;
             """
@@ -295,7 +297,8 @@ public actor CompanionSQLiteStore {
                     lastSeenAt: date(statement, index: 9),
                     pid: pid,
                     tmuxSession: nullableString(statement, index: 11),
-                    lastOutput: nullableString(statement, index: 12)
+                    tmuxPaneID: nullableString(statement, index: 12),
+                    lastOutput: nullableString(statement, index: 13)
                 )
             )
         }

--- a/AgentBoardCompanionKit/CompanionSQLiteStore.swift
+++ b/AgentBoardCompanionKit/CompanionSQLiteStore.swift
@@ -108,6 +108,19 @@ public actor CompanionSQLiteStore {
             );
             """
         )
+
+        runMigrations()
+    }
+
+    private func runMigrations() {
+        let sessionMigrations = [
+            "ALTER TABLE sessions ADD COLUMN pid INTEGER;",
+            "ALTER TABLE sessions ADD COLUMN tmux_session TEXT;",
+            "ALTER TABLE sessions ADD COLUMN last_output TEXT;"
+        ]
+        for sql in sessionMigrations {
+            try? execute(sql)
+        }
     }
 
     public func listTasks() throws -> [AgentTask] {
@@ -194,6 +207,15 @@ public actor CompanionSQLiteStore {
         return current
     }
 
+    public func deleteTask(id: String) throws {
+        let statement = try prepare("DELETE FROM agent_tasks WHERE id = ?;")
+        defer { sqlite3_finalize(statement) }
+        bind(id, to: 1, in: statement)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw StoreError.stepFailed(Self.sqliteMessage(handle.raw))
+        }
+    }
+
     public func replaceSessions(_ sessions: [AgentSession]) throws {
         try execute("DELETE FROM sessions;")
 
@@ -202,9 +224,9 @@ public actor CompanionSQLiteStore {
                 """
                 INSERT INTO sessions (
                     id, source, status, linked_task_id, repo_owner, repo_name, issue_number,
-                    model, started_at, last_seen_at
+                    model, started_at, last_seen_at, pid, tmux_session, last_output
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
                 """
             )
             defer { sqlite3_finalize(statement) }
@@ -215,10 +237,21 @@ public actor CompanionSQLiteStore {
             bind(session.linkedTaskID, to: 4, in: statement)
             bind(session.workItem?.repository.owner, to: 5, in: statement)
             bind(session.workItem?.repository.name, to: 6, in: statement)
-            sqlite3_bind_int(statement, 7, Int32(session.workItem?.issueNumber ?? 0))
+            if let issueNumber = session.workItem?.issueNumber {
+                sqlite3_bind_int(statement, 7, Int32(issueNumber))
+            } else {
+                sqlite3_bind_null(statement, 7)
+            }
             bind(session.model, to: 8, in: statement)
             sqlite3_bind_double(statement, 9, session.startedAt.timeIntervalSince1970)
             sqlite3_bind_double(statement, 10, session.lastSeenAt.timeIntervalSince1970)
+            if let pid = session.pid {
+                sqlite3_bind_int(statement, 11, Int32(pid))
+            } else {
+                sqlite3_bind_null(statement, 11)
+            }
+            bind(session.tmuxSession, to: 12, in: statement)
+            bind(session.lastOutput, to: 13, in: statement)
 
             guard sqlite3_step(statement) == SQLITE_DONE else {
                 throw StoreError.stepFailed(Self.sqliteMessage(handle.raw))
@@ -230,7 +263,7 @@ public actor CompanionSQLiteStore {
         let statement = try prepare(
             """
             SELECT id, source, status, linked_task_id, repo_owner, repo_name, issue_number,
-                   model, started_at, last_seen_at
+                   model, started_at, last_seen_at, pid, tmux_session, last_output
             FROM sessions
             ORDER BY last_seen_at DESC;
             """
@@ -242,6 +275,7 @@ public actor CompanionSQLiteStore {
             let issueNumber = sqlite3_column_type(statement, 6) == SQLITE_NULL ? nil : int(statement, index: 6)
             let owner = nullableString(statement, index: 4)
             let name = nullableString(statement, index: 5)
+            let pid = sqlite3_column_type(statement, 10) == SQLITE_NULL ? nil : int(statement, index: 10)
 
             sessions.append(
                 AgentSession(
@@ -258,7 +292,10 @@ public actor CompanionSQLiteStore {
                     }(),
                     model: nullableString(statement, index: 7),
                     startedAt: date(statement, index: 8),
-                    lastSeenAt: date(statement, index: 9)
+                    lastSeenAt: date(statement, index: 9),
+                    pid: pid,
+                    tmuxSession: nullableString(statement, index: 11),
+                    lastOutput: nullableString(statement, index: 12)
                 )
             )
         }

--- a/AgentBoardCompanionKit/CompanionServer.swift
+++ b/AgentBoardCompanionKit/CompanionServer.swift
@@ -306,49 +306,16 @@ public final class CompanionServer: @unchecked Sendable {
             case ("GET", ["v1", "sessions"]):
                 try sendJSON(await store.listSessions(), over: connection)
 
-            case let ("GET", components)
+            case let (method, components)
                 where components.count == 4 &&
                 components[0] == "v1" &&
-                components[1] == "sessions" &&
-                components[3] == "output":
-                let sessionID = components[2]
-                let sessions = try await store.listSessions()
-                if let session = sessions.first(where: { $0.id == sessionID }) {
-                    let output = await probe.captureOutput(for: session) ?? session.lastOutput ?? ""
-                    try sendJSON(["output": output], over: connection)
-                } else {
-                    try sendJSON(["output": ""], over: connection)
-                }
-
-            case let ("POST", components)
-                where components.count == 4 &&
-                components[0] == "v1" &&
-                components[1] == "sessions" &&
-                components[3] == "nudge":
-                let sessionID = components[2]
-                let sessions = try await store.listSessions()
-                if let session = sessions.first(where: { $0.id == sessionID }) {
-                    let ok = await probe.nudge(session: session)
-                    try sendJSON(["ok": ok], over: connection)
-                } else {
-                    try sendJSON(["ok": false], over: connection)
-                }
-                await broker.publish(CompanionEvent(kind: .sessionsChanged))
-
-            case let ("POST", components)
-                where components.count == 4 &&
-                components[0] == "v1" &&
-                components[1] == "sessions" &&
-                components[3] == "stop":
-                let sessionID = components[2]
-                let sessions = try await store.listSessions()
-                if let session = sessions.first(where: { $0.id == sessionID }) {
-                    let ok = await probe.stop(session: session)
-                    try sendJSON(["ok": ok], over: connection)
-                } else {
-                    try sendJSON(["ok": false], over: connection)
-                }
-                await broker.publish(CompanionEvent(kind: .sessionsChanged))
+                components[1] == "sessions":
+                try await handleSessionAction(
+                    method: method,
+                    sessionID: components[2],
+                    action: components[3],
+                    over: connection
+                )
 
             case ("GET", ["v1", "agents"]):
                 try sendJSON(await store.listAgents(), over: connection)
@@ -389,6 +356,35 @@ public final class CompanionServer: @unchecked Sendable {
                 ),
                 over: connection
             )
+        }
+    }
+
+    private func handleSessionAction(
+        method: String,
+        sessionID: String,
+        action: String,
+        over connection: NWConnection
+    ) async throws {
+        let sessions = try await store.listSessions()
+        let session = sessions.first { $0.id == sessionID }
+        switch (method, action) {
+        case ("GET", "output"):
+            let output: String
+            if let session { output = await probe.captureOutput(for: session) ?? session.lastOutput ?? "" }
+            else { output = "" }
+            try sendJSON(["output": output], over: connection)
+        case ("POST", "nudge"):
+            let ok: Bool
+            if let session { ok = await probe.nudge(session: session) } else { ok = false }
+            try sendJSON(["ok": ok], over: connection)
+            await broker.publish(CompanionEvent(kind: .sessionsChanged))
+        case ("POST", "stop"):
+            let ok: Bool
+            if let session { ok = await probe.stop(session: session) } else { ok = false }
+            try sendJSON(["ok": ok], over: connection)
+            await broker.publish(CompanionEvent(kind: .sessionsChanged))
+        default:
+            try sendJSON(["error": "not_found"], over: connection)
         }
     }
 

--- a/AgentBoardCompanionKit/CompanionServer.swift
+++ b/AgentBoardCompanionKit/CompanionServer.swift
@@ -269,71 +269,8 @@ public final class CompanionServer: @unchecked Sendable {
             )
             return
         }
-
         do {
-            switch (request.method, request.pathComponents) {
-            case ("GET", ["health"]):
-                try sendJSON(["status": "ok"], over: connection)
-
-            case ("GET", ["v1", "tasks"]):
-                try sendJSON(await store.listTasks(), over: connection)
-
-            case ("POST", ["v1", "tasks"]):
-                let draft = try decoder.decode(AgentTaskDraft.self, from: request.body)
-                let task = try await store.createTask(draft)
-                try sendJSON(task, over: connection)
-                await broker.publish(CompanionEvent(kind: .tasksChanged))
-
-            case let ("PATCH", components)
-                where components.count == 3 &&
-                components[0] == "v1" &&
-                components[1] == "tasks":
-                let id = components[2]
-                let patch = try decoder.decode(AgentTaskPatch.self, from: request.body)
-                let task = try await store.updateTask(id: id, patch: patch)
-                try sendJSON(task, over: connection)
-                await broker.publish(CompanionEvent(kind: .tasksChanged))
-
-            case let ("DELETE", components)
-                where components.count == 3 &&
-                components[0] == "v1" &&
-                components[1] == "tasks":
-                let id = components[2]
-                try await store.deleteTask(id: id)
-                try sendJSON(["ok": true], over: connection)
-                await broker.publish(CompanionEvent(kind: .tasksChanged))
-
-            case ("GET", ["v1", "sessions"]):
-                try sendJSON(await store.listSessions(), over: connection)
-
-            case let (method, components)
-                where components.count == 4 &&
-                components[0] == "v1" &&
-                components[1] == "sessions":
-                try await handleSessionAction(
-                    method: method,
-                    sessionID: components[2],
-                    action: components[3],
-                    over: connection
-                )
-
-            case ("GET", ["v1", "agents"]):
-                try sendJSON(await store.listAgents(), over: connection)
-
-            case ("GET", ["v1", "events"]):
-                await registerSSESubscriber(over: connection)
-
-            default:
-                send(
-                    response: HTTPResponse(
-                        statusCode: 404,
-                        reason: "Not Found",
-                        headers: ["Content-Type": "application/json"],
-                        body: Data(#"{"error":"not_found"}"#.utf8)
-                    ),
-                    over: connection
-                )
-            }
+            try await route(request: request, over: connection)
         } catch {
             logger.error("Companion request failed: \(error.localizedDescription, privacy: .public)")
             send(
@@ -342,6 +279,72 @@ public final class CompanionServer: @unchecked Sendable {
                     reason: "Server Error",
                     headers: ["Content-Type": "application/json"],
                     body: Data(#"{"error":"internal_server_error"}"#.utf8)
+                ),
+                over: connection
+            )
+        }
+    }
+
+    private func route(request: HTTPRequest, over connection: NWConnection) async throws {
+        switch (request.method, request.pathComponents) {
+        case ("GET", ["health"]):
+            try sendJSON(["status": "ok"], over: connection)
+
+        case ("GET", ["v1", "tasks"]):
+            try sendJSON(await store.listTasks(), over: connection)
+
+        case ("POST", ["v1", "tasks"]):
+            let draft = try decoder.decode(AgentTaskDraft.self, from: request.body)
+            let task = try await store.createTask(draft)
+            try sendJSON(task, over: connection)
+            await broker.publish(CompanionEvent(kind: .tasksChanged))
+
+        case let ("PATCH", components)
+            where components.count == 3 &&
+            components[0] == "v1" &&
+            components[1] == "tasks":
+            let id = components[2]
+            let patch = try decoder.decode(AgentTaskPatch.self, from: request.body)
+            let task = try await store.updateTask(id: id, patch: patch)
+            try sendJSON(task, over: connection)
+            await broker.publish(CompanionEvent(kind: .tasksChanged))
+
+        case let ("DELETE", components)
+            where components.count == 3 &&
+            components[0] == "v1" &&
+            components[1] == "tasks":
+            let id = components[2]
+            try await store.deleteTask(id: id)
+            try sendJSON(["ok": true], over: connection)
+            await broker.publish(CompanionEvent(kind: .tasksChanged))
+
+        case ("GET", ["v1", "sessions"]):
+            try sendJSON(await store.listSessions(), over: connection)
+
+        case let (method, components)
+            where components.count == 4 &&
+            components[0] == "v1" &&
+            components[1] == "sessions":
+            try await handleSessionAction(
+                method: method,
+                sessionID: components[2],
+                action: components[3],
+                over: connection
+            )
+
+        case ("GET", ["v1", "agents"]):
+            try sendJSON(await store.listAgents(), over: connection)
+
+        case ("GET", ["v1", "events"]):
+            await registerSSESubscriber(over: connection)
+
+        default:
+            send(
+                response: HTTPResponse(
+                    statusCode: 404,
+                    reason: "Not Found",
+                    headers: ["Content-Type": "application/json"],
+                    body: Data(#"{"error":"not_found"}"#.utf8)
                 ),
                 over: connection
             )

--- a/AgentBoardCompanionKit/CompanionServer.swift
+++ b/AgentBoardCompanionKit/CompanionServer.swift
@@ -321,18 +321,7 @@ public final class CompanionServer: @unchecked Sendable {
                 try sendJSON(await store.listAgents(), over: connection)
 
             case ("GET", ["v1", "events"]):
-                let subscriber = SSESubscriber(connection: connection)
-                connection.stateUpdateHandler = { [weak self] state in
-                    switch state {
-                    case .cancelled, .failed:
-                        Task { await self?.broker.unregister(id: subscriber.id) }
-                    default:
-                        break
-                    }
-                }
-                sendSSEHeaders(over: connection)
-                await broker.register(subscriber)
-                subscriber.send(event: CompanionEvent(kind: .snapshotRefreshed))
+                await registerSSESubscriber(over: connection)
 
             default:
                 send(
@@ -359,6 +348,21 @@ public final class CompanionServer: @unchecked Sendable {
         }
     }
 
+    private func registerSSESubscriber(over connection: NWConnection) async {
+        let subscriber = SSESubscriber(connection: connection)
+        connection.stateUpdateHandler = { [weak self] state in
+            switch state {
+            case .cancelled, .failed:
+                Task { await self?.broker.unregister(id: subscriber.id) }
+            default:
+                break
+            }
+        }
+        sendSSEHeaders(over: connection)
+        await broker.register(subscriber)
+        subscriber.send(event: CompanionEvent(kind: .snapshotRefreshed))
+    }
+
     private func handleSessionAction(
         method: String,
         sessionID: String,
@@ -370,8 +374,11 @@ public final class CompanionServer: @unchecked Sendable {
         switch (method, action) {
         case ("GET", "output"):
             let output: String
-            if let session { output = await probe.captureOutput(for: session) ?? session.lastOutput ?? "" }
-            else { output = "" }
+            if let session {
+                output = await probe.captureOutput(for: session) ?? session.lastOutput ?? ""
+            } else {
+                output = ""
+            }
             try sendJSON(["output": output], over: connection)
         case ("POST", "nudge"):
             let ok: Bool

--- a/AgentBoardCompanionKit/CompanionServer.swift
+++ b/AgentBoardCompanionKit/CompanionServer.swift
@@ -294,8 +294,61 @@ public final class CompanionServer: @unchecked Sendable {
                 try sendJSON(task, over: connection)
                 await broker.publish(CompanionEvent(kind: .tasksChanged))
 
+            case let ("DELETE", components)
+                where components.count == 3 &&
+                components[0] == "v1" &&
+                components[1] == "tasks":
+                let id = components[2]
+                try await store.deleteTask(id: id)
+                try sendJSON(["ok": true], over: connection)
+                await broker.publish(CompanionEvent(kind: .tasksChanged))
+
             case ("GET", ["v1", "sessions"]):
                 try sendJSON(await store.listSessions(), over: connection)
+
+            case let ("GET", components)
+                where components.count == 4 &&
+                components[0] == "v1" &&
+                components[1] == "sessions" &&
+                components[3] == "output":
+                let sessionID = components[2]
+                let sessions = try await store.listSessions()
+                if let session = sessions.first(where: { $0.id == sessionID }) {
+                    let output = await probe.captureOutput(for: session) ?? session.lastOutput ?? ""
+                    try sendJSON(["output": output], over: connection)
+                } else {
+                    try sendJSON(["output": ""], over: connection)
+                }
+
+            case let ("POST", components)
+                where components.count == 4 &&
+                components[0] == "v1" &&
+                components[1] == "sessions" &&
+                components[3] == "nudge":
+                let sessionID = components[2]
+                let sessions = try await store.listSessions()
+                if let session = sessions.first(where: { $0.id == sessionID }) {
+                    let ok = await probe.nudge(session: session)
+                    try sendJSON(["ok": ok], over: connection)
+                } else {
+                    try sendJSON(["ok": false], over: connection)
+                }
+                await broker.publish(CompanionEvent(kind: .sessionsChanged))
+
+            case let ("POST", components)
+                where components.count == 4 &&
+                components[0] == "v1" &&
+                components[1] == "sessions" &&
+                components[3] == "stop":
+                let sessionID = components[2]
+                let sessions = try await store.listSessions()
+                if let session = sessions.first(where: { $0.id == sessionID }) {
+                    let ok = await probe.stop(session: session)
+                    try sendJSON(["ok": ok], over: connection)
+                } else {
+                    try sendJSON(["ok": false], over: connection)
+                }
+                await broker.publish(CompanionEvent(kind: .sessionsChanged))
 
             case ("GET", ["v1", "agents"]):
                 try sendJSON(await store.listAgents(), over: connection)

--- a/AgentBoardCore/Models/DomainModels.swift
+++ b/AgentBoardCore/Models/DomainModels.swift
@@ -369,6 +369,7 @@ public struct AgentSession: Codable, Hashable, Identifiable, Sendable {
     public var lastSeenAt: Date
     public var pid: Int?
     public var tmuxSession: String?
+    public var tmuxPaneID: String?
     public var lastOutput: String?
 
     public init(
@@ -382,6 +383,7 @@ public struct AgentSession: Codable, Hashable, Identifiable, Sendable {
         lastSeenAt: Date = .now,
         pid: Int? = nil,
         tmuxSession: String? = nil,
+        tmuxPaneID: String? = nil,
         lastOutput: String? = nil
     ) {
         self.id = id
@@ -394,6 +396,7 @@ public struct AgentSession: Codable, Hashable, Identifiable, Sendable {
         self.lastSeenAt = lastSeenAt
         self.pid = pid
         self.tmuxSession = tmuxSession
+        self.tmuxPaneID = tmuxPaneID
         self.lastOutput = lastOutput
     }
 }

--- a/AgentBoardCore/Models/DomainModels.swift
+++ b/AgentBoardCore/Models/DomainModels.swift
@@ -367,6 +367,9 @@ public struct AgentSession: Codable, Hashable, Identifiable, Sendable {
     public var model: String?
     public var startedAt: Date
     public var lastSeenAt: Date
+    public var pid: Int?
+    public var tmuxSession: String?
+    public var lastOutput: String?
 
     public init(
         id: String,
@@ -376,7 +379,10 @@ public struct AgentSession: Codable, Hashable, Identifiable, Sendable {
         workItem: WorkReference? = nil,
         model: String? = nil,
         startedAt: Date = .now,
-        lastSeenAt: Date = .now
+        lastSeenAt: Date = .now,
+        pid: Int? = nil,
+        tmuxSession: String? = nil,
+        lastOutput: String? = nil
     ) {
         self.id = id
         self.source = source
@@ -386,6 +392,9 @@ public struct AgentSession: Codable, Hashable, Identifiable, Sendable {
         self.model = model
         self.startedAt = startedAt
         self.lastSeenAt = lastSeenAt
+        self.pid = pid
+        self.tmuxSession = tmuxSession
+        self.lastOutput = lastOutput
     }
 }
 

--- a/AgentBoardCore/Persistence/AgentBoardCache.swift
+++ b/AgentBoardCore/Persistence/AgentBoardCache.swift
@@ -154,6 +154,9 @@ private final class CachedSessionRecord {
     var model: String?
     var startedAt: Date
     var lastSeenAt: Date
+    var pid: Int?
+    var tmuxSession: String?
+    var lastOutput: String?
 
     init(
         id: String,
@@ -165,7 +168,10 @@ private final class CachedSessionRecord {
         issueNumber: Int?,
         model: String?,
         startedAt: Date,
-        lastSeenAt: Date
+        lastSeenAt: Date,
+        pid: Int? = nil,
+        tmuxSession: String? = nil,
+        lastOutput: String? = nil
     ) {
         self.id = id
         self.source = source
@@ -177,6 +183,9 @@ private final class CachedSessionRecord {
         self.model = model
         self.startedAt = startedAt
         self.lastSeenAt = lastSeenAt
+        self.pid = pid
+        self.tmuxSession = tmuxSession
+        self.lastOutput = lastOutput
     }
 }
 
@@ -437,7 +446,10 @@ public final class AgentBoardCache {
                 }(),
                 model: record.model,
                 startedAt: record.startedAt,
-                lastSeenAt: record.lastSeenAt
+                lastSeenAt: record.lastSeenAt,
+                pid: record.pid,
+                tmuxSession: record.tmuxSession,
+                lastOutput: record.lastOutput
             )
         }
     }
@@ -456,10 +468,30 @@ public final class AgentBoardCache {
                     issueNumber: session.workItem?.issueNumber,
                     model: session.model,
                     startedAt: session.startedAt,
-                    lastSeenAt: session.lastSeenAt
+                    lastSeenAt: session.lastSeenAt,
+                    pid: session.pid,
+                    tmuxSession: session.tmuxSession,
+                    lastOutput: session.lastOutput
                 )
             )
         }
+        try context.save()
+    }
+
+    public func deleteConversation(id: UUID) throws {
+        let records = try context.fetch(
+            FetchDescriptor<CachedConversationRecord>(
+                predicate: #Predicate { $0.id == id }
+            )
+        )
+        records.forEach(context.delete)
+
+        let messages = try context.fetch(
+            FetchDescriptor<CachedMessageRecord>(
+                predicate: #Predicate { $0.conversationID == id }
+            )
+        )
+        messages.forEach(context.delete)
         try context.save()
     }
 

--- a/AgentBoardCore/Persistence/AgentBoardCache.swift
+++ b/AgentBoardCore/Persistence/AgentBoardCache.swift
@@ -156,6 +156,7 @@ private final class CachedSessionRecord {
     var lastSeenAt: Date
     var pid: Int?
     var tmuxSession: String?
+    var tmuxPaneID: String?
     var lastOutput: String?
 
     init(
@@ -171,6 +172,7 @@ private final class CachedSessionRecord {
         lastSeenAt: Date,
         pid: Int? = nil,
         tmuxSession: String? = nil,
+        tmuxPaneID: String? = nil,
         lastOutput: String? = nil
     ) {
         self.id = id
@@ -185,6 +187,7 @@ private final class CachedSessionRecord {
         self.lastSeenAt = lastSeenAt
         self.pid = pid
         self.tmuxSession = tmuxSession
+        self.tmuxPaneID = tmuxPaneID
         self.lastOutput = lastOutput
     }
 }
@@ -449,6 +452,7 @@ public final class AgentBoardCache {
                 lastSeenAt: record.lastSeenAt,
                 pid: record.pid,
                 tmuxSession: record.tmuxSession,
+                tmuxPaneID: record.tmuxPaneID,
                 lastOutput: record.lastOutput
             )
         }
@@ -471,6 +475,7 @@ public final class AgentBoardCache {
                     lastSeenAt: session.lastSeenAt,
                     pid: session.pid,
                     tmuxSession: session.tmuxSession,
+                    tmuxPaneID: session.tmuxPaneID,
                     lastOutput: session.lastOutput
                 )
             )

--- a/AgentBoardCore/Services/CompanionClient.swift
+++ b/AgentBoardCore/Services/CompanionClient.swift
@@ -109,6 +109,10 @@ public actor CompanionClient {
         request.httpMethod = "POST"
         let (data, response) = try await session.data(for: request)
         try validate(response: response, data: data)
+        if let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let ok = payload["ok"] as? Bool, !ok {
+            throw URLError(.badServerResponse)
+        }
     }
 
     public func nudgeSession(id: String) async throws {
@@ -116,6 +120,10 @@ public actor CompanionClient {
         request.httpMethod = "POST"
         let (data, response) = try await session.data(for: request)
         try validate(response: response, data: data)
+        if let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let ok = payload["ok"] as? Bool, !ok {
+            throw URLError(.badServerResponse)
+        }
     }
 
     public func fetchSessionOutput(id: String) async throws -> String? {

--- a/AgentBoardCore/Services/CompanionClient.swift
+++ b/AgentBoardCore/Services/CompanionClient.swift
@@ -18,6 +18,7 @@ public actor CompanionClient {
         case invalidBaseURL
         case invalidResponse
         case httpError(statusCode: Int, body: String)
+        case operationFailed(String)
 
         public var errorDescription: String? {
             switch self {
@@ -31,6 +32,8 @@ public actor CompanionClient {
                     return "Companion service returned HTTP \(statusCode)."
                 }
                 return "Companion service returned HTTP \(statusCode): \(trimmed.prefix(220))"
+            case let .operationFailed(message):
+                return message
             }
         }
     }
@@ -109,9 +112,12 @@ public actor CompanionClient {
         request.httpMethod = "POST"
         let (data, response) = try await session.data(for: request)
         try validate(response: response, data: data)
-        if let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-           let ok = payload["ok"] as? Bool, !ok {
-            throw URLError(.badServerResponse)
+        guard let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let ok = payload["ok"] as? Bool else {
+            throw ClientError.invalidResponse
+        }
+        if !ok {
+            throw ClientError.operationFailed("Failed to stop session — the session may no longer be running.")
         }
     }
 
@@ -120,9 +126,12 @@ public actor CompanionClient {
         request.httpMethod = "POST"
         let (data, response) = try await session.data(for: request)
         try validate(response: response, data: data)
-        if let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-           let ok = payload["ok"] as? Bool, !ok {
-            throw URLError(.badServerResponse)
+        guard let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let ok = payload["ok"] as? Bool else {
+            throw ClientError.invalidResponse
+        }
+        if !ok {
+            throw ClientError.operationFailed("Failed to nudge session — the session may no longer be running.")
         }
     }
 

--- a/AgentBoardCore/Services/CompanionClient.swift
+++ b/AgentBoardCore/Services/CompanionClient.swift
@@ -97,6 +97,37 @@ public actor CompanionClient {
         try await send(path: "v1/tasks/\(id)", method: "PATCH", payload: patch)
     }
 
+    public func deleteTask(id: String) async throws {
+        var request = makeRequest(path: "v1/tasks/\(id)")
+        request.httpMethod = "DELETE"
+        let (data, response) = try await session.data(for: request)
+        try validate(response: response, data: data)
+    }
+
+    public func stopSession(id: String) async throws {
+        var request = makeRequest(path: "v1/sessions/\(id)/stop")
+        request.httpMethod = "POST"
+        let (data, response) = try await session.data(for: request)
+        try validate(response: response, data: data)
+    }
+
+    public func nudgeSession(id: String) async throws {
+        var request = makeRequest(path: "v1/sessions/\(id)/nudge")
+        request.httpMethod = "POST"
+        let (data, response) = try await session.data(for: request)
+        try validate(response: response, data: data)
+    }
+
+    public func fetchSessionOutput(id: String) async throws -> String? {
+        let (data, response) = try await session.data(for: makeRequest(path: "v1/sessions/\(id)/output"))
+        try validate(response: response, data: data)
+        guard let payload = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let output = payload["output"] as? String else {
+            return nil
+        }
+        return output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : output
+    }
+
     public func events() async throws -> AsyncThrowingStream<CompanionEvent, Error> {
         var request = makeRequest(path: "v1/events")
         request.setValue("text/event-stream", forHTTPHeaderField: "Accept")

--- a/AgentBoardCore/Services/GitHubWorkService.swift
+++ b/AgentBoardCore/Services/GitHubWorkService.swift
@@ -115,6 +115,30 @@ public actor GitHubWorkService {
         }
     }
 
+    public func createIssue(
+        repository: ConfiguredRepository,
+        title: String,
+        body: String,
+        labels: [String]
+    ) async throws -> WorkItem {
+        guard let token, !token.isEmpty else {
+            throw ServiceError.missingConfiguration
+        }
+
+        let url = try buildURL(repository: repository, endpoint: "issues")
+        var request = authorizedRequest(url: url, token: token)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let payload: [String: Any] = ["title": title, "body": body, "labels": labels]
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+
+        let (data, response) = try await session.data(for: request)
+        try validateResponse(response, data: data)
+        let issue = try JSONDecoder().decode(RawIssue.self, from: data)
+        return map(issue: issue, repository: repository)
+    }
+
     public func updateIssue(
         repository: ConfiguredRepository,
         issueNumber: Int,

--- a/AgentBoardCore/Stores/AgentsStore.swift
+++ b/AgentBoardCore/Stores/AgentsStore.swift
@@ -119,6 +119,19 @@ public final class AgentsStore {
         }
     }
 
+    public func deleteTask(id: String) async {
+        do {
+            try await configureCompanion()
+            try await companionClient.deleteTask(id: id)
+            tasks.removeAll { $0.id == id }
+            try cache.replaceTasks(tasks)
+            statusMessage = "Task deleted."
+        } catch {
+            logger.error("Failed to delete task: \(error.localizedDescription, privacy: .public)")
+            errorMessage = error.localizedDescription
+        }
+    }
+
     public func handle(event: CompanionEventKind) async {
         switch event {
         case .tasksChanged, .agentsChanged, .snapshotRefreshed:

--- a/AgentBoardCore/Stores/ChatStore.swift
+++ b/AgentBoardCore/Stores/ChatStore.swift
@@ -70,6 +70,33 @@ public final class ChatStore {
         selectedConversationID = id
     }
 
+    public func renameConversation(id: UUID, title: String) {
+        guard var conversation = conversations.first(where: { $0.id == id }) else { return }
+        conversation.title = title
+        conversation.updatedAt = .now
+        upsert(conversation)
+        persist(conversationID: id)
+    }
+
+    public func deleteConversation(id: UUID) {
+        conversations.removeAll { $0.id == id }
+        messagesByConversationID.removeValue(forKey: id)
+
+        if selectedConversationID == id {
+            selectedConversationID = conversations.first?.id
+        }
+
+        do {
+            try cache.deleteConversation(id: id)
+        } catch {
+            logger.error("Failed to delete conversation from cache: \(error.localizedDescription, privacy: .public)")
+        }
+
+        if conversations.isEmpty {
+            startNewConversation()
+        }
+    }
+
     public func refreshConnection() async {
         errorMessage = nil
         statusMessage = nil

--- a/AgentBoardCore/Stores/ChatStore.swift
+++ b/AgentBoardCore/Stores/ChatStore.swift
@@ -71,8 +71,11 @@ public final class ChatStore {
     }
 
     public func renameConversation(id: UUID, title: String) {
-        guard var conversation = conversations.first(where: { $0.id == id }) else { return }
-        conversation.title = title
+        guard
+            var conversation = conversations.first(where: { $0.id == id }),
+            let trimmedTitle = title.trimmedOrNil
+        else { return }
+        conversation.title = trimmedTitle
         conversation.updatedAt = .now
         upsert(conversation)
         persist(conversationID: id)

--- a/AgentBoardCore/Stores/SessionsStore.swift
+++ b/AgentBoardCore/Stores/SessionsStore.swift
@@ -73,6 +73,51 @@ public final class SessionsStore {
         isLoading = false
     }
 
+    public func stopSession(id: String) async {
+        guard settingsStore.isCompanionConfigured else { return }
+        do {
+            try await companionClient.configure(
+                baseURL: settingsStore.companionURL,
+                bearerToken: settingsStore.companionToken.trimmedOrNil
+            )
+            try await companionClient.stopSession(id: id)
+            await refresh()
+            statusMessage = "Session stopped."
+        } catch {
+            logger.error("Failed to stop session: \(error.localizedDescription, privacy: .public)")
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    public func nudgeSession(id: String) async {
+        guard settingsStore.isCompanionConfigured else { return }
+        do {
+            try await companionClient.configure(
+                baseURL: settingsStore.companionURL,
+                bearerToken: settingsStore.companionToken.trimmedOrNil
+            )
+            try await companionClient.nudgeSession(id: id)
+            statusMessage = "Session nudged."
+        } catch {
+            logger.error("Failed to nudge session: \(error.localizedDescription, privacy: .public)")
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    public func fetchOutput(sessionID: String) async -> String? {
+        guard settingsStore.isCompanionConfigured else { return nil }
+        do {
+            try await companionClient.configure(
+                baseURL: settingsStore.companionURL,
+                bearerToken: settingsStore.companionToken.trimmedOrNil
+            )
+            return try await companionClient.fetchSessionOutput(id: sessionID)
+        } catch {
+            logger.error("Failed to fetch session output: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+
     public func handle(event: CompanionEventKind) async {
         switch event {
         case .sessionsChanged, .snapshotRefreshed:

--- a/AgentBoardCore/Stores/SessionsStore.swift
+++ b/AgentBoardCore/Stores/SessionsStore.swift
@@ -114,6 +114,7 @@ public final class SessionsStore {
             return try await companionClient.fetchSessionOutput(id: sessionID)
         } catch {
             logger.error("Failed to fetch session output: \(error.localizedDescription, privacy: .public)")
+            errorMessage = error.localizedDescription
             return nil
         }
     }

--- a/AgentBoardCore/Stores/WorkStore.swift
+++ b/AgentBoardCore/Stores/WorkStore.swift
@@ -93,6 +93,74 @@ public final class WorkStore {
         isLoading = false
     }
 
+    public func createIssue(
+        repository: ConfiguredRepository,
+        title: String,
+        body: String,
+        labels: [String] = []
+    ) async {
+        guard settingsStore.isGitHubConfigured else {
+            errorMessage = "Connect GitHub before creating issues."
+            return
+        }
+        await service.configure(
+            repositories: settingsStore.repositories,
+            token: settingsStore.githubToken.trimmedOrNil
+        )
+        do {
+            let item = try await service.createIssue(
+                repository: repository,
+                title: title,
+                body: body,
+                labels: labels
+            )
+            upsert(item)
+            try cache.replaceWorkItems(items)
+            statusMessage = "Created \(item.issueReference)."
+        } catch {
+            logger.error("Failed to create issue: \(error.localizedDescription, privacy: .public)")
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    public func updateIssue(
+        _ item: WorkItem,
+        title: String? = nil,
+        body: String? = nil,
+        labels: [String]? = nil,
+        assignees: [String]? = nil,
+        state: WorkState? = nil
+    ) async {
+        guard settingsStore.isGitHubConfigured else {
+            errorMessage = "Connect GitHub before updating issues."
+            return
+        }
+        await service.configure(
+            repositories: settingsStore.repositories,
+            token: settingsStore.githubToken.trimmedOrNil
+        )
+        let patch = GitHubIssuePatch(
+            title: title,
+            body: body,
+            labels: labels,
+            assignees: assignees,
+            state: state
+        )
+        do {
+            let updated = try await service.updateIssue(
+                repository: item.repository,
+                issueNumber: item.issueNumber,
+                patch: patch
+            )
+            upsert(updated)
+            try cache.replaceWorkItems(items)
+            statusMessage = "Updated \(updated.issueReference)."
+        } catch {
+            logger.error("Failed to update issue: \(error.localizedDescription, privacy: .public)")
+            errorMessage = error.localizedDescription
+        }
+    }
+
     public func updateStatus(for item: WorkItem, to state: WorkState) async {
         guard settingsStore.isGitHubConfigured else {
             errorMessage = "Connect GitHub before updating work items."

--- a/AgentBoardCore/Stores/WorkStore.swift
+++ b/AgentBoardCore/Stores/WorkStore.swift
@@ -99,6 +99,8 @@ public final class WorkStore {
         body: String,
         labels: [String] = []
     ) async {
+        errorMessage = nil
+        statusMessage = nil
         guard settingsStore.isGitHubConfigured else {
             errorMessage = "Connect GitHub before creating issues."
             return
@@ -116,6 +118,7 @@ public final class WorkStore {
             )
             upsert(item)
             try cache.replaceWorkItems(items)
+            errorMessage = nil
             statusMessage = "Created \(item.issueReference)."
         } catch {
             logger.error("Failed to create issue: \(error.localizedDescription, privacy: .public)")
@@ -131,6 +134,8 @@ public final class WorkStore {
         assignees: [String]? = nil,
         state: WorkState? = nil
     ) async {
+        errorMessage = nil
+        statusMessage = nil
         guard settingsStore.isGitHubConfigured else {
             errorMessage = "Connect GitHub before updating issues."
             return

--- a/AgentBoardUI/Components/MarkdownText.swift
+++ b/AgentBoardUI/Components/MarkdownText.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+struct MarkdownText: View {
+    let content: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
+                switch segment {
+                case let .prose(text):
+                    if let attributed = try? AttributedString(
+                        markdown: text,
+                        options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+                    ) {
+                        Text(attributed)
+                            .textSelection(.enabled)
+                            .foregroundStyle(.white)
+                            .fixedSize(horizontal: false, vertical: true)
+                    } else {
+                        Text(text)
+                            .textSelection(.enabled)
+                            .foregroundStyle(.white)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                case let .code(code, language):
+                    VStack(alignment: .leading, spacing: 4) {
+                        if let language, !language.isEmpty {
+                            Text(language.uppercased())
+                                .font(.caption2.weight(.semibold))
+                                .tracking(1.2)
+                                .foregroundStyle(.white.opacity(0.5))
+                        }
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            Text(code)
+                                .font(.system(.footnote, design: .monospaced))
+                                .foregroundStyle(BoardPalette.mint)
+                                .textSelection(.enabled)
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 8)
+                        }
+                    }
+                    .background(
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .fill(Color.black.opacity(0.32))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .stroke(Color.white.opacity(0.06), lineWidth: 1)
+                    )
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private enum Segment {
+        case prose(String)
+        case code(String, String?)
+    }
+
+    private var segments: [Segment] {
+        var result: [Segment] = []
+        var remaining = content
+
+        while !remaining.isEmpty {
+            if let fenceRange = remaining.range(of: "```") {
+                let before = String(remaining[remaining.startIndex ..< fenceRange.lowerBound])
+                if !before.isEmpty {
+                    result.append(.prose(before))
+                }
+                remaining = String(remaining[fenceRange.upperBound...])
+
+                let firstLine = remaining.prefix(while: { $0 != "\n" })
+                let language = String(firstLine).trimmingCharacters(in: .whitespaces).isEmpty
+                    ? nil
+                    : String(firstLine).trimmingCharacters(in: .whitespaces)
+
+                if !firstLine.isEmpty {
+                    remaining = String(remaining.dropFirst(firstLine.count))
+                }
+                if remaining.first == "\n" {
+                    remaining = String(remaining.dropFirst())
+                }
+
+                if let closingRange = remaining.range(of: "```") {
+                    let code = String(remaining[remaining.startIndex ..< closingRange.lowerBound])
+                        .trimmingCharacters(in: .newlines)
+                    result.append(.code(code, language))
+                    remaining = String(remaining[closingRange.upperBound...])
+                    if remaining.first == "\n" {
+                        remaining = String(remaining.dropFirst())
+                    }
+                } else {
+                    result.append(.code(remaining.trimmingCharacters(in: .newlines), language))
+                    remaining = ""
+                }
+            } else {
+                result.append(.prose(remaining))
+                remaining = ""
+            }
+        }
+
+        return result
+    }
+}

--- a/AgentBoardUI/Screens/AgentsScreen.swift
+++ b/AgentBoardUI/Screens/AgentsScreen.swift
@@ -194,8 +194,8 @@ struct AgentsScreen: View {
                             }
                         }
                         Picker("Priority", selection: $priority) {
-                            ForEach(WorkPriority.allCases) { p in
-                                Text(p.title).tag(p)
+                            ForEach(WorkPriority.allCases) { prio in
+                                Text(prio.title).tag(prio)
                             }
                         }
                         TextField("Notes", text: $note, axis: .vertical)

--- a/AgentBoardUI/Screens/AgentsScreen.swift
+++ b/AgentBoardUI/Screens/AgentsScreen.swift
@@ -240,63 +240,62 @@ private struct AgentTaskCard: View {
     @State private var showDeleteConfirm = false
 
     var body: some View {
-        Button(action: onTap) {
-            BoardSurface {
-                VStack(alignment: .leading, spacing: 10) {
-                    HStack(alignment: .top) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(task.workItem.issueReference)
-                                .font(.caption.weight(.semibold))
-                                .foregroundStyle(BoardPalette.gold)
-                            Text(task.title)
-                                .font(.headline)
-                                .foregroundStyle(.white)
-                                .multilineTextAlignment(.leading)
-                        }
-                        Spacer(minLength: 8)
-
-                        Menu {
-                            Button("Edit") { onTap() }
-                            Divider()
-                            Button("Delete", role: .destructive) {
-                                showDeleteConfirm = true
-                            }
-                        } label: {
-                            Image(systemName: "ellipsis.circle")
-                                .font(.title3)
-                                .foregroundStyle(.white.opacity(0.8))
-                        }
-                        .buttonStyle(.plain)
-                    }
-
-                    if !task.note.isEmpty {
-                        Text(task.note)
-                            .font(.subheadline)
-                            .foregroundStyle(BoardPalette.paper.opacity(0.78))
-                            .lineLimit(2)
+        BoardSurface {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(task.workItem.issueReference)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(BoardPalette.gold)
+                        Text(task.title)
+                            .font(.headline)
+                            .foregroundStyle(.white)
                             .multilineTextAlignment(.leading)
                     }
+                    Spacer(minLength: 8)
 
-                    HStack(spacing: 8) {
-                        PriorityPill(priority: task.priority)
-                        BoardChip(label: task.assignedAgent, systemImage: "person.fill", tint: BoardPalette.gold)
+                    Menu {
+                        Button("Edit") { onTap() }
+                        Divider()
+                        Button("Delete", role: .destructive) {
+                            showDeleteConfirm = true
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis.circle")
+                            .font(.title3)
+                            .foregroundStyle(.white.opacity(0.8))
                     }
-
-                    if let sessionID = task.sessionID {
-                        Text(sessionID)
-                            .font(.caption)
-                            .foregroundStyle(BoardPalette.paper.opacity(0.5))
-                            .lineLimit(1)
-                    }
-
-                    Text(task.updatedAt, style: .relative)
-                        .font(.caption)
-                        .foregroundStyle(BoardPalette.paper.opacity(0.68))
-                        .frame(maxWidth: .infinity, alignment: .trailing)
+                    .buttonStyle(.plain)
                 }
+
+                if !task.note.isEmpty {
+                    Text(task.note)
+                        .font(.subheadline)
+                        .foregroundStyle(BoardPalette.paper.opacity(0.78))
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                }
+
+                HStack(spacing: 8) {
+                    PriorityPill(priority: task.priority)
+                    BoardChip(label: task.assignedAgent, systemImage: "person.fill", tint: BoardPalette.gold)
+                }
+
+                if let sessionID = task.sessionID {
+                    Text(sessionID)
+                        .font(.caption)
+                        .foregroundStyle(BoardPalette.paper.opacity(0.5))
+                        .lineLimit(1)
+                }
+
+                Text(task.updatedAt, style: .relative)
+                    .font(.caption)
+                    .foregroundStyle(BoardPalette.paper.opacity(0.68))
+                    .frame(maxWidth: .infinity, alignment: .trailing)
             }
         }
-        .buttonStyle(.plain)
+        .contentShape(Rectangle())
+        .onTapGesture { onTap() }
         .alert("Delete Task", isPresented: $showDeleteConfirm) {
             Button("Delete", role: .destructive) {
                 Task { await appModel.agentsStore.deleteTask(id: task.id) }
@@ -307,4 +306,3 @@ private struct AgentTaskCard: View {
         }
     }
 }
-

--- a/AgentBoardUI/Screens/AgentsScreen.swift
+++ b/AgentBoardUI/Screens/AgentsScreen.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct AgentsScreen: View {
     @Environment(AgentBoardAppModel.self) private var appModel
     @State private var isPresentingCreateSheet = false
+    @State private var selectedTask: AgentTask?
     @State private var selectedWorkItemID: String?
     @State private var taskTitle = ""
     @State private var assignedAgent = ""
@@ -11,95 +12,42 @@ struct AgentsScreen: View {
     @State private var status: AgentTaskState = .backlog
     @State private var priority: WorkPriority = .medium
 
-    private let columns = [GridItem(.adaptive(minimum: 220), spacing: 16)]
+    private var groupedTasks: [(state: AgentTaskState, tasks: [AgentTask])] {
+        AgentTaskState.allCases.map { state in
+            (state, appModel.agentsStore.tasks.filter { $0.status == state })
+        }
+    }
 
     var body: some View {
         ZStack {
             BoardBackground()
 
             VStack(alignment: .leading, spacing: 18) {
-                HStack(alignment: .top) {
-                    BoardHeader(
-                        eyebrow: "Agents",
-                        title: "Execution state lives beside the work",
-                        subtitle:
-                        "Agent tasks are companion-managed execution objects linked back "
-                            + "to GitHub issues, with summaries and sessions flowing into the same "
-                            + "shared model."
-                    )
+                header
 
-                    Spacer(minLength: 20)
-
-                    VStack(alignment: .trailing, spacing: 10) {
-                        Button("Refresh") {
-                            Task { await appModel.agentsStore.refresh() }
-                        }
-                        .buttonStyle(.bordered)
-                        .tint(.white)
-
-                        Button("New Task") {
-                            assignedAgent = appModel.agentsStore.summaries.first?.name ?? "Codex"
-                            selectedWorkItemID = appModel.workStore.items.first?.id
-                            taskTitle = ""
-                            note = ""
-                            status = .backlog
-                            priority = .medium
-                            isPresentingCreateSheet = true
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .tint(BoardPalette.coral)
-                        .disabled(appModel.workStore.items.isEmpty)
-                    }
-                }
-
-                if appModel.agentsStore.summaries.isEmpty && appModel.agentsStore.tasks.isEmpty {
+                if appModel.agentsStore.tasks.isEmpty && appModel.agentsStore.summaries.isEmpty {
                     EmptyStateCard(
                         title: "No agent activity yet",
                         message: appModel.agentsStore.statusMessage
-                            ??
-                            "Start the companion service and point Settings at it to watch tasks and live execution state.",
+                            ?? "Start the companion service and point Settings at it to watch tasks and live execution state.",
                         systemImage: "person.3.sequence"
                     )
                 } else {
-                    ScrollView {
-                        LazyVStack(alignment: .leading, spacing: 18) {
-                            LazyVGrid(columns: columns, spacing: 16) {
-                                ForEach(appModel.agentsStore.summaries) { summary in
-                                    BoardSurface {
-                                        VStack(alignment: .leading, spacing: 12) {
-                                            HStack {
-                                                Text(summary.name)
-                                                    .font(.title3.weight(.semibold))
-                                                    .foregroundStyle(.white)
-
-                                                Spacer()
-
-                                                AgentHealthPill(health: summary.health)
-                                            }
-
-                                            Text(summary.recentActivity)
-                                                .font(.subheadline)
-                                                .foregroundStyle(BoardPalette.paper.opacity(0.78))
-
-                                            HStack {
-                                                StatBadge(label: "Tasks", value: "\(summary.activeTaskCount)")
-                                                StatBadge(label: "Sessions", value: "\(summary.activeSessionCount)")
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-
-                            BoardSectionTitle("Task Queue", subtitle: appModel.agentsStore.statusMessage)
-
-                            ForEach(appModel.agentsStore.tasks) { task in
-                                AgentTaskCard(task: task)
-                            }
-                        }
+                    if !appModel.agentsStore.summaries.isEmpty {
+                        agentSummaryRail
                     }
+                    kanbanBoard
                 }
             }
             .padding(24)
+        }
+        .navigationTitle("Agents")
+        .refreshable {
+            await appModel.agentsStore.refresh()
+        }
+        .sheet(item: $selectedTask) { task in
+            TaskDetailSheet(task: task)
+                .environment(appModel)
         }
         .sheet(isPresented: $isPresentingCreateSheet) {
             createTaskSheet
@@ -107,45 +55,163 @@ struct AgentsScreen: View {
         }
     }
 
+    private var header: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("AGENTS".uppercased())
+                    .font(.caption.weight(.semibold))
+                    .tracking(2)
+                    .foregroundStyle(BoardPalette.gold)
+                Text("Task Board")
+                    .font(.system(size: 28, weight: .bold, design: .serif))
+                    .foregroundStyle(.white)
+            }
+
+            Spacer(minLength: 20)
+
+            HStack(spacing: 8) {
+                Button("Refresh") {
+                    Task { await appModel.agentsStore.refresh() }
+                }
+                .buttonStyle(.bordered)
+                .tint(.white)
+
+                Button("New Task") {
+                    assignedAgent = appModel.agentsStore.summaries.first?.name ?? "Codex"
+                    selectedWorkItemID = appModel.workStore.items.first?.id
+                    taskTitle = ""
+                    note = ""
+                    status = .backlog
+                    priority = .medium
+                    isPresentingCreateSheet = true
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(BoardPalette.coral)
+                .disabled(appModel.workStore.items.isEmpty)
+            }
+        }
+    }
+
+    private var agentSummaryRail: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 12) {
+                ForEach(appModel.agentsStore.summaries) { summary in
+                    BoardSurface {
+                        VStack(alignment: .leading, spacing: 10) {
+                            HStack {
+                                Text(summary.name)
+                                    .font(.headline)
+                                    .foregroundStyle(.white)
+                                Spacer()
+                                AgentHealthPill(health: summary.health)
+                            }
+                            Text(summary.recentActivity)
+                                .font(.caption)
+                                .foregroundStyle(BoardPalette.paper.opacity(0.78))
+                                .lineLimit(2)
+                            HStack(spacing: 8) {
+                                Label("\(summary.activeTaskCount)", systemImage: "checkmark.circle")
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(BoardPalette.mint)
+                                Label("\(summary.activeSessionCount)", systemImage: "bolt.horizontal.circle")
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(BoardPalette.cobalt)
+                            }
+                        }
+                        .frame(width: 240, alignment: .topLeading)
+                    }
+                }
+            }
+        }
+    }
+
+    private var kanbanBoard: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(alignment: .top, spacing: 16) {
+                ForEach(groupedTasks, id: \.state) { column in
+                    BoardSurface {
+                        VStack(alignment: .leading, spacing: 12) {
+                            HStack {
+                                Text(column.state.title)
+                                    .font(.headline.weight(.semibold))
+                                    .foregroundStyle(columnTint(for: column.state))
+                                Spacer()
+                                Text("\(column.tasks.count)")
+                                    .font(.headline)
+                                    .foregroundStyle(.white)
+                            }
+
+                            if column.tasks.isEmpty {
+                                Text("None")
+                                    .font(.subheadline)
+                                    .foregroundStyle(BoardPalette.paper.opacity(0.45))
+                                    .frame(maxWidth: .infinity, alignment: .center)
+                                    .padding(.vertical, 12)
+                            } else {
+                                ForEach(column.tasks) { task in
+                                    AgentTaskCard(task: task) {
+                                        selectedTask = task
+                                    }
+                                }
+                            }
+                        }
+                        .frame(width: 300, alignment: .topLeading)
+                    }
+                }
+            }
+            .padding(.trailing, 4)
+        }
+    }
+
+    private func columnTint(for state: AgentTaskState) -> Color {
+        switch state {
+        case .backlog: BoardPalette.paper.opacity(0.78)
+        case .inProgress: BoardPalette.cobalt
+        case .blocked: BoardPalette.coral
+        case .done: BoardPalette.mint
+        }
+    }
+
     private var createTaskSheet: some View {
         NavigationStack {
-            Form {
-                Section("Work Item") {
-                    Picker("Issue", selection: $selectedWorkItemID) {
-                        ForEach(appModel.workStore.items) { item in
-                            Text(item.issueReference).tag(Optional(item.id))
+            ZStack {
+                BoardBackground()
+                Form {
+                    Section("Work Item") {
+                        Picker("Issue", selection: $selectedWorkItemID) {
+                            ForEach(appModel.workStore.items) { item in
+                                Text(item.issueReference).tag(Optional(item.id))
+                            }
                         }
                     }
-                }
 
-                Section("Task") {
-                    TextField("Task title", text: $taskTitle)
-                    TextField("Assigned agent", text: $assignedAgent)
-                    Picker("Status", selection: $status) {
-                        ForEach(AgentTaskState.allCases) { state in
-                            Text(state.title).tag(state)
+                    Section("Task") {
+                        TextField("Task title", text: $taskTitle)
+                        TextField("Assigned agent", text: $assignedAgent)
+                        Picker("Status", selection: $status) {
+                            ForEach(AgentTaskState.allCases) { state in
+                                Text(state.title).tag(state)
+                            }
                         }
-                    }
-                    Picker("Priority", selection: $priority) {
-                        ForEach(WorkPriority.allCases) { priority in
-                            Text(priority.title).tag(priority)
+                        Picker("Priority", selection: $priority) {
+                            ForEach(WorkPriority.allCases) { p in
+                                Text(p.title).tag(p)
+                            }
                         }
+                        TextField("Notes", text: $note, axis: .vertical)
                     }
-                    TextField("Notes", text: $note, axis: .vertical)
                 }
+                .scrollContentBackground(.hidden)
             }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { isPresentingCreateSheet = false }
                 }
-
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Create") {
                         guard let selectedWorkItemID,
                               let workItem = appModel.workStore.items.first(where: { $0.id == selectedWorkItemID })
-                        else {
-                            return
-                        }
+                        else { return }
 
                         let draft = AgentTaskDraft(
                             workItem: workItem.reference,
@@ -155,10 +221,7 @@ struct AgentsScreen: View {
                             assignedAgent: assignedAgent.trimmedOrNil ?? "Codex",
                             note: note.trimmed
                         )
-
-                        Task {
-                            await appModel.agentsStore.createTask(draft)
-                        }
+                        Task { await appModel.agentsStore.createTask(draft) }
                         isPresentingCreateSheet = false
                     }
                     .disabled(selectedWorkItemID == nil)
@@ -172,94 +235,76 @@ struct AgentsScreen: View {
 private struct AgentTaskCard: View {
     @Environment(AgentBoardAppModel.self) private var appModel
     let task: AgentTask
+    let onTap: () -> Void
+
+    @State private var showDeleteConfirm = false
 
     var body: some View {
-        BoardSurface {
-            VStack(alignment: .leading, spacing: 12) {
-                HStack(alignment: .top) {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text(task.title)
-                            .font(.headline)
-                            .foregroundStyle(.white)
-
-                        Text(task.workItem.issueReference)
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(BoardPalette.gold)
-                    }
-
-                    Spacer()
-
-                    Menu {
-                        ForEach(AgentTaskState.allCases) { status in
-                            Button(status.title) {
-                                Task {
-                                    await appModel.agentsStore.updateTask(
-                                        id: task.id,
-                                        patch: AgentTaskPatch(status: status)
-                                    )
-                                }
-                            }
+        Button(action: onTap) {
+            BoardSurface {
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(alignment: .top) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(task.workItem.issueReference)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(BoardPalette.gold)
+                            Text(task.title)
+                                .font(.headline)
+                                .foregroundStyle(.white)
+                                .multilineTextAlignment(.leading)
                         }
-                    } label: {
-                        Image(systemName: "ellipsis.circle")
-                            .font(.title3)
-                            .foregroundStyle(.white.opacity(0.8))
+                        Spacer(minLength: 8)
+
+                        Menu {
+                            Button("Edit") { onTap() }
+                            Divider()
+                            Button("Delete", role: .destructive) {
+                                showDeleteConfirm = true
+                            }
+                        } label: {
+                            Image(systemName: "ellipsis.circle")
+                                .font(.title3)
+                                .foregroundStyle(.white.opacity(0.8))
+                        }
+                        .buttonStyle(.plain)
                     }
-                    .buttonStyle(.plain)
-                }
 
-                Text(task.note.isEmpty ? "No task notes yet." : task.note)
-                    .font(.subheadline)
-                    .foregroundStyle(BoardPalette.paper.opacity(0.78))
+                    if !task.note.isEmpty {
+                        Text(task.note)
+                            .font(.subheadline)
+                            .foregroundStyle(BoardPalette.paper.opacity(0.78))
+                            .lineLimit(2)
+                            .multilineTextAlignment(.leading)
+                    }
 
-                HStack(spacing: 8) {
-                    BoardChip(
-                        label: task.status.title,
-                        systemImage: "arrow.triangle.branch",
-                        tint: task.status == .done ? BoardPalette.mint : BoardPalette.cobalt
-                    )
-                    PriorityPill(priority: task.priority)
-                    BoardChip(label: task.assignedAgent, systemImage: "person.fill", tint: BoardPalette.gold)
-                }
+                    HStack(spacing: 8) {
+                        PriorityPill(priority: task.priority)
+                        BoardChip(label: task.assignedAgent, systemImage: "person.fill", tint: BoardPalette.gold)
+                    }
 
-                HStack {
                     if let sessionID = task.sessionID {
                         Text(sessionID)
                             .font(.caption)
-                            .foregroundStyle(BoardPalette.paper.opacity(0.68))
+                            .foregroundStyle(BoardPalette.paper.opacity(0.5))
+                            .lineLimit(1)
                     }
-
-                    Spacer()
 
                     Text(task.updatedAt, style: .relative)
                         .font(.caption)
                         .foregroundStyle(BoardPalette.paper.opacity(0.68))
+                        .frame(maxWidth: .infinity, alignment: .trailing)
                 }
             }
         }
-    }
-}
-
-private struct StatBadge: View {
-    let label: String
-    let value: String
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(label.uppercased())
-                .font(.caption.weight(.semibold))
-                .tracking(1.5)
-                .foregroundStyle(BoardPalette.paper.opacity(0.6))
-
-            Text(value)
-                .font(.title3.weight(.bold))
-                .foregroundStyle(.white)
+        .buttonStyle(.plain)
+        .alert("Delete Task", isPresented: $showDeleteConfirm) {
+            Button("Delete", role: .destructive) {
+                Task { await appModel.agentsStore.deleteTask(id: task.id) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Are you sure you want to delete \"\(task.title)\"?")
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(12)
-        .background(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .fill(Color.black.opacity(0.2))
-        )
     }
 }
+

--- a/AgentBoardUI/Screens/ChatScreen.swift
+++ b/AgentBoardUI/Screens/ChatScreen.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 struct ChatScreen: View {
     @Environment(AgentBoardAppModel.self) private var appModel
+    @State private var editingConversationID: UUID?
+    @State private var editingTitle = ""
 
     var body: some View {
         @Bindable var chatStore = appModel.chatStore
@@ -10,88 +12,42 @@ struct ChatScreen: View {
         ZStack {
             BoardBackground()
 
-            VStack(alignment: .leading, spacing: 18) {
-                header
+            VStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading, spacing: 14) {
+                    header
 
-                if !chatStore.conversations.isEmpty {
-                    conversationRail
-                }
-
-                BoardSurface {
-                    if chatStore.messages.isEmpty {
-                        EmptyStateCard(
-                            title: "Start the Hermes conversation",
-                            message:
-                            "The new chat surface is shared across macOS and iOS, streams assistant output in place, and keeps local history in SwiftData.",
-                            systemImage: "sparkles"
-                        )
-                    } else {
-                        ScrollView {
-                            LazyVStack(alignment: .leading, spacing: 14) {
-                                ForEach(chatStore.messages) { message in
-                                    ChatBubble(message: message)
-                                }
-                            }
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        }
+                    if !chatStore.conversations.isEmpty {
+                        conversationRail
                     }
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(.horizontal, 24)
+                .padding(.top, 24)
+                .padding(.bottom, 12)
 
-                BoardSurface {
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text("Prompt")
-                            .font(.headline)
-                            .foregroundStyle(.white)
+                messageList
+                    .padding(.horizontal, 24)
 
-                        TextEditor(text: $chatStore.draft)
-                            .scrollContentBackground(.hidden)
-                            .frame(minHeight: 120)
-                            .padding(10)
-                            .background(
-                                RoundedRectangle(cornerRadius: 20, style: .continuous)
-                                    .fill(Color.black.opacity(0.22))
-                            )
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 20, style: .continuous)
-                                    .stroke(Color.white.opacity(0.08), lineWidth: 1)
-                            )
-                            .foregroundStyle(.white)
-
-                        HStack {
-                            Text(chatStore.errorMessage ?? chatStore
-                                .statusMessage ?? "Hermes-first streaming is ready.")
-                                .font(.footnote)
-                                .foregroundStyle(chatStore.errorMessage == nil ? BoardPalette.paper
-                                    .opacity(0.75) : BoardPalette.coral)
-
-                            Spacer()
-
-                            Button("Send") {
-                                Task {
-                                    await chatStore.sendDraft()
-                                }
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .tint(BoardPalette.coral)
-                            .disabled(chatStore.draft.trimmedOrNil == nil || chatStore.isStreaming)
-                        }
-                    }
-                }
+                composeArea
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 16)
             }
-            .padding(24)
         }
+        .navigationTitle("Chat")
     }
 
     private var header: some View {
         HStack(alignment: .top) {
-            BoardHeader(
-                eyebrow: "Hermes Chat",
-                title: "A fresh client for gateway-native conversations",
-                subtitle: "Streaming, reconnect state, and conversation history all live in the new shared core instead of the legacy AppState."
-            )
+            VStack(alignment: .leading, spacing: 6) {
+                Text("CHAT".uppercased())
+                    .font(.caption.weight(.semibold))
+                    .tracking(2)
+                    .foregroundStyle(BoardPalette.gold)
+                Text("Hermes AI")
+                    .font(.system(size: 28, weight: .bold, design: .serif))
+                    .foregroundStyle(.white)
+            }
 
-            Spacer(minLength: 20)
+            Spacer(minLength: 16)
 
             VStack(alignment: .trailing, spacing: 10) {
                 HStack(spacing: 8) {
@@ -100,14 +56,11 @@ struct ChatScreen: View {
                         systemImage: "dot.radiowaves.left.and.right",
                         tint: chipTint(for: appModel.chatStore.connectionState)
                     )
-                    BoardChip(
-                        label: appModel.settingsStore.hermesModelID.trimmedOrNil ?? "hermes-agent",
-                        systemImage: "cpu",
-                        tint: BoardPalette.gold
-                    )
+
+                    modelPickerMenu
                 }
 
-                HStack(spacing: 10) {
+                HStack(spacing: 8) {
                     Button("Refresh") {
                         Task {
                             await appModel.chatStore.refreshConnection()
@@ -117,7 +70,7 @@ struct ChatScreen: View {
                     .buttonStyle(.bordered)
                     .tint(.white)
 
-                    Button("New Conversation") {
+                    Button("New") {
                         appModel.chatStore.startNewConversation()
                     }
                     .buttonStyle(.borderedProminent)
@@ -127,39 +80,188 @@ struct ChatScreen: View {
         }
     }
 
+    private var modelPickerMenu: some View {
+        Menu {
+            ForEach(appModel.chatStore.availableModels, id: \.self) { model in
+                Button {
+                    appModel.settingsStore.hermesModelID = model
+                    Task { await appModel.chatStore.refreshModels() }
+                } label: {
+                    HStack {
+                        Text(model)
+                        if model == appModel.settingsStore.hermesModelID {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+            }
+        } label: {
+            BoardChip(
+                label: appModel.settingsStore.hermesModelID.trimmedOrNil ?? "model",
+                systemImage: "cpu",
+                tint: BoardPalette.gold
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
     private var conversationRail: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 10) {
                 ForEach(appModel.chatStore.conversations) { conversation in
-                    Button {
-                        appModel.chatStore.selectConversation(conversation.id)
-                    } label: {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(conversation.title)
-                                .font(.headline)
-                                .lineLimit(1)
-                                .foregroundStyle(.white)
+                    conversationRailItem(conversation)
+                }
+            }
+        }
+    }
 
-                            Text(conversation.updatedAt, style: .relative)
-                                .font(.caption)
-                                .foregroundStyle(BoardPalette.paper.opacity(0.7))
+    private func conversationRailItem(_ conversation: ChatConversation) -> some View {
+        let isSelected = conversation.id == appModel.chatStore.selectedConversationID
+
+        return Group {
+            if editingConversationID == conversation.id {
+                HStack(spacing: 6) {
+                    TextField("Name", text: $editingTitle)
+                        .textFieldStyle(.plain)
+                        .foregroundStyle(.white)
+                        .font(.headline)
+                        .frame(width: 160)
+                        .onSubmit {
+                            appModel.chatStore.renameConversation(id: conversation.id, title: editingTitle)
+                            editingConversationID = nil
                         }
-                        .frame(width: 220, alignment: .leading)
-                        .padding(14)
-                        .background(
-                            RoundedRectangle(cornerRadius: 22, style: .continuous)
-                                .fill(
-                                    conversation.id == appModel.chatStore.selectedConversationID
-                                        ? BoardPalette.cobalt.opacity(0.32)
-                                        : Color.white.opacity(0.08)
-                                )
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 22, style: .continuous)
-                                .stroke(Color.white.opacity(0.08), lineWidth: 1)
-                        )
+                    Button {
+                        appModel.chatStore.renameConversation(id: conversation.id, title: editingTitle)
+                        editingConversationID = nil
+                    } label: {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(BoardPalette.mint)
                     }
                     .buttonStyle(.plain)
+                }
+                .frame(width: 220, alignment: .leading)
+                .padding(14)
+                .background(
+                    RoundedRectangle(cornerRadius: 22, style: .continuous)
+                        .fill(BoardPalette.cobalt.opacity(0.32))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 22, style: .continuous)
+                        .stroke(BoardPalette.cobalt.opacity(0.5), lineWidth: 1)
+                )
+            } else {
+                Button {
+                    appModel.chatStore.selectConversation(conversation.id)
+                } label: {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(conversation.title)
+                            .font(.headline)
+                            .lineLimit(1)
+                            .foregroundStyle(.white)
+                        Text(conversation.updatedAt, style: .relative)
+                            .font(.caption)
+                            .foregroundStyle(BoardPalette.paper.opacity(0.7))
+                    }
+                    .frame(width: 220, alignment: .leading)
+                    .padding(14)
+                    .background(
+                        RoundedRectangle(cornerRadius: 22, style: .continuous)
+                            .fill(isSelected ? BoardPalette.cobalt.opacity(0.32) : Color.white.opacity(0.08))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 22, style: .continuous)
+                            .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                    )
+                }
+                .buttonStyle(.plain)
+                .contextMenu {
+                    Button {
+                        editingTitle = conversation.title
+                        editingConversationID = conversation.id
+                    } label: {
+                        Label("Rename", systemImage: "pencil")
+                    }
+                    Button(role: .destructive) {
+                        appModel.chatStore.deleteConversation(id: conversation.id)
+                    } label: {
+                        Label("Delete", systemImage: "trash")
+                    }
+                }
+            }
+        }
+    }
+
+    private var messageList: some View {
+        BoardSurface {
+            if appModel.chatStore.messages.isEmpty {
+                EmptyStateCard(
+                    title: "Start a conversation",
+                    message: "Your messages stream live from the Hermes gateway and are saved locally.",
+                    systemImage: "sparkles"
+                )
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 14) {
+                            ForEach(appModel.chatStore.messages) { message in
+                                ChatBubble(message: message)
+                                    .id(message.id)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.bottom, 4)
+                    }
+                    .refreshable {
+                        await appModel.chatStore.refreshConnection()
+                    }
+                    .onChange(of: appModel.chatStore.messages.count) {
+                        if let last = appModel.chatStore.messages.last {
+                            withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
+                        }
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var composeArea: some View {
+        @Bindable var chatStore = appModel.chatStore
+
+        return BoardSurface {
+            VStack(alignment: .leading, spacing: 10) {
+                if let err = chatStore.errorMessage {
+                    Text(err)
+                        .font(.footnote)
+                        .foregroundStyle(BoardPalette.coral)
+                } else if let status = chatStore.statusMessage {
+                    Text(status)
+                        .font(.footnote)
+                        .foregroundStyle(BoardPalette.paper.opacity(0.75))
+                }
+
+                TextEditor(text: $chatStore.draft)
+                    .scrollContentBackground(.hidden)
+                    .frame(minHeight: 80, maxHeight: 160)
+                    .padding(10)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .fill(Color.black.opacity(0.22))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                    )
+                    .foregroundStyle(.white)
+
+                HStack {
+                    Spacer()
+                    Button(chatStore.isStreaming ? "Stop" : "Send") {
+                        Task { await chatStore.sendDraft() }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(chatStore.isStreaming ? BoardPalette.coral : BoardPalette.cobalt)
+                    .disabled(chatStore.draft.trimmedOrNil == nil && !chatStore.isStreaming)
                 }
             }
         }
@@ -179,7 +281,7 @@ private struct ChatBubble: View {
     let message: ConversationMessage
 
     var body: some View {
-        HStack {
+        HStack(alignment: .top) {
             if message.role == .assistant {
                 bubble
                 Spacer(minLength: 48)
@@ -204,20 +306,26 @@ private struct ChatBubble: View {
                 }
             }
 
-            Text(message.content.isEmpty && message.isStreaming ? "Streaming response..." : message.content)
-                .textSelection(.enabled)
-                .foregroundStyle(.white)
-                .frame(maxWidth: .infinity, alignment: .leading)
+            if message.isStreaming && message.content.isEmpty {
+                Text("Streaming response…")
+                    .foregroundStyle(BoardPalette.paper.opacity(0.6))
+            } else {
+                MarkdownText(content: message.content)
+            }
         }
         .padding(16)
         .background(
-            RoundedRectangle(cornerRadius: 24, style: .continuous)
-                .fill(message.role == .assistant ? Color.white.opacity(0.09) : BoardPalette.coral.opacity(0.28))
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(
+                    message.role == .assistant
+                        ? Color.white.opacity(0.09)
+                        : BoardPalette.coral.opacity(0.28)
+                )
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 24, style: .continuous)
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
                 .stroke(Color.white.opacity(0.08), lineWidth: 1)
         )
-        .frame(maxWidth: 720, alignment: .leading)
+        .frame(maxWidth: 680, alignment: .leading)
     }
 }

--- a/AgentBoardUI/Screens/CreateIssueSheet.swift
+++ b/AgentBoardUI/Screens/CreateIssueSheet.swift
@@ -1,0 +1,124 @@
+import AgentBoardCore
+import SwiftUI
+
+struct CreateIssueSheet: View {
+    @Environment(AgentBoardAppModel.self) private var appModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var selectedRepository: ConfiguredRepository?
+    @State private var title = ""
+    @State private var body = ""
+    @State private var labels = ""
+    @State private var isCreating = false
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                BoardBackground()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        BoardSurface {
+                            VStack(alignment: .leading, spacing: 14) {
+                                BoardSectionTitle("New GitHub Issue")
+
+                                VStack(alignment: .leading, spacing: 6) {
+                                    Text("Repository").font(.headline).foregroundStyle(.white)
+                                    Picker("Repository", selection: $selectedRepository) {
+                                        Text("Select…").tag(Optional<ConfiguredRepository>.none)
+                                        ForEach(appModel.settingsStore.repositories) { repo in
+                                            Text(repo.fullName).tag(Optional(repo))
+                                        }
+                                    }
+                                    .pickerStyle(.menu)
+                                    .foregroundStyle(.white)
+                                    .padding(.horizontal, 16)
+                                    .padding(.vertical, 12)
+                                    .background(RoundedRectangle(cornerRadius: 16).fill(Color.black.opacity(0.22)))
+                                }
+
+                                VStack(alignment: .leading, spacing: 6) {
+                                    Text("Title").font(.headline).foregroundStyle(.white)
+                                    TextField("Issue title", text: $title)
+                                        .fieldStyle()
+                                }
+
+                                VStack(alignment: .leading, spacing: 6) {
+                                    Text("Description").font(.headline).foregroundStyle(.white)
+                                    TextEditor(text: $body)
+                                        .scrollContentBackground(.hidden)
+                                        .frame(minHeight: 120)
+                                        .padding(10)
+                                        .background(RoundedRectangle(cornerRadius: 16).fill(Color.black.opacity(0.22)))
+                                        .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.white.opacity(0.08), lineWidth: 1))
+                                        .foregroundStyle(.white)
+                                }
+
+                                VStack(alignment: .leading, spacing: 6) {
+                                    Text("Labels (comma-separated)").font(.headline).foregroundStyle(.white)
+                                    TextField("bug, priority:p1", text: $labels)
+                                        .fieldStyle()
+                                }
+                            }
+                        }
+
+                        if let error = appModel.workStore.errorMessage {
+                            Text(error)
+                                .font(.footnote)
+                                .foregroundStyle(BoardPalette.coral)
+                                .padding(.horizontal, 4)
+                        }
+                    }
+                    .padding(24)
+                }
+            }
+            .navigationTitle("New Issue")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundStyle(.white)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Create") { create() }
+                        .buttonStyle(.borderedProminent)
+                        .tint(BoardPalette.cobalt)
+                        .disabled(
+                            selectedRepository == nil ||
+                                title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+                                isCreating
+                        )
+                }
+            }
+        }
+    }
+
+    private func create() {
+        guard let repo = selectedRepository else { return }
+        isCreating = true
+        let parsed = labels
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        Task {
+            await appModel.workStore.createIssue(
+                repository: repo,
+                title: title.trimmingCharacters(in: .whitespacesAndNewlines),
+                body: body.trimmingCharacters(in: .whitespacesAndNewlines),
+                labels: parsed
+            )
+            isCreating = false
+            if appModel.workStore.errorMessage == nil {
+                dismiss()
+            }
+        }
+    }
+}
+
+private extension View {
+    func fieldStyle() -> some View {
+        padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(RoundedRectangle(cornerRadius: 16).fill(Color.black.opacity(0.22)))
+            .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.white.opacity(0.08), lineWidth: 1))
+            .foregroundStyle(.white)
+    }
+}

--- a/AgentBoardUI/Screens/IssueDetailSheet.swift
+++ b/AgentBoardUI/Screens/IssueDetailSheet.swift
@@ -59,18 +59,15 @@ struct IssueDetailSheet: View {
                     Text(item.title)
                         .font(.title2.weight(.bold))
                         .foregroundStyle(.white)
-
                     HStack(spacing: 8) {
                         WorkStatusPill(state: item.status)
                         PriorityPill(priority: item.priority)
                     }
-
                     if !item.assignees.isEmpty {
                         Label(item.assignees.joined(separator: ", "), systemImage: "person.fill")
                             .font(.subheadline)
                             .foregroundStyle(BoardPalette.paper.opacity(0.82))
                     }
-
                     if let milestone = item.milestone {
                         Label(milestone.title, systemImage: "flag")
                             .font(.subheadline)
@@ -78,64 +75,75 @@ struct IssueDetailSheet: View {
                     }
                 }
             }
+            descriptionCard
+            labelsCard
+            timelineCard
+        }
+    }
 
-            if !item.bodySummary.isEmpty {
-                BoardSurface {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Description")
-                            .font(.headline)
-                            .foregroundStyle(.white)
-                        Text(item.bodySummary)
-                            .font(.body)
-                            .foregroundStyle(BoardPalette.paper.opacity(0.82))
-                            .textSelection(.enabled)
-                    }
-                }
-            }
-
-            if !item.labels.isEmpty {
-                BoardSurface {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Labels")
-                            .font(.headline)
-                            .foregroundStyle(.white)
-                        FlowLayout(spacing: 8) {
-                            ForEach(item.labels, id: \.self) { label in
-                                Text(label)
-                                    .font(.caption.weight(.semibold))
-                                    .foregroundStyle(.white)
-                                    .padding(.horizontal, 10)
-                                    .padding(.vertical, 5)
-                                    .background(
-                                        Capsule().fill(BoardPalette.cobalt.opacity(0.28))
-                                    )
-                            }
-                        }
-                    }
-                }
-            }
-
+    @ViewBuilder
+    private var descriptionCard: some View {
+        if !item.bodySummary.isEmpty {
             BoardSurface {
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Timeline")
+                    Text("Description")
                         .font(.headline)
                         .foregroundStyle(.white)
-                    HStack {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Created")
+                    Text(item.bodySummary)
+                        .font(.body)
+                        .foregroundStyle(BoardPalette.paper.opacity(0.82))
+                        .textSelection(.enabled)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var labelsCard: some View {
+        if !item.labels.isEmpty {
+            BoardSurface {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Labels")
+                        .font(.headline)
+                        .foregroundStyle(.white)
+                    FlowLayout(spacing: 8) {
+                        ForEach(item.labels, id: \.self) { label in
+                            Text(label)
                                 .font(.caption.weight(.semibold))
-                                .foregroundStyle(BoardPalette.paper.opacity(0.6))
-                            Text(item.createdAt, style: .relative)
                                 .foregroundStyle(.white)
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 5)
+                                .background(
+                                    Capsule().fill(BoardPalette.cobalt.opacity(0.28))
+                                )
                         }
-                        Spacer()
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Updated")
-                                .font(.caption.weight(.semibold))
-                                .foregroundStyle(BoardPalette.paper.opacity(0.6))
-                            Text(item.updatedAt, style: .relative)
-                                .foregroundStyle(.white)
-                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var timelineCard: some View {
+        BoardSurface {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Timeline")
+                    .font(.headline)
+                    .foregroundStyle(.white)
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Created")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(BoardPalette.paper.opacity(0.6))
+                        Text(item.createdAt, style: .relative)
+                            .foregroundStyle(.white)
+                    }
+                    Spacer()
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Updated")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(BoardPalette.paper.opacity(0.6))
+                        Text(item.updatedAt, style: .relative)
+                            .foregroundStyle(.white)
                     }
                 }
             }

--- a/AgentBoardUI/Screens/IssueDetailSheet.swift
+++ b/AgentBoardUI/Screens/IssueDetailSheet.swift
@@ -1,0 +1,279 @@
+import AgentBoardCore
+import SwiftUI
+
+struct IssueDetailSheet: View {
+    @Environment(AgentBoardAppModel.self) private var appModel
+    @Environment(\.dismiss) private var dismiss
+
+    let item: WorkItem
+
+    @State private var isEditing = false
+    @State private var editTitle = ""
+    @State private var editBody = ""
+    @State private var editLabels = ""
+    @State private var editAssignees = ""
+    @State private var editState: WorkState = .open
+    @State private var isSaving = false
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                BoardBackground()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        if isEditing {
+                            editForm
+                        } else {
+                            readView
+                        }
+                    }
+                    .padding(24)
+                }
+            }
+            .navigationTitle(item.issueReference)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                        .foregroundStyle(.white)
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    if isEditing {
+                        Button("Save") { save() }
+                            .buttonStyle(.borderedProminent)
+                            .tint(BoardPalette.cobalt)
+                            .disabled(isSaving || editTitle.trimmedOrNil == nil)
+                    } else {
+                        Button("Edit") { beginEditing() }
+                            .buttonStyle(.bordered)
+                            .tint(.white)
+                    }
+                }
+            }
+        }
+    }
+
+    private var readView: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            BoardSurface {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text(item.title)
+                        .font(.title2.weight(.bold))
+                        .foregroundStyle(.white)
+
+                    HStack(spacing: 8) {
+                        WorkStatusPill(state: item.status)
+                        PriorityPill(priority: item.priority)
+                    }
+
+                    if !item.assignees.isEmpty {
+                        Label(item.assignees.joined(separator: ", "), systemImage: "person.fill")
+                            .font(.subheadline)
+                            .foregroundStyle(BoardPalette.paper.opacity(0.82))
+                    }
+
+                    if let milestone = item.milestone {
+                        Label(milestone.title, systemImage: "flag")
+                            .font(.subheadline)
+                            .foregroundStyle(BoardPalette.gold)
+                    }
+                }
+            }
+
+            if !item.bodySummary.isEmpty {
+                BoardSurface {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Description")
+                            .font(.headline)
+                            .foregroundStyle(.white)
+                        Text(item.bodySummary)
+                            .font(.body)
+                            .foregroundStyle(BoardPalette.paper.opacity(0.82))
+                            .textSelection(.enabled)
+                    }
+                }
+            }
+
+            if !item.labels.isEmpty {
+                BoardSurface {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Labels")
+                            .font(.headline)
+                            .foregroundStyle(.white)
+                        FlowLayout(spacing: 8) {
+                            ForEach(item.labels, id: \.self) { label in
+                                Text(label)
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(.white)
+                                    .padding(.horizontal, 10)
+                                    .padding(.vertical, 5)
+                                    .background(
+                                        Capsule().fill(BoardPalette.cobalt.opacity(0.28))
+                                    )
+                            }
+                        }
+                    }
+                }
+            }
+
+            BoardSurface {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Timeline")
+                        .font(.headline)
+                        .foregroundStyle(.white)
+                    HStack {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Created")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(BoardPalette.paper.opacity(0.6))
+                            Text(item.createdAt, style: .relative)
+                                .foregroundStyle(.white)
+                        }
+                        Spacer()
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Updated")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(BoardPalette.paper.opacity(0.6))
+                            Text(item.updatedAt, style: .relative)
+                                .foregroundStyle(.white)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var editForm: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            BoardSurface {
+                VStack(alignment: .leading, spacing: 14) {
+                    BoardSectionTitle("Edit Issue")
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Title").font(.headline).foregroundStyle(.white)
+                        TextField("Issue title", text: $editTitle)
+                            .boardFieldStyle()
+                    }
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Description").font(.headline).foregroundStyle(.white)
+                        TextEditor(text: $editBody)
+                            .scrollContentBackground(.hidden)
+                            .frame(minHeight: 100)
+                            .padding(10)
+                            .background(RoundedRectangle(cornerRadius: 16).fill(Color.black.opacity(0.22)))
+                            .foregroundStyle(.white)
+                    }
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Labels (comma-separated)").font(.headline).foregroundStyle(.white)
+                        TextField("bug, enhancement, priority:p1", text: $editLabels)
+                            .boardFieldStyle()
+                    }
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Assignees (comma-separated)").font(.headline).foregroundStyle(.white)
+                        TextField("alice, bob", text: $editAssignees)
+                            .boardFieldStyle()
+                    }
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Status").font(.headline).foregroundStyle(.white)
+                        Picker("Status", selection: $editState) {
+                            ForEach(WorkState.allCases) { state in
+                                Text(state.title).tag(state)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                    }
+                }
+            }
+
+            if isSaving {
+                ProgressView("Saving…")
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
+        }
+    }
+
+    private func beginEditing() {
+        editTitle = item.title
+        editBody = item.bodySummary
+        editLabels = item.labels.joined(separator: ", ")
+        editAssignees = item.assignees.joined(separator: ", ")
+        editState = item.status
+        isEditing = true
+    }
+
+    private func save() {
+        isSaving = true
+        let labels = editLabels.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
+        let assignees = editAssignees.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
+        Task {
+            await appModel.workStore.updateIssue(
+                item,
+                title: editTitle.trimmedOrNil,
+                body: editBody.trimmedOrNil,
+                labels: labels,
+                assignees: assignees,
+                state: editState
+            )
+            isSaving = false
+            isEditing = false
+            dismiss()
+        }
+    }
+}
+
+private struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache _: inout ()) -> CGSize {
+        let width = proposal.width ?? 0
+        var height: CGFloat = 0
+        var x: CGFloat = 0
+        var rowHeight: CGFloat = 0
+
+        for view in subviews {
+            let size = view.sizeThatFits(.unspecified)
+            if x + size.width > width, x > 0 {
+                height += rowHeight + spacing
+                x = 0
+                rowHeight = 0
+            }
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+        height += rowHeight
+        return CGSize(width: width, height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache _: inout ()) {
+        var x = bounds.minX
+        var y = bounds.minY
+        var rowHeight: CGFloat = 0
+
+        for view in subviews {
+            let size = view.sizeThatFits(.unspecified)
+            if x + size.width > bounds.maxX, x > bounds.minX {
+                y += rowHeight + spacing
+                x = bounds.minX
+                rowHeight = 0
+            }
+            view.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+}
+
+private extension View {
+    func boardFieldStyle() -> some View {
+        padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(RoundedRectangle(cornerRadius: 16).fill(Color.black.opacity(0.22)))
+            .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.white.opacity(0.08), lineWidth: 1))
+            .foregroundStyle(.white)
+    }
+}
+

--- a/AgentBoardUI/Screens/IssueDetailSheet.swift
+++ b/AgentBoardUI/Screens/IssueDetailSheet.swift
@@ -276,4 +276,3 @@ private extension View {
             .foregroundStyle(.white)
     }
 }
-

--- a/AgentBoardUI/Screens/SessionDetailSheet.swift
+++ b/AgentBoardUI/Screens/SessionDetailSheet.swift
@@ -1,0 +1,216 @@
+import AgentBoardCore
+import SwiftUI
+
+struct SessionDetailSheet: View {
+    @Environment(AgentBoardAppModel.self) private var appModel
+    @Environment(\.dismiss) private var dismiss
+
+    let session: AgentSession
+
+    @State private var output: String?
+    @State private var isLoadingOutput = false
+    @State private var showStopConfirm = false
+    @State private var isActing = false
+
+    private var isControllable: Bool {
+        session.status == .running || session.status == .idle
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                BoardBackground()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        metadataCard
+                        outputCard
+                        if isControllable {
+                            controlCard
+                        }
+                    }
+                    .padding(24)
+                }
+            }
+            .navigationTitle(session.source)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                        .foregroundStyle(.white)
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        Task { await loadOutput() }
+                    } label: {
+                        Label("Refresh Output", systemImage: "arrow.clockwise")
+                    }
+                    .foregroundStyle(.white)
+                    .disabled(isLoadingOutput)
+                }
+            }
+            .alert("Stop Session", isPresented: $showStopConfirm) {
+                Button("Stop", role: .destructive) {
+                    Task {
+                        isActing = true
+                        await appModel.sessionsStore.stopSession(id: session.id)
+                        isActing = false
+                        dismiss()
+                    }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("Send a stop signal to \"\(session.source)\"? The session will be terminated.")
+            }
+        }
+        .task { await loadOutput() }
+    }
+
+    private var metadataCard: some View {
+        BoardSurface {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    SessionStatusPill(status: session.status)
+                    Spacer()
+                    if let pid = session.pid {
+                        BoardChip(label: "PID \(pid)", systemImage: "cpu", tint: BoardPalette.paper.opacity(0.6))
+                    }
+                }
+
+                Text(session.source)
+                    .font(.title2.weight(.bold))
+                    .foregroundStyle(.white)
+
+                if let model = session.model {
+                    Label(model, systemImage: "cpu")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(BoardPalette.paper.opacity(0.82))
+                }
+
+                if let tmux = session.tmuxSession {
+                    Label(tmux, systemImage: "terminal")
+                        .font(.subheadline)
+                        .foregroundStyle(BoardPalette.paper.opacity(0.72))
+                }
+
+                if let linkedTask = appModel.agentsStore.tasks.first(where: { $0.sessionID == session.id }) {
+                    Label(linkedTask.title, systemImage: "checkmark.circle")
+                        .font(.subheadline)
+                        .foregroundStyle(BoardPalette.gold)
+                }
+
+                if let workItem = session.workItem {
+                    Label(workItem.issueReference, systemImage: "square.grid.2x2")
+                        .font(.subheadline)
+                        .foregroundStyle(BoardPalette.cobalt)
+                }
+
+                Divider().overlay(Color.white.opacity(0.1))
+
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Started")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(BoardPalette.paper.opacity(0.6))
+                        Text(session.startedAt, style: .relative)
+                            .foregroundStyle(.white)
+                    }
+                    Spacer()
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Last Seen")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(BoardPalette.paper.opacity(0.6))
+                        Text(session.lastSeenAt, style: .relative)
+                            .foregroundStyle(.white)
+                    }
+                }
+            }
+        }
+    }
+
+    private var outputCard: some View {
+        BoardSurface {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Terminal Output")
+                        .font(.headline)
+                        .foregroundStyle(.white)
+                    Spacer()
+                    if isLoadingOutput {
+                        ProgressView()
+                            .controlSize(.small)
+                            .tint(BoardPalette.gold)
+                    }
+                }
+
+                if let output, !output.isEmpty {
+                    ScrollView {
+                        Text(output)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(BoardPalette.mint)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(12)
+                    }
+                    .frame(maxHeight: 320)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .fill(Color.black.opacity(0.36))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .stroke(Color.white.opacity(0.06), lineWidth: 1)
+                    )
+                } else if !isLoadingOutput {
+                    Text("No output captured. The companion service may need tmux enabled.")
+                        .font(.subheadline)
+                        .foregroundStyle(BoardPalette.paper.opacity(0.55))
+                        .padding(.top, 4)
+                }
+            }
+        }
+    }
+
+    private var controlCard: some View {
+        BoardSurface {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Controls")
+                    .font(.headline)
+                    .foregroundStyle(.white)
+
+                HStack(spacing: 12) {
+                    Button {
+                        Task {
+                            isActing = true
+                            await appModel.sessionsStore.nudgeSession(id: session.id)
+                            isActing = false
+                        }
+                    } label: {
+                        Label("Nudge", systemImage: "hand.tap")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(BoardPalette.cobalt)
+                    .disabled(isActing)
+
+                    Button {
+                        showStopConfirm = true
+                    } label: {
+                        Label("Stop", systemImage: "stop.circle")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(BoardPalette.coral)
+                    .disabled(isActing)
+                }
+            }
+        }
+    }
+
+    private func loadOutput() async {
+        isLoadingOutput = true
+        output = await appModel.sessionsStore.fetchOutput(sessionID: session.id)
+        if output == nil {
+            output = session.lastOutput
+        }
+        isLoadingOutput = false
+    }
+}

--- a/AgentBoardUI/Screens/SessionsScreen.swift
+++ b/AgentBoardUI/Screens/SessionsScreen.swift
@@ -33,9 +33,6 @@ struct SessionsScreen: View {
                             }
                         }
                     }
-                    .refreshable {
-                        await appModel.sessionsStore.refresh()
-                    }
                 }
             }
             .padding(24)

--- a/AgentBoardUI/Screens/SessionsScreen.swift
+++ b/AgentBoardUI/Screens/SessionsScreen.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct SessionsScreen: View {
     @Environment(AgentBoardAppModel.self) private var appModel
+    @State private var selectedSession: AgentSession?
     private let columns = [GridItem(.adaptive(minimum: 280), spacing: 16)]
 
     var body: some View {
@@ -10,96 +11,127 @@ struct SessionsScreen: View {
             BoardBackground()
 
             VStack(alignment: .leading, spacing: 18) {
-                HStack(alignment: .top) {
-                    BoardHeader(
-                        eyebrow: "Sessions",
-                        title: "Live execution status from the companion service",
-                        subtitle: "The new app tracks sessions as companion-owned runtime state rather than terminal capture views inside the client."
-                    )
-
-                    Spacer(minLength: 20)
-
-                    Button("Refresh") {
-                        Task { await appModel.sessionsStore.refresh() }
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .tint(BoardPalette.cobalt)
-                }
+                header
 
                 if appModel.sessionsStore.sessions.isEmpty {
                     EmptyStateCard(
                         title: "No sessions yet",
-                        message: appModel.sessionsStore
-                            .statusMessage ??
-                            "Once the companion sees agent processes, their live state will appear here.",
+                        message: appModel.sessionsStore.statusMessage
+                            ?? "Once the companion sees agent processes, their live state will appear here.",
                         systemImage: "bolt.horizontal.circle"
                     )
                 } else {
                     ScrollView {
                         LazyVGrid(columns: columns, spacing: 16) {
                             ForEach(appModel.sessionsStore.sessions) { session in
-                                BoardSurface {
-                                    VStack(alignment: .leading, spacing: 12) {
-                                        HStack {
-                                            SessionStatusPill(status: session.status)
-                                            Spacer()
-                                            Text(session.id)
-                                                .font(.caption.weight(.semibold))
-                                                .foregroundStyle(BoardPalette.gold)
-                                        }
-
-                                        Text(session.source)
-                                            .font(.headline)
-                                            .foregroundStyle(.white)
-
-                                        if let model = session.model {
-                                            Text(model)
-                                                .font(.subheadline.weight(.semibold))
-                                                .foregroundStyle(BoardPalette.paper.opacity(0.82))
-                                        }
-
-                                        if let taskID = session.linkedTaskID {
-                                            Text("Task \(taskID)")
-                                                .font(.subheadline)
-                                                .foregroundStyle(BoardPalette.paper.opacity(0.72))
-                                        }
-
-                                        if let workItem = session.workItem {
-                                            Text(workItem.issueReference)
-                                                .font(.caption)
-                                                .foregroundStyle(BoardPalette.paper.opacity(0.72))
-                                        }
-
-                                        Divider()
-                                            .overlay(Color.white.opacity(0.1))
-
-                                        HStack {
-                                            VStack(alignment: .leading, spacing: 4) {
-                                                Text("Started")
-                                                    .font(.caption.weight(.semibold))
-                                                    .foregroundStyle(BoardPalette.paper.opacity(0.6))
-                                                Text(session.startedAt, style: .relative)
-                                                    .foregroundStyle(.white)
-                                            }
-
-                                            Spacer()
-
-                                            VStack(alignment: .leading, spacing: 4) {
-                                                Text("Last Seen")
-                                                    .font(.caption.weight(.semibold))
-                                                    .foregroundStyle(BoardPalette.paper.opacity(0.6))
-                                                Text(session.lastSeenAt, style: .relative)
-                                                    .foregroundStyle(.white)
-                                            }
-                                        }
-                                    }
+                                Button {
+                                    selectedSession = session
+                                } label: {
+                                    sessionCard(session)
                                 }
+                                .buttonStyle(.plain)
                             }
                         }
+                    }
+                    .refreshable {
+                        await appModel.sessionsStore.refresh()
                     }
                 }
             }
             .padding(24)
+        }
+        .navigationTitle("Sessions")
+        .refreshable {
+            await appModel.sessionsStore.refresh()
+        }
+        .sheet(item: $selectedSession) { session in
+            SessionDetailSheet(session: session)
+                .environment(appModel)
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("SESSIONS".uppercased())
+                    .font(.caption.weight(.semibold))
+                    .tracking(2)
+                    .foregroundStyle(BoardPalette.gold)
+                Text("Runtime")
+                    .font(.system(size: 28, weight: .bold, design: .serif))
+                    .foregroundStyle(.white)
+            }
+
+            Spacer(minLength: 20)
+
+            Button("Refresh") {
+                Task { await appModel.sessionsStore.refresh() }
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(BoardPalette.cobalt)
+        }
+    }
+
+    private func sessionCard(_ session: AgentSession) -> some View {
+        BoardSurface {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    SessionStatusPill(status: session.status)
+                    Spacer()
+                    if let pid = session.pid {
+                        Text("PID \(pid)")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(BoardPalette.gold)
+                    } else {
+                        Text(session.id)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(BoardPalette.gold)
+                            .lineLimit(1)
+                    }
+                }
+
+                Text(session.source)
+                    .font(.headline)
+                    .foregroundStyle(.white)
+
+                if let model = session.model {
+                    Text(model)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(BoardPalette.paper.opacity(0.82))
+                }
+
+                if let taskID = session.linkedTaskID {
+                    Text("Task \(taskID)")
+                        .font(.subheadline)
+                        .foregroundStyle(BoardPalette.paper.opacity(0.72))
+                }
+
+                if let workItem = session.workItem {
+                    Text(workItem.issueReference)
+                        .font(.caption)
+                        .foregroundStyle(BoardPalette.paper.opacity(0.72))
+                }
+
+                Divider().overlay(Color.white.opacity(0.1))
+
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Started")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(BoardPalette.paper.opacity(0.6))
+                        Text(session.startedAt, style: .relative)
+                            .foregroundStyle(.white)
+                    }
+                    Spacer()
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Last Seen")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(BoardPalette.paper.opacity(0.6))
+                        Text(session.lastSeenAt, style: .relative)
+                            .foregroundStyle(.white)
+                    }
+                }
+            }
         }
     }
 }

--- a/AgentBoardUI/Screens/SettingsScreen.swift
+++ b/AgentBoardUI/Screens/SettingsScreen.swift
@@ -11,7 +11,6 @@ struct SettingsScreen: View {
 
         ZStack {
             BoardBackground()
-
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
                     BoardHeader(
@@ -19,138 +18,125 @@ struct SettingsScreen: View {
                         title: "Current Apple stack, minimal legacy baggage",
                         subtitle: "Hermes, GitHub, and the companion service are all configured independently so the app stays modular and modern."
                     )
-
                     BoardSurface {
                         VStack(alignment: .leading, spacing: 14) {
                             BoardSectionTitle("Hermes Gateway", subtitle: "Chat lives here and nowhere else.")
-
                             TextField("Gateway URL", text: $settingsStore.hermesGatewayURL)
                                 .boardFieldStyle()
-
                             TextField("Preferred model", text: $settingsStore.hermesModelID)
                                 .boardFieldStyle()
-
                             SecureField("API key (optional)", text: $settingsStore.hermesAPIKey)
                                 .boardFieldStyle()
                         }
                     }
-
-                    BoardSurface {
-                        VStack(alignment: .leading, spacing: 14) {
-                            BoardSectionTitle("GitHub Issues", subtitle: "Tickets are the canonical work source.")
-
-                            SecureField("GitHub token", text: $settingsStore.githubToken)
-                                .boardFieldStyle()
-
-                            HStack(spacing: 10) {
-                                TextField("Owner", text: $repositoryOwner)
-                                    .boardFieldStyle()
-
-                                TextField("Repo", text: $repositoryName)
-                                    .boardFieldStyle()
-
-                                Button("Add") {
-                                    settingsStore.addRepository(owner: repositoryOwner, name: repositoryName)
-                                    repositoryOwner = ""
-                                    repositoryName = ""
-                                }
-                                .buttonStyle(.borderedProminent)
-                                .tint(BoardPalette.cobalt)
-                            }
-
-                            if settingsStore.repositories.isEmpty {
-                                Text("No repositories connected yet.")
-                                    .font(.subheadline)
-                                    .foregroundStyle(BoardPalette.paper.opacity(0.72))
-                            } else {
-                                ForEach(settingsStore.repositories) { repository in
-                                    HStack {
-                                        Text(repository.fullName)
-                                            .foregroundStyle(.white)
-
-                                        Spacer()
-
-                                        Button("Remove") {
-                                            settingsStore.removeRepository(repository)
-                                        }
-                                        .buttonStyle(.bordered)
-                                    }
-                                    .padding(12)
-                                    .background(
-                                        RoundedRectangle(cornerRadius: 18, style: .continuous)
-                                            .fill(Color.black.opacity(0.2))
-                                    )
-                                }
-                            }
-                        }
-                    }
-
-                    BoardSurface {
-                        VStack(alignment: .leading, spacing: 14) {
-                            BoardSectionTitle(
-                                "Companion Service",
-                                subtitle: "Tasks, sessions, and live events come from this process."
-                            )
-
-                            TextField("Companion URL", text: $settingsStore.companionURL)
-                                .boardFieldStyle()
-
-                            SecureField("Companion token", text: $settingsStore.companionToken)
-                                .boardFieldStyle()
-
-                            VStack(alignment: .leading, spacing: 8) {
-                                Text("Auto refresh interval")
-                                    .font(.headline)
-                                    .foregroundStyle(.white)
-
-                                HStack {
-                                    Slider(value: $settingsStore.autoRefreshInterval, in: 15 ... 120, step: 15)
-                                        .tint(BoardPalette.gold)
-                                    Text("\(Int(settingsStore.autoRefreshInterval))s")
-                                        .foregroundStyle(BoardPalette.paper.opacity(0.78))
-                                        .frame(width: 52)
-                                }
-                            }
-                        }
-                    }
-
-                    BoardSurface {
-                        VStack(alignment: .leading, spacing: 12) {
-                            Text(
-                                appModel.settingsStore.errorMessage
-                                    ?? appModel.settingsStore.statusMessage
-                                    ?? appModel.statusMessage
-                                    ?? "The new architecture is ready for both platforms."
-                            )
-                            .font(.subheadline)
-                            .foregroundStyle(appModel.settingsStore.errorMessage == nil ? BoardPalette.paper
-                                .opacity(0.78) : BoardPalette.coral)
-
-                            HStack(spacing: 10) {
-                                Button("Save and Refresh") {
-                                    Task {
-                                        await appModel.saveSettingsAndReconnect()
-                                    }
-                                }
-                                .buttonStyle(.borderedProminent)
-                                .tint(BoardPalette.coral)
-
-                                Button("Refresh Hermes") {
-                                    Task {
-                                        await appModel.chatStore.refreshConnection()
-                                        await appModel.chatStore.refreshModels()
-                                    }
-                                }
-                                .buttonStyle(.bordered)
-                                .tint(.white)
-                            }
-                        }
-                    }
+                    githubSection
+                    companionSection
+                    statusSection
                 }
                 .padding(24)
             }
         }
         .navigationTitle("Settings")
+    }
+
+    private var githubSection: some View {
+        @Bindable var settingsStore = appModel.settingsStore
+        return BoardSurface {
+            VStack(alignment: .leading, spacing: 14) {
+                BoardSectionTitle("GitHub Issues", subtitle: "Tickets are the canonical work source.")
+                SecureField("GitHub token", text: $settingsStore.githubToken)
+                    .boardFieldStyle()
+                HStack(spacing: 10) {
+                    TextField("Owner", text: $repositoryOwner)
+                        .boardFieldStyle()
+                    TextField("Repo", text: $repositoryName)
+                        .boardFieldStyle()
+                    Button("Add") {
+                        settingsStore.addRepository(owner: repositoryOwner, name: repositoryName)
+                        repositoryOwner = ""
+                        repositoryName = ""
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(BoardPalette.cobalt)
+                }
+                if settingsStore.repositories.isEmpty {
+                    Text("No repositories connected yet.")
+                        .font(.subheadline)
+                        .foregroundStyle(BoardPalette.paper.opacity(0.72))
+                } else {
+                    ForEach(settingsStore.repositories) { repository in
+                        HStack {
+                            Text(repository.fullName).foregroundStyle(.white)
+                            Spacer()
+                            Button("Remove") { settingsStore.removeRepository(repository) }
+                                .buttonStyle(.bordered)
+                        }
+                        .padding(12)
+                        .background(RoundedRectangle(cornerRadius: 18, style: .continuous)
+                            .fill(Color.black.opacity(0.2)))
+                    }
+                }
+            }
+        }
+    }
+
+    private var companionSection: some View {
+        @Bindable var settingsStore = appModel.settingsStore
+        return BoardSurface {
+            VStack(alignment: .leading, spacing: 14) {
+                BoardSectionTitle(
+                    "Companion Service",
+                    subtitle: "Tasks, sessions, and live events come from this process."
+                )
+                TextField("Companion URL", text: $settingsStore.companionURL)
+                    .boardFieldStyle()
+                SecureField("Companion token", text: $settingsStore.companionToken)
+                    .boardFieldStyle()
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Auto refresh interval")
+                        .font(.headline)
+                        .foregroundStyle(.white)
+                    HStack {
+                        Slider(value: $settingsStore.autoRefreshInterval, in: 15 ... 120, step: 15)
+                            .tint(BoardPalette.gold)
+                        Text("\(Int(settingsStore.autoRefreshInterval))s")
+                            .foregroundStyle(BoardPalette.paper.opacity(0.78))
+                            .frame(width: 52)
+                    }
+                }
+            }
+        }
+    }
+
+    private var statusSection: some View {
+        BoardSurface {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(
+                    appModel.settingsStore.errorMessage
+                        ?? appModel.settingsStore.statusMessage
+                        ?? appModel.statusMessage
+                        ?? "The new architecture is ready for both platforms."
+                )
+                .font(.subheadline)
+                .foregroundStyle(appModel.settingsStore.errorMessage == nil
+                    ? BoardPalette.paper.opacity(0.78) : BoardPalette.coral)
+                HStack(spacing: 10) {
+                    Button("Save and Refresh") {
+                        Task { await appModel.saveSettingsAndReconnect() }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(BoardPalette.coral)
+                    Button("Refresh Hermes") {
+                        Task {
+                            await appModel.chatStore.refreshConnection()
+                            await appModel.chatStore.refreshModels()
+                        }
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.white)
+                }
+            }
+        }
     }
 }
 

--- a/AgentBoardUI/Screens/SettingsScreen.swift
+++ b/AgentBoardUI/Screens/SettingsScreen.swift
@@ -150,6 +150,7 @@ struct SettingsScreen: View {
                 .padding(24)
             }
         }
+        .navigationTitle("Settings")
     }
 }
 

--- a/AgentBoardUI/Screens/TaskDetailSheet.swift
+++ b/AgentBoardUI/Screens/TaskDetailSheet.swift
@@ -12,7 +12,7 @@ struct TaskDetailSheet: View {
     @State private var editPriority: WorkPriority = .medium
     @State private var editAgent = ""
     @State private var editNote = ""
-    @State private var editSessionID: String? = nil
+    @State private var editSessionID: String?
     @State private var isSaving = false
     @State private var showDeleteConfirm = false
 
@@ -22,113 +22,14 @@ struct TaskDetailSheet: View {
                 BoardBackground()
                 ScrollView {
                     VStack(alignment: .leading, spacing: 16) {
-                        BoardSurface {
-                            VStack(alignment: .leading, spacing: 14) {
-                                BoardSectionTitle("Edit Task")
-
-                                VStack(alignment: .leading, spacing: 6) {
-                                    Text("Title").font(.headline).foregroundStyle(.white)
-                                    TextField("Task title", text: $editTitle)
-                                        .taskFieldStyle()
-                                }
-
-                                HStack(spacing: 16) {
-                                    VStack(alignment: .leading, spacing: 6) {
-                                        Text("Status").font(.headline).foregroundStyle(.white)
-                                        Picker("Status", selection: $editStatus) {
-                                            ForEach(AgentTaskState.allCases) { state in
-                                                Text(state.title).tag(state)
-                                            }
-                                        }
-                                        .pickerStyle(.menu)
-                                        .foregroundStyle(.white)
-                                        .padding(.horizontal, 14)
-                                        .padding(.vertical, 10)
-                                        .background(RoundedRectangle(cornerRadius: 14).fill(Color.black.opacity(0.22)))
-                                    }
-
-                                    VStack(alignment: .leading, spacing: 6) {
-                                        Text("Priority").font(.headline).foregroundStyle(.white)
-                                        Picker("Priority", selection: $editPriority) {
-                                            ForEach(WorkPriority.allCases) { p in
-                                                Text(p.title).tag(p)
-                                            }
-                                        }
-                                        .pickerStyle(.menu)
-                                        .foregroundStyle(.white)
-                                        .padding(.horizontal, 14)
-                                        .padding(.vertical, 10)
-                                        .background(RoundedRectangle(cornerRadius: 14).fill(Color.black.opacity(0.22)))
-                                    }
-                                }
-
-                                VStack(alignment: .leading, spacing: 6) {
-                                    Text("Assigned Agent").font(.headline).foregroundStyle(.white)
-                                    TextField("agent name", text: $editAgent)
-                                        .taskFieldStyle()
-                                }
-
-                                VStack(alignment: .leading, spacing: 6) {
-                                    Text("Link Session").font(.headline).foregroundStyle(.white)
-                                    Picker("Session", selection: $editSessionID) {
-                                        Text("None").tag(Optional<String>.none)
-                                        ForEach(appModel.sessionsStore.sessions) { session in
-                                            Text("\(session.source) — \(session.status.title)")
-                                                .tag(Optional(session.id))
-                                        }
-                                    }
-                                    .pickerStyle(.menu)
-                                    .foregroundStyle(.white)
-                                    .padding(.horizontal, 14)
-                                    .padding(.vertical, 10)
-                                    .background(RoundedRectangle(cornerRadius: 14).fill(Color.black.opacity(0.22)))
-                                }
-
-                                VStack(alignment: .leading, spacing: 6) {
-                                    Text("Notes").font(.headline).foregroundStyle(.white)
-                                    TextEditor(text: $editNote)
-                                        .scrollContentBackground(.hidden)
-                                        .frame(minHeight: 100)
-                                        .padding(10)
-                                        .background(RoundedRectangle(cornerRadius: 16).fill(Color.black.opacity(0.22)))
-                                        .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.white.opacity(0.08), lineWidth: 1))
-                                        .foregroundStyle(.white)
-                                }
-                            }
-                        }
-
-                        BoardSurface {
-                            VStack(alignment: .leading, spacing: 8) {
-                                Text("Work Item")
-                                    .font(.headline)
-                                    .foregroundStyle(.white)
-                                HStack {
-                                    Text(task.workItem.issueReference)
-                                        .font(.subheadline.weight(.semibold))
-                                        .foregroundStyle(BoardPalette.gold)
-                                    Spacer()
-                                    Text(task.createdAt, style: .relative)
-                                        .font(.caption)
-                                        .foregroundStyle(BoardPalette.paper.opacity(0.6))
-                                }
-                            }
-                        }
-
+                        editForm
+                        workItemCard
                         if isSaving {
                             ProgressView("Saving…")
                                 .foregroundStyle(.white)
                                 .frame(maxWidth: .infinity, alignment: .center)
                         }
-
-                        Button(role: .destructive) {
-                            showDeleteConfirm = true
-                        } label: {
-                            Label("Delete Task", systemImage: "trash")
-                                .frame(maxWidth: .infinity)
-                        }
-                        .buttonStyle(.bordered)
-                        .tint(BoardPalette.coral)
-                        .padding(.top, 4)
+                        deleteButton
                     }
                     .padding(24)
                 }
@@ -159,6 +60,116 @@ struct TaskDetailSheet: View {
             }
         }
         .onAppear { populate() }
+    }
+
+    private var editForm: some View {
+        BoardSurface {
+            VStack(alignment: .leading, spacing: 14) {
+                BoardSectionTitle("Edit Task")
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Title").font(.headline).foregroundStyle(.white)
+                    TextField("Task title", text: $editTitle)
+                        .taskFieldStyle()
+                }
+
+                statusAndPriorityRow
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Assigned Agent").font(.headline).foregroundStyle(.white)
+                    TextField("agent name", text: $editAgent)
+                        .taskFieldStyle()
+                }
+
+                sessionPicker
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Notes").font(.headline).foregroundStyle(.white)
+                    TextEditor(text: $editNote)
+                        .scrollContentBackground(.hidden)
+                        .frame(minHeight: 100)
+                        .padding(10)
+                        .background(RoundedRectangle(cornerRadius: 16).fill(Color.black.opacity(0.22)))
+                        .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.white.opacity(0.08), lineWidth: 1))
+                        .foregroundStyle(.white)
+                }
+            }
+        }
+    }
+
+    private var statusAndPriorityRow: some View {
+        HStack(spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Status").font(.headline).foregroundStyle(.white)
+                Picker("Status", selection: $editStatus) {
+                    ForEach(AgentTaskState.allCases) { state in
+                        Text(state.title).tag(state)
+                    }
+                }
+                .pickerStyle(.menu)
+                .foregroundStyle(.white)
+                .pickerBackground()
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Priority").font(.headline).foregroundStyle(.white)
+                Picker("Priority", selection: $editPriority) {
+                    ForEach(WorkPriority.allCases) { prio in
+                        Text(prio.title).tag(prio)
+                    }
+                }
+                .pickerStyle(.menu)
+                .foregroundStyle(.white)
+                .pickerBackground()
+            }
+        }
+    }
+
+    private var sessionPicker: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Link Session").font(.headline).foregroundStyle(.white)
+            Picker("Session", selection: $editSessionID) {
+                Text("None").tag(Optional<String>.none)
+                ForEach(appModel.sessionsStore.sessions) { session in
+                    Text("\(session.source) — \(session.status.title)")
+                        .tag(Optional(session.id))
+                }
+            }
+            .pickerStyle(.menu)
+            .foregroundStyle(.white)
+            .pickerBackground()
+        }
+    }
+
+    private var workItemCard: some View {
+        BoardSurface {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Work Item")
+                    .font(.headline)
+                    .foregroundStyle(.white)
+                HStack {
+                    Text(task.workItem.issueReference)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(BoardPalette.gold)
+                    Spacer()
+                    Text(task.createdAt, style: .relative)
+                        .font(.caption)
+                        .foregroundStyle(BoardPalette.paper.opacity(0.6))
+                }
+            }
+        }
+    }
+
+    private var deleteButton: some View {
+        Button(role: .destructive) {
+            showDeleteConfirm = true
+        } label: {
+            Label("Delete Task", systemImage: "trash")
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.bordered)
+        .tint(BoardPalette.coral)
+        .padding(.top, 4)
     }
 
     private func populate() {
@@ -196,5 +207,10 @@ private extension View {
             .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.white.opacity(0.08), lineWidth: 1))
             .foregroundStyle(.white)
     }
-}
 
+    func pickerBackground() -> some View {
+        padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(RoundedRectangle(cornerRadius: 14).fill(Color.black.opacity(0.22)))
+    }
+}

--- a/AgentBoardUI/Screens/TaskDetailSheet.swift
+++ b/AgentBoardUI/Screens/TaskDetailSheet.swift
@@ -1,0 +1,200 @@
+import AgentBoardCore
+import SwiftUI
+
+struct TaskDetailSheet: View {
+    @Environment(AgentBoardAppModel.self) private var appModel
+    @Environment(\.dismiss) private var dismiss
+
+    let task: AgentTask
+
+    @State private var editTitle = ""
+    @State private var editStatus: AgentTaskState = .backlog
+    @State private var editPriority: WorkPriority = .medium
+    @State private var editAgent = ""
+    @State private var editNote = ""
+    @State private var editSessionID: String? = nil
+    @State private var isSaving = false
+    @State private var showDeleteConfirm = false
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                BoardBackground()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        BoardSurface {
+                            VStack(alignment: .leading, spacing: 14) {
+                                BoardSectionTitle("Edit Task")
+
+                                VStack(alignment: .leading, spacing: 6) {
+                                    Text("Title").font(.headline).foregroundStyle(.white)
+                                    TextField("Task title", text: $editTitle)
+                                        .taskFieldStyle()
+                                }
+
+                                HStack(spacing: 16) {
+                                    VStack(alignment: .leading, spacing: 6) {
+                                        Text("Status").font(.headline).foregroundStyle(.white)
+                                        Picker("Status", selection: $editStatus) {
+                                            ForEach(AgentTaskState.allCases) { state in
+                                                Text(state.title).tag(state)
+                                            }
+                                        }
+                                        .pickerStyle(.menu)
+                                        .foregroundStyle(.white)
+                                        .padding(.horizontal, 14)
+                                        .padding(.vertical, 10)
+                                        .background(RoundedRectangle(cornerRadius: 14).fill(Color.black.opacity(0.22)))
+                                    }
+
+                                    VStack(alignment: .leading, spacing: 6) {
+                                        Text("Priority").font(.headline).foregroundStyle(.white)
+                                        Picker("Priority", selection: $editPriority) {
+                                            ForEach(WorkPriority.allCases) { p in
+                                                Text(p.title).tag(p)
+                                            }
+                                        }
+                                        .pickerStyle(.menu)
+                                        .foregroundStyle(.white)
+                                        .padding(.horizontal, 14)
+                                        .padding(.vertical, 10)
+                                        .background(RoundedRectangle(cornerRadius: 14).fill(Color.black.opacity(0.22)))
+                                    }
+                                }
+
+                                VStack(alignment: .leading, spacing: 6) {
+                                    Text("Assigned Agent").font(.headline).foregroundStyle(.white)
+                                    TextField("agent name", text: $editAgent)
+                                        .taskFieldStyle()
+                                }
+
+                                VStack(alignment: .leading, spacing: 6) {
+                                    Text("Link Session").font(.headline).foregroundStyle(.white)
+                                    Picker("Session", selection: $editSessionID) {
+                                        Text("None").tag(Optional<String>.none)
+                                        ForEach(appModel.sessionsStore.sessions) { session in
+                                            Text("\(session.source) — \(session.status.title)")
+                                                .tag(Optional(session.id))
+                                        }
+                                    }
+                                    .pickerStyle(.menu)
+                                    .foregroundStyle(.white)
+                                    .padding(.horizontal, 14)
+                                    .padding(.vertical, 10)
+                                    .background(RoundedRectangle(cornerRadius: 14).fill(Color.black.opacity(0.22)))
+                                }
+
+                                VStack(alignment: .leading, spacing: 6) {
+                                    Text("Notes").font(.headline).foregroundStyle(.white)
+                                    TextEditor(text: $editNote)
+                                        .scrollContentBackground(.hidden)
+                                        .frame(minHeight: 100)
+                                        .padding(10)
+                                        .background(RoundedRectangle(cornerRadius: 16).fill(Color.black.opacity(0.22)))
+                                        .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.white.opacity(0.08), lineWidth: 1))
+                                        .foregroundStyle(.white)
+                                }
+                            }
+                        }
+
+                        BoardSurface {
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text("Work Item")
+                                    .font(.headline)
+                                    .foregroundStyle(.white)
+                                HStack {
+                                    Text(task.workItem.issueReference)
+                                        .font(.subheadline.weight(.semibold))
+                                        .foregroundStyle(BoardPalette.gold)
+                                    Spacer()
+                                    Text(task.createdAt, style: .relative)
+                                        .font(.caption)
+                                        .foregroundStyle(BoardPalette.paper.opacity(0.6))
+                                }
+                            }
+                        }
+
+                        if isSaving {
+                            ProgressView("Saving…")
+                                .foregroundStyle(.white)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                        }
+
+                        Button(role: .destructive) {
+                            showDeleteConfirm = true
+                        } label: {
+                            Label("Delete Task", systemImage: "trash")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(BoardPalette.coral)
+                        .padding(.top, 4)
+                    }
+                    .padding(24)
+                }
+            }
+            .navigationTitle(task.workItem.issueReference)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundStyle(.white)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }
+                        .buttonStyle(.borderedProminent)
+                        .tint(BoardPalette.cobalt)
+                        .disabled(isSaving || editTitle.trimmedOrNil == nil)
+                }
+            }
+            .alert("Delete Task", isPresented: $showDeleteConfirm) {
+                Button("Delete", role: .destructive) {
+                    Task {
+                        await appModel.agentsStore.deleteTask(id: task.id)
+                        dismiss()
+                    }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("Are you sure you want to delete \"\(task.title)\"? This cannot be undone.")
+            }
+        }
+        .onAppear { populate() }
+    }
+
+    private func populate() {
+        editTitle = task.title
+        editStatus = task.status
+        editPriority = task.priority
+        editAgent = task.assignedAgent
+        editNote = task.note
+        editSessionID = task.sessionID
+    }
+
+    private func save() {
+        isSaving = true
+        let patch = AgentTaskPatch(
+            title: editTitle.trimmedOrNil,
+            status: editStatus,
+            priority: editPriority,
+            assignedAgent: editAgent.trimmedOrNil,
+            sessionID: editSessionID,
+            note: editNote.trimmedOrNil
+        )
+        Task {
+            await appModel.agentsStore.updateTask(id: task.id, patch: patch)
+            isSaving = false
+            dismiss()
+        }
+    }
+}
+
+private extension View {
+    func taskFieldStyle() -> some View {
+        padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(RoundedRectangle(cornerRadius: 16).fill(Color.black.opacity(0.22)))
+            .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.white.opacity(0.08), lineWidth: 1))
+            .foregroundStyle(.white)
+    }
+}
+

--- a/AgentBoardUI/Screens/WorkScreen.swift
+++ b/AgentBoardUI/Screens/WorkScreen.swift
@@ -5,107 +5,181 @@ private enum WorkLayoutMode: String, CaseIterable, Identifiable {
     case board
     case list
 
-    var id: String {
-        rawValue
-    }
+    var id: String { rawValue }
 }
 
 struct WorkScreen: View {
     @Environment(AgentBoardAppModel.self) private var appModel
     @State private var layoutMode: WorkLayoutMode = .board
+    @State private var selectedItem: WorkItem?
+    @State private var isPresentingCreate = false
+    @State private var selectedRepo: String = "all"
 
     var body: some View {
         ZStack {
             BoardBackground()
 
-            VStack(alignment: .leading, spacing: 18) {
-                HStack(alignment: .top) {
-                    BoardHeader(
-                        eyebrow: "GitHub Work",
-                        title: "Issues become the board, not beads",
-                        subtitle: "The new work surface groups GitHub Issues into a modern board or list and lets status changes round-trip back to GitHub."
-                    )
+            VStack(alignment: .leading, spacing: 14) {
+                header
 
-                    Spacer(minLength: 20)
+                filterBar
 
-                    VStack(alignment: .trailing, spacing: 10) {
-                        Picker("Layout", selection: $layoutMode) {
-                            ForEach(WorkLayoutMode.allCases) { mode in
-                                Text(mode.rawValue.capitalized).tag(mode)
-                            }
-                        }
-                        .pickerStyle(.segmented)
-                        .frame(maxWidth: 220)
-
-                        Button("Refresh") {
-                            Task { await appModel.workStore.refresh() }
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .tint(BoardPalette.cobalt)
-                    }
-                }
-
-                BoardSurface {
-                    HStack(spacing: 14) {
-                        TextField("Search issues, labels, or references", text: Bindable(appModel.workStore).searchText)
-                            .textFieldStyle(.plain)
-                            .foregroundStyle(.white)
-                            .padding(.horizontal, 16)
-                            .padding(.vertical, 12)
-                            .background(
-                                RoundedRectangle(cornerRadius: 18, style: .continuous)
-                                    .fill(Color.black.opacity(0.24))
-                            )
-
-                        Text("\(appModel.workStore.filteredItems.count) items")
-                            .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(BoardPalette.paper.opacity(0.78))
-                    }
-                }
-
-                if appModel.workStore.filteredItems.isEmpty {
+                if filteredItems.isEmpty {
                     EmptyStateCard(
-                        title: "No work items yet",
+                        title: "No work items",
                         message: appModel.workStore.statusMessage
-                            ??
-                            "Connect a GitHub token and at least one repository in Settings to start filling the board.",
+                            ?? "Connect a GitHub token and repository in Settings.",
                         systemImage: "tray"
                     )
                 } else if layoutMode == .board {
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(alignment: .top, spacing: 16) {
-                            ForEach(appModel.workStore.groupedItems, id: \.state) { column in
-                                BoardSurface {
-                                    VStack(alignment: .leading, spacing: 12) {
-                                        HStack {
-                                            WorkStatusPill(state: column.state)
-                                            Spacer()
-                                            Text("\(column.items.count)")
-                                                .font(.headline)
-                                                .foregroundStyle(.white)
-                                        }
-
-                                        ForEach(column.items) { item in
-                                            WorkCard(item: item)
-                                        }
-                                    }
-                                    .frame(width: 320, alignment: .topLeading)
-                                }
-                            }
-                        }
-                        .padding(.trailing, 4)
-                    }
+                    boardLayout
                 } else {
-                    ScrollView {
-                        LazyVStack(spacing: 14) {
-                            ForEach(appModel.workStore.filteredItems) { item in
-                                WorkCard(item: item)
-                            }
-                        }
-                    }
+                    listLayout
                 }
             }
             .padding(24)
+        }
+        .navigationTitle("Work")
+        .refreshable {
+            await appModel.workStore.refresh()
+        }
+        .sheet(item: $selectedItem) { item in
+            IssueDetailSheet(item: item)
+                .environment(appModel)
+        }
+        .sheet(isPresented: $isPresentingCreate) {
+            CreateIssueSheet()
+                .environment(appModel)
+        }
+    }
+
+    private var filteredItems: [WorkItem] {
+        let base = appModel.workStore.filteredItems
+        guard selectedRepo != "all" else { return base }
+        return base.filter { $0.repository.fullName == selectedRepo }
+    }
+
+    private var groupedFilteredItems: [(state: WorkState, items: [WorkItem])] {
+        WorkState.allCases.map { state in
+            (state, filteredItems.filter { $0.status == state })
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("WORK".uppercased())
+                    .font(.caption.weight(.semibold))
+                    .tracking(2)
+                    .foregroundStyle(BoardPalette.gold)
+                Text("GitHub Issues")
+                    .font(.system(size: 28, weight: .bold, design: .serif))
+                    .foregroundStyle(.white)
+            }
+
+            Spacer(minLength: 16)
+
+            VStack(alignment: .trailing, spacing: 10) {
+                Picker("Layout", selection: $layoutMode) {
+                    ForEach(WorkLayoutMode.allCases) { mode in
+                        Image(systemName: mode == .board ? "square.grid.2x2" : "list.bullet")
+                            .tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .frame(maxWidth: 100)
+
+                HStack(spacing: 8) {
+                    Button("Refresh") {
+                        Task { await appModel.workStore.refresh() }
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.white)
+
+                    Button("New Issue") {
+                        isPresentingCreate = true
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(BoardPalette.cobalt)
+                    .disabled(!appModel.settingsStore.isGitHubConfigured)
+                }
+            }
+        }
+    }
+
+    private var filterBar: some View {
+        BoardSurface {
+            HStack(spacing: 12) {
+                TextField("Search issues, labels, references…", text: Bindable(appModel.workStore).searchText)
+                    .textFieldStyle(.plain)
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+                    .background(RoundedRectangle(cornerRadius: 14).fill(Color.black.opacity(0.24)))
+
+                if appModel.settingsStore.repositories.count > 1 {
+                    Picker("Repo", selection: $selectedRepo) {
+                        Text("All repos").tag("all")
+                        ForEach(appModel.settingsStore.repositories) { repo in
+                            Text(repo.shortName).tag(repo.fullName)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .foregroundStyle(.white)
+                    .tint(.white)
+                }
+
+                Text("\(filteredItems.count)")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(BoardPalette.paper.opacity(0.78))
+            }
+        }
+    }
+
+    private var boardLayout: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(alignment: .top, spacing: 16) {
+                ForEach(groupedFilteredItems, id: \.state) { column in
+                    BoardSurface {
+                        VStack(alignment: .leading, spacing: 12) {
+                            HStack {
+                                WorkStatusPill(state: column.state)
+                                Spacer()
+                                Text("\(column.items.count)")
+                                    .font(.headline)
+                                    .foregroundStyle(.white)
+                            }
+
+                            if column.items.isEmpty {
+                                Text("None")
+                                    .font(.subheadline)
+                                    .foregroundStyle(BoardPalette.paper.opacity(0.45))
+                                    .frame(maxWidth: .infinity, alignment: .center)
+                                    .padding(.vertical, 12)
+                            } else {
+                                ForEach(column.items) { item in
+                                    WorkCard(item: item) { selectedItem = item }
+                                }
+                            }
+                        }
+                        .frame(width: 300, alignment: .topLeading)
+                    }
+                }
+            }
+            .padding(.trailing, 4)
+        }
+    }
+
+    private var listLayout: some View {
+        ScrollView {
+            LazyVStack(spacing: 12) {
+                ForEach(filteredItems) { item in
+                    WorkCard(item: item) { selectedItem = item }
+                }
+            }
+        }
+        .refreshable {
+            await appModel.workStore.refresh()
         }
     }
 }
@@ -113,60 +187,64 @@ struct WorkScreen: View {
 private struct WorkCard: View {
     @Environment(AgentBoardAppModel.self) private var appModel
     let item: WorkItem
+    let onTap: () -> Void
 
     var body: some View {
-        BoardSurface {
-            VStack(alignment: .leading, spacing: 12) {
-                HStack(alignment: .top) {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text(item.issueReference)
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(BoardPalette.gold)
+        Button(action: onTap) {
+            BoardSurface {
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(alignment: .top) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(item.issueReference)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(BoardPalette.gold)
+                            Text(item.title)
+                                .font(.headline)
+                                .foregroundStyle(.white)
+                                .multilineTextAlignment(.leading)
+                        }
 
-                        Text(item.title)
-                            .font(.headline)
-                            .foregroundStyle(.white)
-                    }
+                        Spacer(minLength: 8)
 
-                    Spacer(minLength: 8)
-
-                    Menu {
-                        ForEach(WorkState.allCases) { state in
-                            Button(state.title) {
-                                Task {
-                                    await appModel.workStore.updateStatus(for: item, to: state)
+                        Menu {
+                            ForEach(WorkState.allCases) { state in
+                                Button(state.title) {
+                                    Task { await appModel.workStore.updateStatus(for: item, to: state) }
                                 }
                             }
+                        } label: {
+                            Image(systemName: "ellipsis.circle")
+                                .font(.title3)
+                                .foregroundStyle(.white.opacity(0.8))
                         }
-                    } label: {
-                        Image(systemName: "ellipsis.circle")
-                            .font(.title3)
-                            .foregroundStyle(.white.opacity(0.8))
+                        .buttonStyle(.plain)
                     }
-                    .buttonStyle(.plain)
-                }
 
-                Text(item.bodySummary.isEmpty ? "No body summary provided." : item.bodySummary)
-                    .font(.subheadline)
-                    .foregroundStyle(BoardPalette.paper.opacity(0.78))
+                    if !item.bodySummary.isEmpty {
+                        Text(item.bodySummary)
+                            .font(.subheadline)
+                            .foregroundStyle(BoardPalette.paper.opacity(0.78))
+                            .lineLimit(2)
+                            .multilineTextAlignment(.leading)
+                    }
 
-                HStack(spacing: 8) {
-                    WorkStatusPill(state: item.status)
-                    PriorityPill(priority: item.priority)
-                }
+                    HStack(spacing: 8) {
+                        WorkStatusPill(state: item.status)
+                        PriorityPill(priority: item.priority)
+                    }
 
-                HStack {
-                    Text(item.assignees.isEmpty ? "Unassigned" : item.assignees.joined(separator: ", "))
-                        .font(.caption)
-                        .foregroundStyle(BoardPalette.paper.opacity(0.68))
-
-                    Spacer()
-
-                    Text(item.updatedAt, style: .relative)
-                        .font(.caption)
-                        .foregroundStyle(BoardPalette.paper.opacity(0.68))
+                    HStack {
+                        Text(item.assignees.isEmpty ? "Unassigned" : item.assignees.joined(separator: ", "))
+                            .font(.caption)
+                            .foregroundStyle(BoardPalette.paper.opacity(0.68))
+                        Spacer()
+                        Text(item.updatedAt, style: .relative)
+                            .font(.caption)
+                            .foregroundStyle(BoardPalette.paper.opacity(0.68))
+                    }
                 }
             }
         }
+        .buttonStyle(.plain)
     }
 }

--- a/AgentBoardUI/Screens/WorkScreen.swift
+++ b/AgentBoardUI/Screens/WorkScreen.swift
@@ -178,9 +178,6 @@ struct WorkScreen: View {
                 }
             }
         }
-        .refreshable {
-            await appModel.workStore.refresh()
-        }
     }
 }
 
@@ -190,61 +187,60 @@ private struct WorkCard: View {
     let onTap: () -> Void
 
     var body: some View {
-        Button(action: onTap) {
-            BoardSurface {
-                VStack(alignment: .leading, spacing: 10) {
-                    HStack(alignment: .top) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(item.issueReference)
-                                .font(.caption.weight(.semibold))
-                                .foregroundStyle(BoardPalette.gold)
-                            Text(item.title)
-                                .font(.headline)
-                                .foregroundStyle(.white)
-                                .multilineTextAlignment(.leading)
-                        }
-
-                        Spacer(minLength: 8)
-
-                        Menu {
-                            ForEach(WorkState.allCases) { state in
-                                Button(state.title) {
-                                    Task { await appModel.workStore.updateStatus(for: item, to: state) }
-                                }
-                            }
-                        } label: {
-                            Image(systemName: "ellipsis.circle")
-                                .font(.title3)
-                                .foregroundStyle(.white.opacity(0.8))
-                        }
-                        .buttonStyle(.plain)
-                    }
-
-                    if !item.bodySummary.isEmpty {
-                        Text(item.bodySummary)
-                            .font(.subheadline)
-                            .foregroundStyle(BoardPalette.paper.opacity(0.78))
-                            .lineLimit(2)
+        BoardSurface {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(item.issueReference)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(BoardPalette.gold)
+                        Text(item.title)
+                            .font(.headline)
+                            .foregroundStyle(.white)
                             .multilineTextAlignment(.leading)
                     }
 
-                    HStack(spacing: 8) {
-                        WorkStatusPill(state: item.status)
-                        PriorityPill(priority: item.priority)
-                    }
+                    Spacer(minLength: 8)
 
-                    HStack {
-                        Text(item.assignees.isEmpty ? "Unassigned" : item.assignees.joined(separator: ", "))
-                            .font(.caption)
-                            .foregroundStyle(BoardPalette.paper.opacity(0.68))
-                        Spacer()
-                        Text(item.updatedAt, style: .relative)
-                            .font(.caption)
-                            .foregroundStyle(BoardPalette.paper.opacity(0.68))
+                    Menu {
+                        ForEach(WorkState.allCases) { state in
+                            Button(state.title) {
+                                Task { await appModel.workStore.updateStatus(for: item, to: state) }
+                            }
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis.circle")
+                            .font(.title3)
+                            .foregroundStyle(.white.opacity(0.8))
                     }
+                    .buttonStyle(.plain)
+                }
+
+                if !item.bodySummary.isEmpty {
+                    Text(item.bodySummary)
+                        .font(.subheadline)
+                        .foregroundStyle(BoardPalette.paper.opacity(0.78))
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                }
+
+                HStack(spacing: 8) {
+                    WorkStatusPill(state: item.status)
+                    PriorityPill(priority: item.priority)
+                }
+
+                HStack {
+                    Text(item.assignees.isEmpty ? "Unassigned" : item.assignees.joined(separator: ", "))
+                        .font(.caption)
+                        .foregroundStyle(BoardPalette.paper.opacity(0.68))
+                    Spacer()
+                    Text(item.updatedAt, style: .relative)
+                        .font(.caption)
+                        .foregroundStyle(BoardPalette.paper.opacity(0.68))
                 }
             }
         }
-        .buttonStyle(.plain)
+        .contentShape(Rectangle())
+        .onTapGesture { onTap() }
     }
 }


### PR DESCRIPTION
## Summary

- **Session control (macOS P1):** `CompanionLocalProbe` gains tmux pane detection, `captureOutput`, `nudge`, and `stop`. New `SessionDetailSheet` shows terminal output and Stop/Nudge controls. `CompanionServer` exposes `DELETE /tasks/{id}`, `POST /sessions/{id}/stop|nudge`, and `GET /sessions/{id}/output`. `AgentSession` model gains `pid`, `tmuxSession`, `lastOutput` fields with safe SQLite migration.
- **Agent task management (iOS + macOS P1):** `AgentsScreen` replaced with a 4-column kanban board (Backlog / In Progress / Blocked / Done). New `TaskDetailSheet` supports full CRUD — title, status, priority, agent, notes, session linker, and delete with confirmation. `AgentsStore.deleteTask` wires through to the companion.
- **Full chat experience (iOS + macOS P1):** New `MarkdownText` component renders prose via `AttributedString(markdown:)` and fenced code blocks in a monospaced scrollable view. `ChatScreen` uses it in `ChatBubble`, adds a model picker `Menu`, and conversation rename/delete via rail context menus with inline editing.
- **Work screen:** Repo filter picker, `IssueDetailSheet` (read + edit mode with label `FlowLayout`), `CreateIssueSheet`, and board-column empty states. `WorkStore.createIssue` and full `updateIssue` (title/body/labels/assignees/state) backed by GitHub REST.
- **macOS sidebar:** `DesktopRootView` now uses sectioned `List` — Workspace (Chat, Work) and Runtime (Agents, Sessions) — plus a connection-state dot chip in the toolbar.

## Test plan

- [ ] Chat: send a message with `**bold**` and a ` ```swift ``` ` block — verify markdown renders with bold text and monospaced code panel
- [ ] Chat: open model picker chip → select a different model → chip label updates and send still works
- [ ] Chat: long-press a conversation rail item → Rename and Delete options appear; rename saves inline
- [ ] Work: tap any issue card → `IssueDetailSheet` opens with full metadata; tap Edit → save changes → card reflects update
- [ ] Work: press New Issue → fill repo/title/labels → Create → card appears in kanban column
- [ ] Agents: four kanban columns visible (Backlog / In Progress / Blocked / Done) with tasks grouped by status
- [ ] Agents: tap a task card body → `TaskDetailSheet` opens; edit fields and Save → changes persist
- [ ] Agents: ellipsis menu → Delete → confirm alert → task disappears from board
- [ ] Sessions: tap a session card → `SessionDetailSheet` opens with status, PID (if present), and output section
- [ ] Sessions: Stop and Nudge buttons appear only for running/idle sessions; Stop shows confirmation
- [ ] macOS: sidebar shows "Workspace" and "Runtime" sections with connection dot in toolbar

https://claude.ai/code/session_015dYwYoH4uZL2kZT86sjB8R

---
_Generated by [Claude Code](https://claude.ai/code/session_015dYwYoH4uZL2kZT86sjB8R)_