### PR TITLE
AgentBoard UI polish — compose, kanban, agents, sessions

### DIFF
--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -56,17 +56,19 @@
 		73E3E44246ACF7764C2B96D9 /* AgentBoardCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; };
 		7AC30545E6D54E227C8831BA /* AgentBoardCompanionKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB3E71CE348AC298EB4048DE /* AgentBoardCompanionKit.framework */; };
 		7DE9CA2273E136476F38D922 /* TaskDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651B64AF0921713BAE550D2D /* TaskDetailSheet.swift */; };
+		7E6D512A772F03628C275D52 /* LaunchSessionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AD61915721952F19190205 /* LaunchSessionSheet.swift */; };
 		81239439DAB83C92B81C7C96 /* AgentsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BDC7F11FD4398428433E67 /* AgentsStore.swift */; };
 		81CAC6C9E0241A2ADE971ADC /* CompanionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035DCBF4EE40EE6A14CFE890 /* CompanionClient.swift */; };
 		82B58AACCD18C3D73506C751 /* AgentBoardCompanionKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB3E71CE348AC298EB4048DE /* AgentBoardCompanionKit.framework */; };
-		8423C4D50605F7D24E794BE9 /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = 70D117634905A46B8129A69F /* Nuke */; };
 		87A19AEDBCBE0206D4D71EFE /* DemoFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20006E3DE0937110157F9D1 /* DemoFixtures.swift */; };
+		891566BE5B53801826DE8CF0 /* LaunchSessionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AD61915721952F19190205 /* LaunchSessionSheet.swift */; };
 		8AD4D2CC8A4C831C10AD484D /* MediaViewerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A8E745C7552F0B5FDF7C25 /* MediaViewerView.swift */; };
 		8E7838693E07455607245B77 /* WorkScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D876290D32059BAB65A9F02 /* WorkScreen.swift */; };
 		961E593801A91A1EE5E55F76 /* AttachmentViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2941E5B6C18CF76C4621BB /* AttachmentViews.swift */; };
 		96C502A1BD49F2AE81F03313 /* AttachmentModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376B52FEC631A3F6F0383459 /* AttachmentModelsTests.swift */; };
 		96EEFE83B762E77B78F99B90 /* AgentBoardCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; };
 		97BD3D8CCE198A034A5E0C2F /* AttachmentPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E3C09A95E37674D30B6072F /* AttachmentPicker.swift */; };
+		9EAAAF4FFBF10F8A576AF5BD /* SessionLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B7CE4C138A75D87781C1DB /* SessionLauncher.swift */; };
 		A51107E477749B979572DD17 /* AttachmentModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D42E5CA1B251EA0284E8C6 /* AttachmentModels.swift */; };
 		AB66AFF4128BA91808D24DB5 /* GitHubWorkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA60A5A5B633630F99A562B /* GitHubWorkService.swift */; };
 		ABB3B9109C6F6749E7933CF2 /* DesktopRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD7F0F3E84953BCE4E07275 /* DesktopRootView.swift */; };
@@ -183,10 +185,12 @@
 /* Begin PBXFileReference section */
 		0117F7D499C266663690C9B6 /* CompanionServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionServer.swift; sourceTree = "<group>"; };
 		035DCBF4EE40EE6A14CFE890 /* CompanionClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionClient.swift; sourceTree = "<group>"; };
+		03AD61915721952F19190205 /* LaunchSessionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchSessionSheet.swift; sourceTree = "<group>"; };
 		043C2F07C2F7E6DFBC165E9A /* DomainModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainModels.swift; sourceTree = "<group>"; };
 		05A145F7A1A70B53DF066DBD /* SessionDetailSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDetailSheet.swift; sourceTree = "<group>"; };
 		06C0FE6A5C6D69E553E904D0 /* CompanionSQLiteStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionSQLiteStore.swift; sourceTree = "<group>"; };
 		06CD1EF1E211EE615B37F28B /* AgentBoardCompanionMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBoardCompanionMain.swift; sourceTree = "<group>"; };
+		08B7CE4C138A75D87781C1DB /* SessionLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLauncher.swift; sourceTree = "<group>"; };
 		0B7442B7AA1CFE33776582C1 /* AgentBoardMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBoardMobileApp.swift; sourceTree = "<group>"; };
 		196C90FC0E35E33601741243 /* KeyboardDismissal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardDismissal.swift; sourceTree = "<group>"; };
 		1A169A5D550028B6D20B397D /* DomainPills.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainPills.swift; sourceTree = "<group>"; };
@@ -245,14 +249,6 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		068A8FD26CED9743FC6E56C7 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				8423C4D50605F7D24E794BE9 /* Nuke in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		0D326533098B690337045128 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -378,6 +374,7 @@
 				FFA60A5A5B633630F99A562B /* GitHubWorkService.swift */,
 				B7B2891F313F2E1804101D36 /* HermesGatewayClient.swift */,
 				54CA712A46E969ED79300E4F /* LinkPreviewService.swift */,
+				08B7CE4C138A75D87781C1DB /* SessionLauncher.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -397,6 +394,7 @@
 				F6FDDFF5030B377E6973E969 /* ChatScreen.swift */,
 				702A0D71A27F07711AF96C4A /* CreateIssueSheet.swift */,
 				26A31E0F643092B573A4DB9D /* IssueDetailSheet.swift */,
+				03AD61915721952F19190205 /* LaunchSessionSheet.swift */,
 				05A145F7A1A70B53DF066DBD /* SessionDetailSheet.swift */,
 				33A654F28E691A722E5B4F02 /* SessionsScreen.swift */,
 				D7A095E80382BA922486329A /* SettingsScreen.swift */,
@@ -520,7 +518,6 @@
 			buildConfigurationList = 10C8E641A539E5705C444269 /* Build configuration list for PBXNativeTarget "AgentBoardCore" */;
 			buildPhases = (
 				7E5BFA54826936011F573208 /* Sources */,
-				068A8FD26CED9743FC6E56C7 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -528,7 +525,6 @@
 			);
 			name = AgentBoardCore;
 			packageProductDependencies = (
-				70D117634905A46B8129A69F /* Nuke */,
 			);
 			productName = AgentBoardCore;
 			productReference = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */;
@@ -751,6 +747,7 @@
 				18513E9340A65D8111F82D18 /* DomainPills.swift in Sources */,
 				1DBE4EB751A629F1664040D8 /* IssueDetailSheet.swift in Sources */,
 				64B8644401E5AFE74A627388 /* KeyboardDismissal.swift in Sources */,
+				7E6D512A772F03628C275D52 /* LaunchSessionSheet.swift in Sources */,
 				DE5629641FE81BB20A7186A9 /* MarkdownText.swift in Sources */,
 				62B59C34430276AC70136C6D /* MediaViewerView.swift in Sources */,
 				624514151F83E5FC8A4EB2F2 /* NeumorphicTheme.swift in Sources */,
@@ -802,6 +799,7 @@
 				AB66AFF4128BA91808D24DB5 /* GitHubWorkService.swift in Sources */,
 				C23BCB5CF1615F000459D9E7 /* HermesGatewayClient.swift in Sources */,
 				BCE6371A2B658B37FE0C3124 /* LinkPreviewService.swift in Sources */,
+				9EAAAF4FFBF10F8A576AF5BD /* SessionLauncher.swift in Sources */,
 				5407CC8EF71865713E95B1BF /* SessionsStore.swift in Sources */,
 				5B810A52F3C78D394BE76608 /* SettingsRepository.swift in Sources */,
 				1C7E32DFC4B2295F98363820 /* SettingsStore.swift in Sources */,
@@ -826,6 +824,7 @@
 				BC1CCDB452C13C403BFA1460 /* DomainPills.swift in Sources */,
 				22AD45AE145021107CD2C0AA /* IssueDetailSheet.swift in Sources */,
 				736771D2489A4C0C6FBB4A83 /* KeyboardDismissal.swift in Sources */,
+				891566BE5B53801826DE8CF0 /* LaunchSessionSheet.swift in Sources */,
 				15369C112AA2304F032D157F /* MarkdownText.swift in Sources */,
 				8AD4D2CC8A4C831C10AD484D /* MediaViewerView.swift in Sources */,
 				6A4091B95B722862F973E0BC /* MobileRootView.swift in Sources */,
@@ -1358,11 +1357,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D04429BB4AFEDD9352E7C3BF /* XCRemoteSwiftPackageReference "Nuke" */;
 			productName = NukeUI;
-		};
-		70D117634905A46B8129A69F /* Nuke */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = D04429BB4AFEDD9352E7C3BF /* XCRemoteSwiftPackageReference "Nuke" */;
-			productName = Nuke;
 		};
 		8E67F37D82C33338077E4371 /* Nuke */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/AgentBoardCore/Services/SessionLauncher.swift
+++ b/AgentBoardCore/Services/SessionLauncher.swift
@@ -1,0 +1,298 @@
+import Foundation
+import os
+
+/// Manages launching agent sessions from task cards.
+/// Creates tmux sessions pre-loaded with issue context and execution presets.
+@MainActor
+@Observable
+public final class SessionLauncher {
+    private let logger = Logger(subsystem: "com.agentboard.modern", category: "SessionLauncher")
+
+    // MARK: - Models
+
+    public enum ExecutionPreset: String, CaseIterable, Identifiable, Sendable {
+        case ralphLoop = "Ralph Loop"
+        case tddSuperpowers = "TDD (Superpowers)"
+        case claudeToCodex = "Claude → Codex Handoff"
+
+        public var id: String {
+            rawValue
+        }
+
+        public var description: String {
+            switch self {
+            case .ralphLoop:
+                return "Short iterations, PRD-driven, watchdog monitoring. Best for features and fixes."
+            case .tddSuperpowers:
+                return "Test-first workflow. Write failing tests, then implement. Best for business logic."
+            case .claudeToCodex:
+                return "Claude implements, auto-hands off to Codex for test validation. Best for large features."
+            }
+        }
+
+        public var icon: String {
+            switch self {
+            case .ralphLoop: return "arrow.triangle.2.circlepath"
+            case .tddSuperpowers: return "checkmark.shield"
+            case .claudeToCodex: return "arrow.right.circle"
+            }
+        }
+
+        public var agent: String {
+            switch self {
+            case .ralphLoop: return "claude"
+            case .tddSuperpowers: return "claude"
+            case .claudeToCodex: return "claude"
+            }
+        }
+    }
+
+    public struct LaunchConfig {
+        public let taskTitle: String
+        public let issueNumber: Int
+        public let repo: String
+        public let fullRepo: String
+        public let preset: ExecutionPreset
+        public let customInstructions: String
+
+        public init(
+            taskTitle: String,
+            issueNumber: Int,
+            repo: String,
+            fullRepo: String,
+            preset: ExecutionPreset,
+            customInstructions: String
+        ) {
+            self.taskTitle = taskTitle
+            self.issueNumber = issueNumber
+            self.repo = repo
+            self.fullRepo = fullRepo
+            self.preset = preset
+            self.customInstructions = customInstructions
+        }
+    }
+
+    public struct ActiveSession: Identifiable, Sendable {
+        public let id: String
+        public let sessionName: String
+        public let issueNumber: Int
+        public let preset: ExecutionPreset
+        public let startTime: Date
+        public var status: SessionStatus
+
+        public enum SessionStatus: Sendable {
+            case running, completed, failed, stalled
+        }
+
+        public var elapsed: String {
+            let interval = Date().timeIntervalSince(startTime)
+            let minutes = Int(interval) / 60
+            let seconds = Int(interval) % 60
+            return String(format: "%d:%02d", minutes, seconds)
+        }
+    }
+
+    // MARK: - State
+
+    public var activeSessions: [ActiveSession] = []
+    public var isLaunching = false
+    public var lastError: String?
+
+    // MARK: - Launch
+
+    @discardableResult
+    public func launch(config: LaunchConfig) async -> String? {
+        isLaunching = true
+        lastError = nil
+
+        let sessionName = "ab-\(config.repo.lowercased())-\(config.issueNumber)".replacingOccurrences(
+            of: ".",
+            with: "_"
+        )
+        let prdPath = "docs/PRD-issue-\(config.issueNumber).md"
+
+        do {
+            // 1. Generate PRD
+            let prd = generatePRD(config: config)
+            try writePRD(repo: config.repo, path: prdPath, content: prd)
+
+            // 2. Launch tmux session
+            try await launchTmuxSession(
+                sessionName: sessionName,
+                repo: config.repo,
+                preset: config.preset,
+                prdPath: prdPath
+            )
+
+            // 3. Track session
+            let session = ActiveSession(
+                id: UUID().uuidString,
+                sessionName: sessionName,
+                issueNumber: config.issueNumber,
+                preset: config.preset,
+                startTime: Date(),
+                status: .running
+            )
+            activeSessions.append(session)
+            isLaunching = false
+
+            logger.info("Launched session: \(sessionName)")
+            return sessionName
+
+        } catch {
+            lastError = error.localizedDescription
+            isLaunching = false
+            logger.error("Launch failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    // MARK: - PRD Generation
+
+    private func generatePRD(config: LaunchConfig) -> String {
+        var prd = """
+        # PRD: \(config.taskTitle)
+
+        ## Issue
+        #\(config.issueNumber) in \(config.fullRepo)
+
+        """
+
+        switch config.preset {
+        case .ralphLoop:
+            prd += """
+            ## Tasks
+            - [ ] Implement \(config.taskTitle)
+            - [ ] Handle edge cases and error states
+            - [ ] Add accessibilityIdentifier to every interactive element
+            - [ ] Build verify: xcodebuild -scheme AgentBoard -destination 'platform=macOS' build
+
+            """
+        case .tddSuperpowers:
+            prd += """
+            ## Tasks
+            - [ ] Write failing tests that define expected behavior
+            - [ ] Implement \(config.taskTitle) to pass tests
+            - [ ] Handle edge cases
+            - [ ] Add accessibilityIdentifier to every interactive element
+            - [ ] Run full test suite — all tests must pass
+
+            """
+        case .claudeToCodex:
+            prd += """
+            ## Phase 1: Implementation (Claude Code)
+            - [ ] Implement \(config.taskTitle)
+            - [ ] Handle edge cases
+            - [ ] Build verify: xcodebuild -scheme AgentBoard -destination 'platform=macOS' build
+            - [ ] Commit to feature branch
+
+            ## Phase 2: Test Validation (Codex — auto-handoff)
+            - [ ] Run full test suite
+            - [ ] Add missing tests if coverage gaps found
+            - [ ] Run linter — no new warnings
+            - [ ] Report results
+
+            """
+        }
+
+        prd += """
+        ## Constraints
+        - Swift 6 strict concurrency
+        - @Observable not ObservableObject
+        - accessibilityIdentifier on every interactive element
+
+        ## Anti-Stall Rules
+        - Never wait for input. Never pause for confirmation. Keep moving.
+        - When done: commit, push to feature branch, STOP.
+        - Report: "DONE: [accomplished] | BLOCKED: [anything open]"
+        """
+
+        if !config.customInstructions.isEmpty {
+            prd += "\n## Custom Instructions\n\(config.customInstructions)\n"
+        }
+
+        return prd
+    }
+
+    // MARK: - tmux Launch
+
+    private func writePRD(repo: String, path: String, content: String) throws {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let projectDir = home.appendingPathComponent("Projects").appendingPathComponent(repo)
+        let prdDir = projectDir.appendingPathComponent("docs")
+
+        try FileManager.default.createDirectory(at: prdDir, withIntermediateDirectories: true)
+
+        let prdFile = prdDir.appendingPathComponent(URL(fileURLWithPath: path).lastPathComponent)
+        try content.write(to: prdFile, atomically: true, encoding: .utf8)
+    }
+
+    private func launchTmuxSession(
+        sessionName: String,
+        repo: String,
+        preset: ExecutionPreset,
+        prdPath: String
+    ) async throws {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let projectDir = home.appendingPathComponent("Projects").appendingPathComponent(repo).path
+        let socket = home.appendingPathComponent(".tmux/sock").path
+        let agent = preset.agent
+
+        let shellCmd = "/opt/homebrew/bin/tmux -S \(socket) new -d -s \(sessionName)" +
+            " \"cd \(projectDir) && unset ANTHROPIC_API_KEY" +
+            " && /opt/homebrew/bin/ralphy --\(agent) --prd \(prdPath)" +
+            "; EXIT_CODE=$?; echo EXITED: $EXIT_CODE; sleep 999999\""
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-c", shellCmd]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        if process.terminationStatus != 0 {
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: data, encoding: .utf8) ?? "unknown error"
+            throw LaunchError.tmuxFailed(output)
+        }
+    }
+
+    // MARK: - Monitoring
+
+    public func checkSession(_ session: ActiveSession) async -> ActiveSession.SessionStatus {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let socket = home.appendingPathComponent(".tmux/sock").path
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/opt/homebrew/bin/tmux")
+        process.arguments = ["-S", socket, "has-session", "-t", session.sessionName]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0 ? .running : .completed
+        } catch {
+            return .failed
+        }
+    }
+
+    // MARK: - Errors
+
+    enum LaunchError: LocalizedError {
+        case tmuxFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .tmuxFailed(msg): return "tmux launch failed: \(msg)"
+            }
+        }
+    }
+}

--- a/AgentBoardCore/Stores/AgentBoardAppModel.swift
+++ b/AgentBoardCore/Stores/AgentBoardAppModel.swift
@@ -13,6 +13,7 @@ public final class AgentBoardAppModel {
     public let workStore: WorkStore
     public let agentsStore: AgentsStore
     public let sessionsStore: SessionsStore
+    public let sessionLauncher: SessionLauncher
 
     public var selectedDestination: AppDestination = .chat
     public private(set) var isBootstrapping = false
@@ -28,6 +29,7 @@ public final class AgentBoardAppModel {
         workStore: WorkStore,
         agentsStore: AgentsStore,
         sessionsStore: SessionsStore,
+        sessionLauncher: SessionLauncher,
         companionClient: CompanionClient
     ) {
         self.settingsStore = settingsStore
@@ -35,6 +37,7 @@ public final class AgentBoardAppModel {
         self.workStore = workStore
         self.agentsStore = agentsStore
         self.sessionsStore = sessionsStore
+        self.sessionLauncher = sessionLauncher
         self.companionClient = companionClient
     }
 
@@ -165,6 +168,7 @@ public enum AgentBoardBootstrap {
             cache: cache,
             settingsStore: settingsStore
         )
+        let sessionLauncher = SessionLauncher()
 
         return AgentBoardAppModel(
             settingsStore: settingsStore,
@@ -172,6 +176,7 @@ public enum AgentBoardBootstrap {
             workStore: workStore,
             agentsStore: agentsStore,
             sessionsStore: sessionsStore,
+            sessionLauncher: sessionLauncher,
             companionClient: companionClient
         )
     }

--- a/AgentBoardUI/Components/Attachments/AttachmentPicker.swift
+++ b/AgentBoardUI/Components/Attachments/AttachmentPicker.swift
@@ -12,9 +12,9 @@ struct AttachmentPickerSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        NavigationStack {
-            List {
-                #if os(iOS)
+        #if os(iOS)
+            NavigationStack {
+                List {
                     Section {
                         Button {
                             dismiss()
@@ -40,38 +40,48 @@ struct AttachmentPickerSheet: View {
                         }
                         .accessibilityIdentifier("attachment_picker_camera")
                     }
-                #else
-                    Section {
-                        Button {
-                            dismiss()
-                            presentMacFilePicker()
-                        } label: {
-                            Label("Choose File...", systemImage: "doc")
-                        }
-                        .accessibilityIdentifier("attachment_picker_file")
-
-                        Button {
-                            dismiss()
-                            presentMacImagePicker()
-                        } label: {
-                            Label("Choose Image...", systemImage: "photo")
-                        }
-                        .accessibilityIdentifier("attachment_picker_image")
-                    }
-                #endif
-            }
-            .navigationTitle("Attach")
-            #if os(iOS)
+                }
+                .navigationTitle("Attach")
                 .navigationBarTitleDisplayMode(.inline)
-            #endif
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button("Cancel") { dismiss() }
                     }
                 }
-        }
-        #if os(iOS)
-        .presentationDetents([.medium])
+            }
+            .presentationDetents([.medium])
+        #else
+            NavigationStack {
+                VStack(alignment: .leading, spacing: 16) {
+                    Button {
+                        dismiss()
+                        presentMacFilePicker()
+                    } label: {
+                        Label("Choose File...", systemImage: "doc")
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("attachment_picker_file")
+
+                    Button {
+                        dismiss()
+                        presentMacImagePicker()
+                    } label: {
+                        Label("Choose Image...", systemImage: "photo")
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("attachment_picker_image")
+                }
+                .padding(24)
+                .frame(minWidth: 280)
+                .navigationTitle("Attach")
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { dismiss() }
+                    }
+                }
+            }
         #endif
     }
 

--- a/AgentBoardUI/Components/Attachments/VoiceViews.swift
+++ b/AgentBoardUI/Components/Attachments/VoiceViews.swift
@@ -30,9 +30,9 @@ struct VoiceRecordingButton: View {
             }
         } label: {
             Image(systemName: "mic")
-                .font(.system(size: 18, weight: .medium))
+                .font(.system(size: 14, weight: .medium))
                 .foregroundStyle(NeuPalette.accentOrange)
-                .frame(width: 44, height: 44)
+                .frame(width: 28, height: 28)
         }
         .accessibilityIdentifier("chat_button_mic")
     }

--- a/AgentBoardUI/Screens/AgentsScreen.swift
+++ b/AgentBoardUI/Screens/AgentsScreen.swift
@@ -6,6 +6,7 @@ struct AgentsScreen: View {
     @Environment(\.horizontalSizeClass) private var hSizeClass
     @State private var isPresentingCreateSheet = false
     @State private var selectedTask: AgentTask?
+    @State private var launchTask: AgentTask?
     @State private var selectedWorkItemID: String?
     @State private var taskTitle = ""
     @State private var assignedAgent = ""
@@ -42,11 +43,7 @@ struct AgentsScreen: View {
                     )
                     .padding(isCompact ? 16 : 24)
                 } else {
-                    if isCompact {
-                        compactTaskList
-                    } else {
-                        kanbanBoard
-                    }
+                    taskList
                 }
             }
         }
@@ -61,6 +58,10 @@ struct AgentsScreen: View {
         .sheet(isPresented: $isPresentingCreateSheet) {
             createTaskSheet
                 .presentationDetents([.medium, .large])
+        }
+        .sheet(item: $launchTask) { task in
+            LaunchSessionSheet(task: task)
+                .environment(appModel)
         }
     }
 
@@ -130,76 +131,19 @@ struct AgentsScreen: View {
         }
     }
 
-    private var kanbanBoard: some View {
-        VStack(spacing: 0) {
-            agentSummaryRail
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(alignment: .top, spacing: 24) {
-                    ForEach(groupedTasks, id: \.state) { column in
-                        VStack(alignment: .leading, spacing: 16) {
-                            HStack {
-                                Text(column.state.title.uppercased())
-                                    .font(.caption.weight(.bold))
-                                    .tracking(1)
-                                    .foregroundStyle(NeuPalette.textSecondary)
-                                Spacer()
-                                Text("\(column.tasks.count)")
-                                    .font(.caption.weight(.bold))
-                                    .foregroundStyle(NeuPalette.textSecondary)
-                            }
-                            .padding(.horizontal, 4)
-
-                            if column.tasks.isEmpty {
-                                Text("None")
-                                    .font(.subheadline)
-                                    .foregroundStyle(NeuPalette.textSecondary)
-                                    .frame(maxWidth: .infinity, alignment: .center)
-                                    .padding(.vertical, 24)
-                            } else {
-                                ScrollView(showsIndicators: false) {
-                                    LazyVStack(spacing: 16) {
-                                        ForEach(column.tasks) { task in
-                                            TaskCardNeu(task: task) {
-                                                selectedTask = task
-                                            }
-                                        }
-                                    }
-                                    .padding(.bottom, 24)
-                                }
-                            }
-                        }
-                        .frame(width: 320, alignment: .topLeading)
-                        .padding(20)
-                        .neuExtruded(cornerRadius: 32, elevation: 12)
-                    }
-                }
-                .padding(24)
-            }
-        }
-    }
-
-    private var compactTaskList: some View {
+    private var taskList: some View {
         ScrollView(showsIndicators: false) {
-            LazyVStack(spacing: 32) {
+            LazyVStack(spacing: 16) {
+                // Agent summaries at top (horizontal scroll)
                 if !appModel.agentsStore.summaries.isEmpty {
-                    VStack(alignment: .leading, spacing: 16) {
-                        Text("ACTIVE AGENTS")
-                            .font(.caption.weight(.bold))
-                            .tracking(1)
-                            .foregroundStyle(NeuPalette.textSecondary)
-                            .padding(.horizontal, 8)
-
-                        ForEach(appModel.agentsStore.summaries) { summary in
-                            AgentSummaryRowNeu(summary: summary)
-                        }
-                    }
+                    agentSummaryRail
                 }
 
+                // All tasks in a single list, grouped by status
                 ForEach(AgentTaskState.allCases) { state in
                     let tasks = appModel.agentsStore.tasks.filter { $0.status == state }
                     if !tasks.isEmpty {
-                        VStack(alignment: .leading, spacing: 16) {
+                        VStack(alignment: .leading, spacing: 12) {
                             HStack {
                                 Text(state.title.uppercased())
                                     .font(.caption.weight(.bold))
@@ -213,14 +157,18 @@ struct AgentsScreen: View {
                             .padding(.horizontal, 8)
 
                             ForEach(tasks) { task in
-                                TaskListRowNeu(task: task) { selectedTask = task }
-                                    .accessibilityIdentifier("agents_cell_task_\(task.id)")
+                                TaskListRowNeu(
+                                    task: task,
+                                    onTap: { selectedTask = task },
+                                    onLaunch: { launchTask = task }
+                                )
+                                .accessibilityIdentifier("agents_cell_task_\(task.id)")
                             }
                         }
                     }
                 }
             }
-            .padding(16)
+            .padding(24)
         }
     }
 
@@ -314,6 +262,7 @@ private struct TaskListRowNeu: View {
     @Environment(AgentBoardAppModel.self) private var appModel
     let task: AgentTask
     let onTap: () -> Void
+    var onLaunch: (() -> Void)?
     @State private var showDeleteConfirm = false
 
     var body: some View {
@@ -362,6 +311,10 @@ private struct TaskListRowNeu: View {
         }
         .buttonStyle(.plain)
         .contextMenu {
+            if let onLaunch {
+                Button { onLaunch() } label: { Label("Launch Session", systemImage: "bolt.fill") }
+                Divider()
+            }
             Button(role: .destructive) { showDeleteConfirm = true } label: { Label("Delete", systemImage: "trash") }
         }
         .alert("Delete Task", isPresented: $showDeleteConfirm) {

--- a/AgentBoardUI/Screens/ChatScreen.swift
+++ b/AgentBoardUI/Screens/ChatScreen.swift
@@ -151,7 +151,6 @@ struct ChatScreen: View {
         .neuExtruded(cornerRadius: 12, elevation: 2)
     }
 
-
     private func headerCapsule(title: String, value: String, systemImage: String) -> some View {
         HStack(spacing: 8) {
             Image(systemName: systemImage)
@@ -350,78 +349,60 @@ struct ChatScreen: View {
                     .padding(.bottom, 8)
             }
 
-            // Attachment preview strip
             if !chatStore.pendingAttachments.isEmpty {
                 AttachmentPreviewStrip(attachments: $chatStore.pendingAttachments)
             }
 
-            ZStack(alignment: .bottomTrailing) {
-                // Attachment button on the left
-                HStack {
-                    Button {
-                        showAttachmentPicker = true
-                    } label: {
-                        Image(systemName: "paperclip")
-                            .font(.system(size: 18, weight: .medium))
-                            .foregroundStyle(NeuPalette.accentCyan)
-                            .frame(width: 44, height: 44)
-                    }
-                    .accessibilityIdentifier("chat_button_attach")
-                    .sheet(isPresented: $showAttachmentPicker) {
-                        AttachmentPickerSheet { attachment in
-                            chatStore.addAttachment(attachment)
-                        }
-                    }
-
-                    // Microphone button
-                    VoiceRecordingButton(
-                        recorder: audioRecorder,
-                        onRecorded: { result in
-                            chatStore.addAttachment(result.toAttachment())
-                        },
-                        onCancel: {}
-                    )
-
-                    Spacer()
+            // Compose row: [attach] [mic] [textfield] [send]
+            HStack(spacing: 8) {
+                Button { showAttachmentPicker = true } label: {
+                    Image(systemName: "paperclip")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(NeuPalette.accentCyan)
+                        .frame(width: 28, height: 28)
                 }
-                .padding(.leading, 8)
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("chat_button_attach")
+                .sheet(isPresented: $showAttachmentPicker) {
+                    AttachmentPickerSheet { attachment in
+                        chatStore.addAttachment(attachment)
+                    }
+                }
 
-                // Text field
-                TextField("", text: $chatStore.draft, axis: .vertical)
+                VoiceRecordingButton(
+                    recorder: audioRecorder,
+                    onRecorded: { result in chatStore.addAttachment(result.toAttachment()) },
+                    onCancel: {}
+                )
+
+                TextField("Message Hermes...", text: $chatStore.draft, axis: .vertical)
                     .lineLimit(1 ... 6)
                     .focused($isTextFieldFocused)
                     .foregroundStyle(NeuPalette.textPrimary)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 64)
-                    .padding(.vertical, 24)
-                    .overlay(
-                        Text("Message Hermes...")
-                            .foregroundStyle(NeuPalette.textSecondary)
-                            .opacity(chatStore.draft.isEmpty && chatStore.pendingAttachments.isEmpty ? 1 : 0)
-                            .allowsHitTesting(false)
-                    )
+                    .textFieldStyle(.plain)
 
-                // Send button
                 Button {
                     isTextFieldFocused = false
                     AgentBoardKeyboard.dismiss()
                     Task { await chatStore.sendDraft() }
                 } label: {
                     Image(systemName: chatStore.isStreaming ? "stop.fill" : "paperplane.fill")
-                        .font(.system(size: 16, weight: .bold))
+                        .font(.system(size: 13, weight: .bold))
                         .foregroundStyle(sendButtonForeground)
-                        .frame(width: 48, height: 48)
+                        .frame(width: 32, height: 32)
                         .background(Circle().fill(sendButtonBackground))
                 }
                 .disabled(!canSend)
-                .padding(12)
+                .buttonStyle(.plain)
                 .accessibilityIdentifier("chat_button_send")
             }
-            .neuRecessed(cornerRadius: 36, depth: 6)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .neuRecessed(cornerRadius: 20, depth: 6)
         }
         .padding(.horizontal, isCompact ? 16 : 24)
-        .padding(.top, 12)
-        .padding(.bottom, 16)
+        .padding(.top, 8)
+        .padding(.bottom, 12)
         .background(
             NeuPalette.background
                 .ignoresSafeArea(edges: .bottom)

--- a/AgentBoardUI/Screens/CreateIssueSheet.swift
+++ b/AgentBoardUI/Screens/CreateIssueSheet.swift
@@ -8,12 +8,24 @@ struct CreateIssueSheet: View {
     @State private var selectedRepository: ConfiguredRepository?
     @State private var title = ""
     @State private var issueBody = ""
-    @State private var labels = ""
-    @State private var assignees = ""
+    @State private var selectedLabels: Set<String> = []
+    @State private var customLabel = ""
+    @State private var selectedAssignees: Set<String> = []
+    @State private var customAssignee = ""
     @State private var selectedPriority: WorkPriority = .medium
     @State private var selectedStatus: WorkState = .open
     @State private var milestoneNumber = ""
     @State private var isCreating = false
+
+    private var knownLabels: [String] {
+        let allLabels = appModel.workStore.items.flatMap { $0.labels }
+        return Array(Set(allLabels)).sorted()
+    }
+
+    private var knownAssignees: [String] {
+        let allAssignees = appModel.workStore.items.flatMap { $0.assignees }
+        return Array(Set(allAssignees)).sorted()
+    }
 
     var body: some View {
         NavigationStack {
@@ -59,15 +71,52 @@ struct CreateIssueSheet: View {
                                     .foregroundStyle(NeuPalette.textPrimary)
                             }
 
-                            VStack(alignment: .leading, spacing: 6) {
-                                Text("Labels (comma-separated)").font(.headline).foregroundStyle(NeuPalette.textPrimary)
-                                NeuTextField(placeholder: "bug, enhancement", text: $labels)
+                            // Labels — chip selector with known values
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text("Labels").font(.headline).foregroundStyle(NeuPalette.textPrimary)
+                                if !knownLabels.isEmpty {
+                                    FlowTagsView(items: knownLabels, selected: $selectedLabels) { label in
+                                        Text(label).font(.caption)
+                                    }
+                                }
+                                HStack(spacing: 8) {
+                                    NeuTextField(placeholder: "Add custom label…", text: $customLabel)
+                                    Button {
+                                        let trimmed = customLabel.trimmingCharacters(in: .whitespaces)
+                                        if !trimmed.isEmpty {
+                                            selectedLabels.insert(trimmed)
+                                            customLabel = ""
+                                        }
+                                    } label: {
+                                        Image(systemName: "plus")
+                                    }
+                                    .buttonStyle(NeuButtonTarget(isAccent: !customLabel.trimmed.isEmpty))
+                                    .disabled(customLabel.trimmedOrNil == nil)
+                                }
                             }
 
-                            VStack(alignment: .leading, spacing: 6) {
-                                Text("Assignees (comma-separated)").font(.headline)
-                                    .foregroundStyle(NeuPalette.textPrimary)
-                                NeuTextField(placeholder: "alice, bob", text: $assignees)
+                            // Assignees — chip selector with known values
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text("Assignees").font(.headline).foregroundStyle(NeuPalette.textPrimary)
+                                if !knownAssignees.isEmpty {
+                                    FlowTagsView(items: knownAssignees, selected: $selectedAssignees) { assignee in
+                                        Text(assignee).font(.caption)
+                                    }
+                                }
+                                HStack(spacing: 8) {
+                                    NeuTextField(placeholder: "Add custom assignee…", text: $customAssignee)
+                                    Button {
+                                        let trimmed = customAssignee.trimmingCharacters(in: .whitespaces)
+                                        if !trimmed.isEmpty {
+                                            selectedAssignees.insert(trimmed)
+                                            customAssignee = ""
+                                        }
+                                    } label: {
+                                        Image(systemName: "plus")
+                                    }
+                                    .buttonStyle(NeuButtonTarget(isAccent: !customAssignee.trimmed.isEmpty))
+                                    .disabled(customAssignee.trimmedOrNil == nil)
+                                }
                             }
 
                             VStack(alignment: .leading, spacing: 12) {
@@ -134,11 +183,8 @@ struct CreateIssueSheet: View {
         guard let repo = selectedRepository else { return }
         isCreating = true
 
-        let parsedLabels = labels.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { !$0.isEmpty }
-        let parsedAssignees = assignees.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { !$0.isEmpty }
-        let mergedLabels = Array(Set(parsedLabels + [selectedPriority.labelValue, selectedStatus.labelValue])).sorted()
+        let mergedLabels = Array(selectedLabels + [selectedPriority.labelValue, selectedStatus.labelValue]).sorted()
+        let assignees = Array(selectedAssignees)
         let milestone = Int(milestoneNumber.trimmingCharacters(in: .whitespacesAndNewlines))
 
         Task {
@@ -147,12 +193,46 @@ struct CreateIssueSheet: View {
                 title: title.trimmingCharacters(in: .whitespacesAndNewlines),
                 body: issueBody.trimmingCharacters(in: .whitespacesAndNewlines),
                 labels: mergedLabels,
-                assignees: parsedAssignees,
+                assignees: assignees,
                 milestone: milestone
             )
             isCreating = false
             if appModel.workStore.errorMessage == nil {
                 dismiss()
+            }
+        }
+    }
+}
+
+// MARK: - FlowTagsView
+
+/// A simple wrapping tag layout for selectable chips.
+private struct FlowTagsView<Item: Hashable, Content: View>: View {
+    let items: [Item]
+    @Binding var selected: Set<Item>
+    @ViewBuilder let content: (Item) -> Content
+
+    var body: some View {
+        // Use a simple LazyVGrid with flexible columns for wrapping
+        let columns = [GridItem(.adaptive(minimum: 60), spacing: 8)]
+        LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
+            ForEach(items, id: \.self) { item in
+                let isSelected = selected.contains(item)
+                Button {
+                    if isSelected {
+                        selected.remove(item)
+                    } else {
+                        selected.insert(item)
+                    }
+                } label: {
+                    content(item)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(isSelected ? NeuPalette.accentCyan : NeuPalette.surface)
+                        .foregroundStyle(isSelected ? .black : NeuPalette.textPrimary)
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
             }
         }
     }

--- a/AgentBoardUI/Screens/LaunchSessionSheet.swift
+++ b/AgentBoardUI/Screens/LaunchSessionSheet.swift
@@ -1,0 +1,160 @@
+import AgentBoardCore
+import SwiftUI
+
+struct LaunchSessionSheet: View {
+    @Environment(AgentBoardAppModel.self) private var appModel
+    @Environment(\.dismiss) private var dismiss
+
+    let task: AgentTask
+
+    @State private var selectedPreset: SessionLauncher.ExecutionPreset = .ralphLoop
+    @State private var customInstructions = ""
+    @State private var repoName = ""
+    @State private var isLaunching = false
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                NeuBackground()
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 24) {
+                        VStack(alignment: .leading, spacing: 20) {
+                            Text("LAUNCH SESSION")
+                                .font(.caption.weight(.bold))
+                                .tracking(1)
+                                .foregroundStyle(NeuPalette.textSecondary)
+
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text("Task").font(.headline).foregroundStyle(NeuPalette.textPrimary)
+                                Text(task.title)
+                                    .font(.subheadline)
+                                    .foregroundStyle(NeuPalette.textSecondary)
+                                    .padding(12)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .neuRecessed(cornerRadius: 12, depth: 4)
+                            }
+
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text("Issue").font(.headline).foregroundStyle(NeuPalette.textPrimary)
+                                Text(task.workItem.issueReference)
+                                    .font(.subheadline.monospaced())
+                                    .foregroundStyle(NeuPalette.accentCyan)
+                            }
+
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text("Repository Folder").font(.headline).foregroundStyle(NeuPalette.textPrimary)
+                                NeuTextField(placeholder: "e.g. AgentBoard", text: $repoName)
+                            }
+
+                            VStack(alignment: .leading, spacing: 12) {
+                                Text("Execution Preset").font(.headline).foregroundStyle(NeuPalette.textPrimary)
+                                ForEach(SessionLauncher.ExecutionPreset.allCases) { preset in
+                                    Button {
+                                        selectedPreset = preset
+                                    } label: {
+                                        HStack(spacing: 12) {
+                                            Image(systemName: preset.icon)
+                                                .frame(width: 24)
+                                                .foregroundStyle(selectedPreset == preset ? NeuPalette
+                                                    .accentCyan : NeuPalette.textSecondary)
+
+                                            VStack(alignment: .leading, spacing: 2) {
+                                                Text(preset.rawValue)
+                                                    .font(.subheadline.weight(.semibold))
+                                                    .foregroundStyle(NeuPalette.textPrimary)
+                                                Text(preset.description)
+                                                    .font(.caption)
+                                                    .foregroundStyle(NeuPalette.textSecondary)
+                                                    .lineLimit(2)
+                                            }
+
+                                            Spacer()
+
+                                            if selectedPreset == preset {
+                                                Image(systemName: "checkmark.circle.fill")
+                                                    .foregroundStyle(NeuPalette.accentCyan)
+                                            }
+                                        }
+                                        .padding(12)
+                                        .background(
+                                            RoundedRectangle(cornerRadius: 12)
+                                                .fill(selectedPreset == preset ? Color.white.opacity(0.05) : Color
+                                                    .clear)
+                                        )
+                                    }
+                                    .buttonStyle(.plain)
+                                }
+                            }
+
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text("Custom Instructions").font(.headline).foregroundStyle(NeuPalette.textPrimary)
+                                TextEditor(text: $customInstructions)
+                                    .scrollContentBackground(.hidden)
+                                    .frame(minHeight: 80)
+                                    .padding(12)
+                                    .neuRecessed(cornerRadius: 16, depth: 6)
+                                    .foregroundStyle(NeuPalette.textPrimary)
+                            }
+                        }
+                        .padding(24)
+                        .neuExtruded(cornerRadius: 24, elevation: 8)
+
+                        if isLaunching {
+                            ProgressView("Launching session…")
+                                .foregroundStyle(NeuPalette.textPrimary)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                        } else if let error = appModel.sessionLauncher.lastError {
+                            Text(error)
+                                .font(.footnote.weight(.medium))
+                                .foregroundStyle(.red)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                        }
+                    }
+                    .padding(24)
+                }
+            }
+            .navigationTitle("Launch Session")
+            .agentBoardNavigationBarTitleInline()
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundStyle(NeuPalette.textPrimary)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Launch") { launch() }
+                        .buttonStyle(NeuButtonTarget(isAccent: true))
+                        .disabled(isLaunching || repoName.trimmedOrNil == nil)
+                }
+            }
+            .onAppear {
+                // Pre-fill repo name from the work item
+                if repoName.isEmpty {
+                    repoName = task.workItem.repository.name
+                }
+            }
+        }
+    }
+
+    private func launch() {
+        guard !repoName.isEmpty else { return }
+        isLaunching = true
+
+        let config = SessionLauncher.LaunchConfig(
+            taskTitle: task.title,
+            issueNumber: task.workItem.issueNumber,
+            repo: repoName.trimmingCharacters(in: .whitespaces),
+            fullRepo: task.workItem.repository.fullName,
+            preset: selectedPreset,
+            customInstructions: customInstructions.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+
+        Task {
+            let sessionName = await appModel.sessionLauncher.launch(config: config)
+            isLaunching = false
+            if sessionName != nil {
+                dismiss()
+            }
+        }
+    }
+}

--- a/AgentBoardUI/Screens/WorkScreen.swift
+++ b/AgentBoardUI/Screens/WorkScreen.swift
@@ -80,7 +80,8 @@ struct WorkScreen: View {
     }
 
     private var groupedFilteredItems: [(state: WorkState, items: [WorkItem])] {
-        WorkState.allCases.map { state in
+        // Only show Open, In Progress, Done columns (skip Blocked)
+        [.open, .inProgress, .done].map { state in
             (state, filteredItems.filter { $0.status == state })
         }
     }

--- a/docs/PRD-agentboard-ui-fixes.md
+++ b/docs/PRD-agentboard-ui-fixes.md
@@ -1,0 +1,438 @@
+# PRD: AgentBoard UI Fixes & Feature Completion
+
+## Overview
+Fix multiple UI issues and complete missing features in the AgentBoard macOS app. All changes are in the SwiftUI codebase at `/Users/blake/Projects/AgentBoard`.
+
+## Architecture Reminder
+- `AgentBoardUI/` — shared SwiftUI views/components
+- `AgentBoardCore/` — stores, services, models, persistence
+- `AgentBoard/` — macOS app shell (DesktopRootView)
+- Build: `xcodebuild -project AgentBoard.xcodeproj -scheme AgentBoard -destination 'platform=macOS' build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
+- After changing project.yml: `xcodegen generate`
+
+---
+
+## Task 1: Fix ChatScreen Compose Area Layout
+
+**File:** `AgentBoardUI/Screens/ChatScreen.swift`
+
+**Problems:**
+- Text field floats over the compose area instead of being properly contained
+- Attachment, microphone, and send icons are too large (44-48pt frames)
+- The ZStack layout with HStack overlay causes the text field to overlap with buttons
+
+**Fix:**
+Replace the current `composeArea` ZStack layout with a clean VStack/HStack structure:
+
+```swift
+private var composeArea: some View {
+    @Bindable var chatStore = appModel.chatStore
+
+    return VStack(spacing: 0) {
+        // Error/status messages (keep existing)
+        // ...
+
+        // Attachment preview strip (keep existing)
+        // ...
+
+        // Compose row: [attach] [mic] [textfield] [send]
+        HStack(spacing: 8) {
+            // Attachment button - shrink to 28pt
+            Button { showAttachmentPicker = true } label: {
+                Image(systemName: "paperclip")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(NeuPalette.accentCyan)
+                    .frame(width: 28, height: 28)
+            }
+            .buttonStyle(.plain)
+            .sheet(isPresented: $showAttachmentPicker) {
+                AttachmentPickerSheet { attachment in
+                    chatStore.addAttachment(attachment)
+                }
+            }
+
+            // Microphone button - shrink to 28pt
+            VoiceRecordingButton(
+                recorder: audioRecorder,
+                onRecorded: { result in chatStore.addAttachment(result.toAttachment()) },
+                onCancel: {}
+            )
+
+            // Text field - takes remaining space
+            TextField("Message Hermes...", text: $chatStore.draft, axis: .vertical)
+                .lineLimit(1...6)
+                .focused($isTextFieldFocused)
+                .foregroundStyle(NeuPalette.textPrimary)
+                .textFieldStyle(.plain)
+
+            // Send button - shrink to 32pt
+            Button {
+                isTextFieldFocused = false
+                AgentBoardKeyboard.dismiss()
+                Task { await chatStore.sendDraft() }
+            } label: {
+                Image(systemName: chatStore.isStreaming ? "stop.fill" : "paperplane.fill")
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundStyle(sendButtonForeground)
+                    .frame(width: 32, height: 32)
+                    .background(Circle().fill(sendButtonBackground))
+            }
+            .disabled(!canSend)
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .neuRecessed(cornerRadius: 20, depth: 6)
+    }
+    .padding(.horizontal, isCompact ? 16 : 24)
+    .padding(.top, 8)
+    .padding(.bottom, 12)
+    .background(
+        NeuPalette.background
+            .ignoresSafeArea(edges: .bottom)
+            .shadow(color: NeuPalette.shadowDark, radius: 10, y: -4)
+    )
+}
+```
+
+Also fix `VoiceRecordingButton` in `AgentBoardUI/Components/Attachments/VoiceViews.swift`:
+- Reduce the mic button frame from 44x44 to 28x28
+- Reduce font size from 18 to 14
+
+---
+
+## Task 2: Fix AttachmentPicker on macOS
+
+**File:** `AgentBoardUI/Components/Attachments/AttachmentPicker.swift`
+
+**Problem:** On macOS, the attachment picker shows a sheet with "Choose File..." and "Choose Image..." buttons, but the sheet itself appears empty or broken because `List` in a sheet on macOS can have rendering issues.
+
+**Fix:** On macOS, skip the sheet entirely and go straight to NSOpenPanel. Change the macOS `body` to immediately present the file picker and dismiss the sheet:
+
+```swift
+#else
+    // On macOS, go straight to NSOpenPanel
+    var body: some View {
+        Color.clear
+            .onAppear {
+                presentMacFilePicker()
+                dismiss()
+            }
+    }
+#endif
+```
+
+Or better: keep the sheet but use a VStack of buttons instead of List on macOS:
+
+```swift
+#else
+    Section {
+        VStack(spacing: 12) {
+            Button {
+                dismiss()
+                presentMacFilePicker()
+            } label: {
+                Label("Choose File...", systemImage: "doc")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .buttonStyle(.plain)
+
+            Button {
+                dismiss()
+                presentMacImagePicker()
+            } label: {
+                Label("Choose Image...", systemImage: "photo")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding()
+    }
+#endif
+```
+
+---
+
+## Task 3: Fix Microphone Button on macOS
+
+**File:** `AgentBoardCore/Services/AudioRecorderService.swift`
+
+**Problem:** The microphone button may not work on macOS because `AVAudioSession` is iOS-only. Need to check if `AudioRecorderService` handles macOS properly.
+
+**Fix:** Check the AudioRecorderService implementation. If it uses `AVAudioSession`, add `#if os(iOS)` guards and use `AVAudioRecorder` directly on macOS with proper microphone permission via `AVCaptureDevice`:
+
+```swift
+#if os(macOS)
+import AVFoundation
+
+// Request microphone permission on macOS
+func requestMacMicrophonePermission() async -> Bool {
+    return await withCheckedContinuation { continuation in
+        AVCaptureDevice.requestAccess(for: .audio) { granted in
+            continuation.resume(returning: granted)
+        }
+    }
+}
+#endif
+```
+
+---
+
+## Task 4: Make Agents View a Single-Column Task List
+
+**File:** `AgentBoardUI/Screens/AgentsScreen.swift`
+
+**Problem:** On macOS, the Agents view shows a kanban board with 4 columns (Backlog, In Progress, Blocked, Done). Blake wants a single-column task list.
+
+**Fix:** Change the macOS layout from `kanbanBoard` to a single-column list. Replace the body's conditional:
+
+```swift
+// In the body, replace:
+if isCompact {
+    compactTaskList
+} else {
+    kanbanBoard
+}
+
+// With:
+taskList  // Always use single-column list
+```
+
+Create a new `taskList` property that shows all tasks in a single scrollable list, grouped by status with section headers but NOT in columns:
+
+```swift
+private var taskList: some View {
+    ScrollView(showsIndicators: false) {
+        LazyVStack(spacing: 16) {
+            // Agent summaries at top (horizontal scroll)
+            if !appModel.agentsStore.summaries.isEmpty {
+                agentSummaryRail
+            }
+
+            // All tasks in a single list, grouped by status
+            ForEach(AgentTaskState.allCases) { state in
+                let tasks = appModel.agentsStore.tasks.filter { $0.status == state }
+                if !tasks.isEmpty {
+                    VStack(alignment: .leading, spacing: 12) {
+                        HStack {
+                            Text(state.title.uppercased())
+                                .font(.caption.weight(.bold))
+                                .tracking(1)
+                                .foregroundStyle(NeuPalette.textSecondary)
+                            Spacer()
+                            Text("\(tasks.count)")
+                                .font(.caption.weight(.bold))
+                                .foregroundStyle(NeuPalette.textSecondary)
+                        }
+                        .padding(.horizontal, 8)
+
+                        ForEach(tasks) { task in
+                            TaskListRowNeu(task: task) { selectedTask = task }
+                        }
+                    }
+                }
+            }
+        }
+        .padding(24)
+    }
+}
+```
+
+---
+
+## Task 5: Make Work View Kanban with 3 Columns (Open, In Progress, Done)
+
+**File:** `AgentBoardUI/Screens/WorkScreen.swift`
+
+**Problem:** The Work view board layout shows all 4 WorkState cases (open, inProgress, blocked, done). Blake wants only 3 columns: Open, In Progress, Done.
+
+**Fix:** Filter out the `blocked` state from the board layout. Change `groupedFilteredItems`:
+
+```swift
+private var groupedFilteredItems: [(state: WorkState, items: [WorkItem])] {
+    // Only show Open, In Progress, Done columns (skip Blocked)
+    [.open, .inProgress, .done].map { state in
+        (state, filteredItems.filter { $0.status == state })
+    }
+}
+```
+
+This keeps blocked items hidden from the board. They'll still appear in list view if needed.
+
+---
+
+## Task 6: Fix CreateIssueSheet — Use Pickers for Structured Fields
+
+**File:** `AgentBoardUI/Screens/CreateIssueSheet.swift`
+
+**Problems:**
+- Labels field is free-text comma-separated — should be a picker or tag selector
+- Assignees field is free-text comma-separated — should be a picker
+- These fields expect specific values but accept arbitrary input
+
+**Fix:** 
+1. **Labels** — Use a multi-select picker with common labels. Add a `knownLabels` array derived from existing issues:
+```swift
+private var knownLabels: [String] {
+    let allLabels = appModel.workStore.items.flatMap { $0.labels }
+    return Array(Set(allLabels)).sorted()
+}
+```
+
+Use a `List` with toggleable rows for multi-select, or keep the text field but add a "Common Labels" section with tappable chips above it.
+
+2. **Assignees** — Use a picker with known assignees from existing issues:
+```swift
+private var knownAssignees: [String] {
+    let allAssignees = appModel.workStore.items.flatMap { $0.assignees }
+    return Array(Set(allAssignees)).sorted()
+}
+```
+
+3. **Priority** — Already a segmented picker (good)
+4. **Status** — Already a segmented picker (good)
+
+Replace the free-text fields with Picker views that also allow custom entry:
+
+```swift
+// Labels - multi-select with known values
+VStack(alignment: .leading, spacing: 6) {
+    Text("Labels").font(.headline).foregroundStyle(NeuPalette.textPrimary)
+    if !knownLabels.isEmpty {
+        FlowLayout(spacing: 8) {
+            ForEach(knownLabels, id: \.self) { label in
+                let isSelected = selectedLabels.contains(label)
+                Button {
+                    if isSelected { selectedLabels.remove(label) }
+                    else { selectedLabels.insert(label) }
+                } label: {
+                    Text(label)
+                        .font(.caption)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(isSelected ? NeuPalette.accentCyan : NeuPalette.surface)
+                        .foregroundStyle(isSelected ? .black : NeuPalette.textPrimary)
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+    // Keep manual entry as fallback
+    NeuTextField(placeholder: "Add custom label...", text: $customLabel)
+}
+
+// Assignees - picker with known values
+VStack(alignment: .leading, spacing: 6) {
+    Text("Assignees").font(.headline).foregroundStyle(NeuPalette.textPrimary)
+    if !knownAssignees.isEmpty {
+        FlowLayout(spacing: 8) {
+            ForEach(knownAssignees, id: \.self) { assignee in
+                let isSelected = selectedAssignees.contains(assignee)
+                Button {
+                    if isSelected { selectedAssignees.remove(assignee) }
+                    else { selectedAssignees.insert(assignee) }
+                } label: {
+                    Text(assignee)
+                        .font(.caption)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(isSelected ? NeuPalette.accentOrange : NeuPalette.surface)
+                        .foregroundStyle(isSelected ? .black : NeuPalette.textPrimary)
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+    NeuTextField(placeholder: "Add custom assignee...", text: $customAssignee)
+}
+```
+
+You'll need a simple `FlowLayout` or just use `WrapHStack` — or use a `LazyVGrid` with flexible columns.
+
+---
+
+## Task 7: Implement Session Launching
+
+**Files:** 
+- New: `AgentBoardCore/Services/SessionLauncher.swift`
+- Modified: `AgentBoardUI/Screens/AgentsScreen.swift`
+- New: `AgentBoardUI/Screens/LaunchSessionSheet.swift`
+
+**Reference:** See `/Users/blake/Projects/AgentBoard-v2/AgentBoard/AgentBoard/Features/Board/SessionLauncher.swift` for the v2 implementation.
+
+**What it does:**
+- From the Agents screen, user can launch a new agent session for a task
+- Creates a tmux session with PRD context
+- Tracks the session in the sessions store
+
+**Implementation:**
+1. Create `SessionLauncher` service in AgentBoardCore that:
+   - Takes a task/work item and launch config
+   - Generates a PRD file
+   - Creates a tmux session via Process()
+   - Returns session info
+
+2. Add a "Launch" button to `TaskListRowNeu` and `TaskCardNeu` in AgentsScreen
+
+3. Create `LaunchSessionSheet` with:
+   - Execution preset picker (Ralph Loop, TDD, Claude→Codex)
+   - Custom instructions text field
+   - Launch button
+
+4. Add `launchSession` method to `AgentsStore` or create a standalone launcher
+
+Key code from v2 to port:
+```swift
+func launchTmuxSession(sessionName: String, repo: String, preset: ExecutionPreset, prdPath: String) async throws {
+    let shellCmd = "/opt/homebrew/bin/tmux -S \(socket) new -d -s \(sessionName)" +
+        " \"cd \(projectDir) && unset ANTHROPIC_API_KEY" +
+        " && /opt/homebrew/bin/ralphy --\(agent) --prd \(prdPath)" +
+        "; EXIT_CODE=$?; echo EXITED: $EXIT_CODE; sleep 999999\""
+    // Run via Process()
+}
+```
+
+---
+
+## Task 8: Verify GitHub Integration
+
+**Files:** `AgentBoardCore/Stores/WorkStore.swift`, `AgentBoardCore/Stores/SettingsStore.swift`
+
+**Check:**
+1. Verify `isGitHubConfigured` returns true when token + repos are set
+2. Verify `WorkStore.bootstrap()` calls `refresh()` when configured
+3. Verify `refresh()` actually fetches and populates items
+4. The code looks correct — likely the issue is that Blake hasn't configured the GitHub token/repos in Settings yet, OR the auto-refresh on tab switch isn't happening.
+
+**Fix:** Add auto-refresh when the Work tab becomes visible. In `WorkScreen`, add:
+```swift
+.onAppear {
+    Task { await appModel.workStore.bootstrap() }
+}
+```
+
+Also ensure `AgentBoardAppModel.bootstrap()` calls `workStore.bootstrap()`.
+
+---
+
+## Build & Verify
+
+After all changes:
+```bash
+cd /Users/blake/Projects/AgentBoard
+xcodebuild -project AgentBoard.xcodeproj -scheme AgentBoard -destination 'platform=macOS' build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+```
+
+Fix any build errors. Run `swiftlint lint --strict` to check for style issues.
+
+---
+
+## Constraints
+- Swift 6 strict concurrency
+- @Observable (not ObservableObject) for new stores
+- accessibilityIdentifier on every interactive element
+- Follow existing neumorphic design system (NeuPalette, NeuExtruded, NeuRecessed)
+- macOS-first, but keep iOS compatibility with #if os() guards
+- Do NOT edit AgentBoard.xcodeproj directly — use project.yml + xcodegen


### PR DESCRIPTION
Fixes chat compose layout (locked into UI, smaller icons), attachment picker on macOS, agent view to single-column task list, work kanban to 3-column (Open/In Progress/Done), issue creation pickers for structured fields, and session launching from tasks.