### PR TITLE
feat: handle slash command edge cases (bare /, whitespace separators)

### DIFF
--- a/AgentBoardCore/Services/SlashCommandHandler.swift
+++ b/AgentBoardCore/Services/SlashCommandHandler.swift
@@ -128,11 +128,21 @@ public enum SlashCommandHandler: Sendable {
         guard text.hasPrefix("/") else { return .passthrough }
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        let parts = trimmed.split(separator: " ", maxSplits: 1)
-        let command = String(parts[0]).lowercased()
+        // Split on any whitespace (space, tab, newline) so pasted or multi-line
+        // input like "/model\thermes-pro" still parses correctly.
+        let parts = trimmed.split(
+            maxSplits: 1,
+            omittingEmptySubsequences: true,
+            whereSeparator: { $0.isWhitespace }
+        )
+        guard let firstPart = parts.first else { return .passthrough }
+        let command = String(firstPart).lowercased()
         let argument = parts.count > 1
             ? String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines)
             : ""
+
+        // A bare "/" is treated as a help shortcut so users can discover commands.
+        if command == "/" { return .showHelp }
 
         // Passthrough commands are forwarded to the agent as-is
         if passthroughCommands.contains(command) {

--- a/AgentBoardTests/ChatStoreSlashCommandTests.swift
+++ b/AgentBoardTests/ChatStoreSlashCommandTests.swift
@@ -530,17 +530,19 @@ struct ChatStoreSlashCommandTests {
     @Test
     @MainActor
     func unknownSlashCommandClearsStatusBeforeForwarding() async throws {
-        // Unknown commands fall through to the agent path. They shouldn't
-        // leave a stale "Sending /foo to agent..." status hanging around once
-        // the network call fails — errorMessage should be set instead.
+        // Unknown commands fall through to the agent path. Any temporary
+        // "Sending …" status used while forwarding should be cleared again by
+        // the time sendDraft() returns.
         let store = try makeStore()
         store.draft = "/foobar"
         await store.sendDraft()
-        // After the failed network call, the user message should be persisted
-        // and the draft cleared. (The mock returns 200 OK with empty body, so
-        // streaming finishes without error.)
+
+        // The mock returns 200 OK with an empty body, so forwarding completes
+        // without an error. The forwarded user message should be persisted,
+        // the draft cleared, and no transient status should remain.
         let userMessages = store.messages.filter { $0.role == .user }
         #expect(userMessages.contains { $0.content == "/foobar" })
         #expect(store.draft.isEmpty)
+        #expect(store.statusMessage == nil)
     }
 }

--- a/AgentBoardTests/ChatStoreSlashCommandTests.swift
+++ b/AgentBoardTests/ChatStoreSlashCommandTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import Testing
 
 @Suite("ChatStore — slash command integration", .serialized)
+// swiftlint:disable:next type_body_length
 struct ChatStoreSlashCommandTests {
     @MainActor
     private func makeStore(hermesURL: String = "http://127.0.0.1:8642") throws -> ChatStore {
@@ -437,5 +438,109 @@ struct ChatStoreSlashCommandTests {
         // Normal message creates a user message
         let userMessages = store.messages.filter { $0.role == .user }
         #expect(userMessages.contains { $0.content == "Hello, agent!" })
+    }
+
+    @Test
+    @MainActor
+    func whitespaceOnlyDraftDoesNothing() async throws {
+        let store = try makeStore()
+        store.draft = "   \n\t  "
+        await store.sendDraft()
+        #expect(store.messages.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func leadingWhitespaceBeforeSlashIsStillHandledLocally() async throws {
+        // Dispatcher trims before handing to handler, so leading whitespace
+        // shouldn't prevent a /help command from being recognised.
+        let store = try makeStore()
+        store.draft = "   /help"
+        await store.sendDraft()
+        let systemMessages = store.messages.filter { $0.role == .assistant && !$0.isStreaming }
+        #expect(!systemMessages.isEmpty)
+        #expect(store.draft.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func bareSlashAppendsHelpSystemMessage() async throws {
+        let store = try makeStore()
+        store.draft = "/"
+        await store.sendDraft()
+        let systemMessages = store.messages.filter { $0.role == .assistant && !$0.isStreaming }
+        #expect(!systemMessages.isEmpty)
+        let content = try #require(systemMessages.first?.content)
+        #expect(content.contains("/help") || content.contains("Commands"))
+    }
+
+    @Test
+    @MainActor
+    func tabSeparatedModelCommandSwitchesModel() async throws {
+        let store = try makeStore()
+        store.draft = "/model\thermes-pro"
+        await store.sendDraft()
+        let status = try #require(store.statusMessage)
+        #expect(status.contains("hermes-pro"))
+        #expect(store.draft.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func localSlashCommandClearsPendingAttachments() async throws {
+        let store = try makeStore()
+        let attachment = ChatAttachment(
+            type: .file,
+            payload: .file(FileAttachmentPayload(
+                localURL: URL(fileURLWithPath: "/tmp/edge-case.txt"),
+                fileName: "edge-case.txt"
+            ))
+        )
+        store.addAttachment(attachment)
+        #expect(store.pendingAttachments.count == 1)
+
+        store.draft = "/help"
+        await store.sendDraft()
+
+        // Local commands clear the draft AND any pending attachments — they
+        // shouldn't leak into the next message the user sends.
+        #expect(store.pendingAttachments.isEmpty)
+        #expect(store.draft.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func consecutiveSlashCommandsAccumulateMessages() async throws {
+        // Make sure running multiple local commands in a row doesn't clobber
+        // earlier system messages or get tangled in shared state.
+        let store = try makeStore()
+        store.draft = "/help"
+        await store.sendDraft()
+        let firstCount = store.messages.count
+
+        store.draft = "/status"
+        await store.sendDraft()
+        #expect(store.messages.count >= firstCount + 1)
+
+        store.draft = "/config"
+        await store.sendDraft()
+        #expect(store.messages.count >= firstCount + 2)
+    }
+
+    @Test
+    @MainActor
+    func unknownSlashCommandClearsStatusBeforeForwarding() async throws {
+        // Unknown commands fall through to the agent path. They shouldn't
+        // leave a stale "Sending /foo to agent..." status hanging around once
+        // the network call fails — errorMessage should be set instead.
+        let store = try makeStore()
+        store.draft = "/foobar"
+        await store.sendDraft()
+        // After the failed network call, the user message should be persisted
+        // and the draft cleared. (The mock returns 200 OK with empty body, so
+        // streaming finishes without error.)
+        let userMessages = store.messages.filter { $0.role == .user }
+        #expect(userMessages.contains { $0.content == "/foobar" })
+        #expect(store.draft.isEmpty)
     }
 }

--- a/AgentBoardTests/SlashCommandHandlerTests.swift
+++ b/AgentBoardTests/SlashCommandHandlerTests.swift
@@ -95,6 +95,60 @@ struct SlashCommandHandlerTests {
         #expect(result == .passthrough) // leading space means not a slash command
     }
 
+    @Test func trailingWhitespaceOnCommandIsTrimmed() {
+        #expect(SlashCommandHandler.handle("/help   ") == .showHelp)
+        #expect(SlashCommandHandler.handle("/help\n") == .showHelp)
+    }
+
+    // MARK: - Edge cases
+
+    @Test func bareSlashShowsHelp() {
+        // A user typing just "/" is asking what commands exist.
+        #expect(SlashCommandHandler.handle("/") == .showHelp)
+    }
+
+    @Test func bareSlashWithSurroundingWhitespaceShowsHelp() {
+        #expect(SlashCommandHandler.handle("/   ") == .showHelp)
+        #expect(SlashCommandHandler.handle("/\n") == .showHelp)
+    }
+
+    @Test func tabSeparatedArgumentParsesCorrectly() {
+        let result = SlashCommandHandler.handle("/model\thermes-pro")
+        #expect(result == .switchModel("hermes-pro"))
+    }
+
+    @Test func newlineSeparatedArgumentParsesCorrectly() {
+        let result = SlashCommandHandler.handle("/model\nhermes-pro")
+        #expect(result == .switchModel("hermes-pro"))
+    }
+
+    @Test func skillArgumentPreservesMixedCase() {
+        // Command name is case-insensitive, but arguments must preserve case
+        // because skill identifiers may be case-sensitive.
+        let result = SlashCommandHandler.handle("/SKILL MyCoolSkill")
+        #expect(result == .activateSkill("MyCoolSkill"))
+    }
+
+    @Test func helpIgnoresExtraneousArguments() {
+        #expect(SlashCommandHandler.handle("/help foo bar") == .showHelp)
+    }
+
+    @Test func skillWithWhitespaceOnlyArgumentIsPassthrough() {
+        // After trimming, /skill has no argument → forwarded to agent unchanged.
+        #expect(SlashCommandHandler.handle("/skill   ") == .passthrough)
+        #expect(SlashCommandHandler.handle("/skill\t") == .passthrough)
+    }
+
+    @Test func doubleSlashIsUnknown() {
+        // "//" looks like a comment marker, not a real command — don't claim it.
+        let result = SlashCommandHandler.handle("//foo")
+        if case let .unknown(cmd) = result {
+            #expect(cmd == "//foo")
+        } else {
+            Issue.record("Expected .unknown for '//foo', got \(result)")
+        }
+    }
+
     // MARK: - Format helpers
 
     @Test func formatHelpContainsAllCommands() {


### PR DESCRIPTION
- Bare "/" returns .showHelp so users can discover commands
- Argument splitting now handles tabs and newlines, not just spaces (so "/model\thermes-pro" parses correctly)
- Adds dedicated edge-case test sections covering bare slashes, tab/newline-separated args, mixed-case skill names, double-slash passthrough, whitespace-only drafts, leading-whitespace dispatch, attachment clearing on local commands, and consecutive command runs

Closes the "Handle edge cases" task in docs/PRD-issue-73.md.