### PR TITLE
Add Hermes agent signatures

### DIFF
--- a/AgentBoardCompanionKit/CompanionLocalProbe.swift
+++ b/AgentBoardCompanionKit/CompanionLocalProbe.swift
@@ -21,7 +21,9 @@ public actor CompanionLocalProbe {
         AgentSignature(keyword: "codex", name: "Codex"),
         AgentSignature(keyword: "claude", name: "Claude"),
         AgentSignature(keyword: "aider", name: "Aider"),
-        AgentSignature(keyword: "cursor", name: "Cursor")
+        AgentSignature(keyword: "cursor", name: "Cursor"),
+        AgentSignature(keyword: "hermes-agent", name: "Hermes"),
+        AgentSignature(keyword: "/hermes/", name: "Hermes")
     ]
 
     public init() {}


### PR DESCRIPTION
Update CompanionLocalProbe to recognize Hermes-based agents by adding two AgentSignature entries: "hermes-agent" and "/hermes/", both labeled "Hermes". This expands agent detection to include explicit and regex-style Hermes identifiers.