### PR TITLE
Add companion events tests and accessibility IDs

### DIFF
--- a/.ralphy/deferred.json
+++ b/.ralphy/deferred.json
@@ -9,6 +9,16 @@
       "count": 1,
       "last": "2026-05-18T18:37:08.624Z",
       "title": "Implement Cross-device chat history sync via companion server"
+    },
+    "markdown:docs/PRD-issue-46.md:6": {
+      "count": 1,
+      "last": "2026-05-19T03:37:05.399Z",
+      "title": "Implement Expand modern AgentBoard coverage for companion events and UI smoke flows"
+    },
+    "markdown:docs/PRD-issue-47.md:8": {
+      "count": 1,
+      "last": "2026-05-19T03:37:24.818Z",
+      "title": "Add accessibilityIdentifier to every interactive element"
     }
   }
 }

--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		3D5547FD2C8499B8C8FA087B /* AudioRecorderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E1BE6A2B2B66CFAF5F4AC0 /* AudioRecorderService.swift */; };
 		3FDBA88CC8E8D63388C757C6 /* ConfigBackupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9679A2004F1CFD39A588CC7 /* ConfigBackupService.swift */; };
 		41487A7506D835D9946C1B9E /* ChatScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FDDFF5030B377E6973E969 /* ChatScreen.swift */; };
+		44DFBA6A0CA31D48DE0A0961 /* CompanionClientEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D165293786CA5ACAB31F2F12 /* CompanionClientEventsTests.swift */; };
 		4D05F9AAB6DA0E2642F377F4 /* ShellEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52959B32060C120BA1BB1AB7 /* ShellEnvironment.swift */; };
 		4E523683F87984FFDF08FC54 /* AttachmentInteractions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31C11E46072F7E4A9FFADDB /* AttachmentInteractions.swift */; };
 		5364836AF5802F65E8F2B521 /* SessionTerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDFAB3DEE21BBA70FAF2EBD /* SessionTerminalView.swift */; };
@@ -303,6 +304,7 @@
 		C9679A2004F1CFD39A588CC7 /* ConfigBackupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigBackupService.swift; sourceTree = "<group>"; };
 		C9D42E5CA1B251EA0284E8C6 /* AttachmentModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentModels.swift; sourceTree = "<group>"; };
 		CE1B1DC901AD1D60B3855D38 /* SessionLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLauncherTests.swift; sourceTree = "<group>"; };
+		D165293786CA5ACAB31F2F12 /* CompanionClientEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionClientEventsTests.swift; sourceTree = "<group>"; };
 		D4C9640747C8B7AE6E92BB20 /* AgentBoardAppModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBoardAppModel.swift; sourceTree = "<group>"; };
 		D7A095E80382BA922486329A /* SettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
 		DB3E71CE348AC298EB4048DE /* AgentBoardCompanionKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AgentBoardCompanionKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -387,6 +389,7 @@
 				30366B0DAB9553F53ACE2BE6 /* ChatStoreAdditionalTests.swift */,
 				0551DF2CA889DD84A9EFF3B7 /* ChatStoreSlashCommandTests.swift */,
 				7F925ACBB136730BD7852D8B /* ChatStoreTests.swift */,
+				D165293786CA5ACAB31F2F12 /* CompanionClientEventsTests.swift */,
 				B56A44BC3ACA67014432FDD4 /* CompanionSQLiteStoreTests.swift */,
 				E15329720160FF009D5B1535 /* ConfigBackupServiceTests.swift */,
 				19CE389F4A620817A309F601 /* DesignSemanticsTests.swift */,
@@ -901,6 +904,7 @@
 				C6A73DFEFD3440E23C5AE028 /* ChatStoreAdditionalTests.swift in Sources */,
 				B01C8989FACCB9D76DD46CDF /* ChatStoreSlashCommandTests.swift in Sources */,
 				FF4D3F1289548330CC170576 /* ChatStoreTests.swift in Sources */,
+				44DFBA6A0CA31D48DE0A0961 /* CompanionClientEventsTests.swift in Sources */,
 				58446795E6F62924439AD001 /* CompanionSQLiteStoreTests.swift in Sources */,
 				AC9718464408D550B64EFB4E /* ConfigBackupServiceTests.swift in Sources */,
 				10A2BF960BB432E046A8392E /* DesignSemanticsTests.swift in Sources */,

--- a/AgentBoardCompanionKit/CompanionSQLiteStore.swift
+++ b/AgentBoardCompanionKit/CompanionSQLiteStore.swift
@@ -121,7 +121,7 @@ public actor CompanionSQLiteStore {
     }
 
     private func runMigrations() {
-        guard let existingColumns = try? existingSessionColumns() else { return }
+        guard let sessionColumns = try? existingSessionColumns() else { return }
 
         let sessionMigrations: [(column: String, type: String)] = [
             ("pid", "INTEGER"),
@@ -130,7 +130,7 @@ public actor CompanionSQLiteStore {
             ("last_output", "TEXT")
         ]
         for (column, type) in sessionMigrations {
-            guard !existingColumns.contains(column) else { continue }
+            guard !sessionColumns.contains(column) else { continue }
             try? execute("ALTER TABLE sessions ADD COLUMN \(column) \(type);")
         }
 

--- a/AgentBoardTests/AccessibilityIdentifierTests.swift
+++ b/AgentBoardTests/AccessibilityIdentifierTests.swift
@@ -191,6 +191,80 @@ struct AccessibilityIdentifierTests {
         #expect(source.contains(#"kanban_cell_task_\(task.id)"#))
     }
 
+    @Test("Work screen exposes identifiers for header, search, repo picker, and create flow")
+    func workScreenIdentifiers() throws {
+        let source = try readUISource("Screens/WorkScreen.swift")
+        let required = [
+            "screen_work",
+            "work_section_header",
+            "work_button_search",
+            "work_textfield_search",
+            "work_button_create_issue",
+            "work_picker_repository"
+        ]
+        assertIdentifiers(required, in: source)
+        #expect(source.contains(#"work_column_\(column.state.rawValue)"#))
+    }
+
+    @Test("Create issue sheet exposes identifiers for every interactive control")
+    func createIssueSheetIdentifiers() throws {
+        let source = try readUISource("Screens/CreateIssueSheet.swift")
+        let required = [
+            "create_issue_picker_repository",
+            "create_issue_textfield_title",
+            "create_issue_texteditor_body",
+            "create_issue_picker_type",
+            "create_issue_picker_priority",
+            "create_issue_picker_status",
+            "create_issue_picker_agent",
+            "create_issue_textfield_milestone",
+            "create_issue_button_add_attachment",
+            "create_issue_button_cancel",
+            "create_issue_button_create"
+        ]
+        assertIdentifiers(required, in: source)
+    }
+
+    @Test("Issue detail sheet exposes identifiers for view, edit, and lifecycle controls")
+    func issueDetailSheetIdentifiers() throws {
+        let source = try readUISource("Screens/IssueDetailSheet.swift")
+        let required = [
+            "issue_detail_button_close",
+            "issue_detail_button_save",
+            "issue_detail_button_edit",
+            "issue_detail_button_toolbar_reopen",
+            "issue_detail_button_toolbar_close_issue",
+            "issue_detail_launch_session",
+            "issue_detail_textfield_title",
+            "issue_detail_texteditor_body",
+            "issue_detail_textfield_milestone",
+            "issue_detail_button_add_attachment",
+            "issue_detail_button_card_reopen",
+            "issue_detail_button_card_close_issue",
+            "edit_issue_picker_type",
+            "edit_issue_picker_priority",
+            "edit_issue_picker_status",
+            "edit_issue_picker_agent"
+        ]
+        assertIdentifiers(required, in: source)
+    }
+
+    @Test("Session terminal view exposes identifiers for embedded, failed, and stalled states")
+    func sessionTerminalViewIdentifiers() throws {
+        let source = try readUISource("Screens/SessionTerminalView.swift")
+        let required = [
+            "session_terminal_toggle_expand",
+            "session_terminal_open_terminal",
+            "session_terminal_close",
+            "session_terminal_embedded",
+            "session_terminal_failed_open_terminal",
+            "session_terminal_failed_close",
+            "session_terminal_stalled_open_terminal",
+            "session_terminal_stalled_close"
+        ]
+        assertIdentifiers(required, in: source)
+    }
+
     @Test("Launch session sheet exposes identifiers for every interactive control")
     func launchSessionSheetIdentifiers() throws {
         let source = try readUISource("Screens/LaunchSessionSheet.swift")

--- a/AgentBoardTests/CompanionClientEventsTests.swift
+++ b/AgentBoardTests/CompanionClientEventsTests.swift
@@ -1,0 +1,123 @@
+import AgentBoardCore
+import Foundation
+import Testing
+
+/// Coverage for `CompanionClient.events()` — the SSE stream that powers
+/// live updates from the companion service. The stream parses one
+/// `CompanionEvent` per `data:` line and skips other SSE framing lines.
+@Suite(.serialized)
+struct CompanionClientEventsTests {
+    @Test
+    func eventsDecodesDataLinesAndSkipsOtherSSEFraming() async throws {
+        let firstID = UUID()
+        let secondID = UUID()
+        let sentAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let body = """
+        : heartbeat
+        retry: 5000
+
+        event: companion
+        data: \(eventJSON(id: firstID, kind: .sessionsChanged, sentAt: sentAt))
+
+        data: \(eventJSON(id: secondID, kind: .conversationsChanged, sentAt: sentAt))
+
+
+        """
+
+        let client = CompanionClient(session: makeMockSession { request in
+            #expect(request.url?.path == "/v1/events")
+            #expect(request.value(forHTTPHeaderField: "Accept") == "text/event-stream")
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/event-stream"]
+            )!
+            return (response, Data(body.utf8))
+        })
+
+        try await client.configure(baseURL: "http://companion.test:8742", bearerToken: nil)
+
+        var received: [CompanionEvent] = []
+        for try await event in try await client.events() {
+            received.append(event)
+            if received.count == 2 { break }
+        }
+
+        #expect(received.map(\.id) == [firstID, secondID])
+        #expect(received.map(\.kind) == [.sessionsChanged, .conversationsChanged])
+    }
+
+    @Test
+    func eventsSurfacesHTTPErrorsForNon200Status() async throws {
+        let client = CompanionClient(session: makeMockSession { request in
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 503,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data("companion offline".utf8))
+        })
+
+        try await client.configure(baseURL: "http://companion.test:8742", bearerToken: nil)
+
+        await #expect(throws: CompanionClient.ClientError.self) {
+            for try await _ in try await client.events() {
+                Issue.record("expected stream to throw before yielding")
+            }
+        }
+    }
+
+    @Test
+    func eventsTerminatesStreamOnMalformedDataLine() async throws {
+        let validID = UUID()
+        let body = """
+        data: not-json
+
+        data: \(eventJSON(id: validID, kind: .agentsChanged, sentAt: Date(timeIntervalSince1970: 1_700_000_500)))
+
+        """
+
+        let client = CompanionClient(session: makeMockSession { request in
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/event-stream"]
+            )!
+            return (response, Data(body.utf8))
+        })
+
+        try await client.configure(baseURL: "http://companion.test:8742", bearerToken: nil)
+
+        var streamError: Error?
+        var received: [CompanionEvent] = []
+        do {
+            for try await event in try await client.events() {
+                received.append(event)
+            }
+        } catch {
+            streamError = error
+        }
+
+        // Malformed JSON on a `data:` line currently surfaces as a decoding
+        // error that tears the stream down — the subsequent valid event never
+        // arrives. Pinning that contract prevents silent corruption.
+        #expect(streamError != nil)
+        #expect(received.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func eventJSON(id: UUID, kind: CompanionEventKind, sentAt: Date) -> String {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let event = CompanionEvent(id: id, kind: kind, sentAt: sentAt)
+        guard let data = try? encoder.encode(event),
+              let json = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return json
+    }
+}

--- a/AgentBoardTests/SessionsStoreTests.swift
+++ b/AgentBoardTests/SessionsStoreTests.swift
@@ -218,6 +218,140 @@ struct SessionsStoreTests {
         #expect(store.sessions.first?.id == "remote-3")
     }
 
+    @Test
+    @MainActor
+    func handleSessionsChangedEventRefreshesFromCompanion() async throws {
+        let counter = SyncCounter()
+        let session = AgentSession(
+            id: "remote-evt",
+            source: "Tailscale Mac",
+            status: .running,
+            startedAt: .now,
+            lastSeenAt: .now
+        )
+
+        let companionClient = CompanionClient(session: makeMockSession { request in
+            _ = counter.increment()
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            return try (response, encoder.encode([session]))
+        })
+
+        let store = try await makeStore(
+            companionClient: companionClient,
+            companionURL: "http://test.local:8742"
+        )
+
+        await store.bootstrap()
+        let baseline = counter.snapshot()
+
+        await store.handle(event: .sessionsChanged)
+
+        #expect(counter.snapshot() == baseline + 1)
+        #expect(store.syncStatus == .live)
+    }
+
+    @Test
+    @MainActor
+    func handleSnapshotRefreshedEventRefreshesFromCompanion() async throws {
+        let counter = SyncCounter()
+        let session = AgentSession(
+            id: "remote-evt",
+            source: "Tailscale Mac",
+            status: .running,
+            startedAt: .now,
+            lastSeenAt: .now
+        )
+
+        let companionClient = CompanionClient(session: makeMockSession { request in
+            _ = counter.increment()
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            return try (response, encoder.encode([session]))
+        })
+
+        let store = try await makeStore(
+            companionClient: companionClient,
+            companionURL: "http://test.local:8742"
+        )
+
+        await store.bootstrap()
+        let baseline = counter.snapshot()
+
+        await store.handle(event: .snapshotRefreshed)
+
+        #expect(counter.snapshot() == baseline + 1)
+        #expect(store.syncStatus == .live)
+    }
+
+    @Test
+    @MainActor
+    func handleAgentsChangedEventDoesNotRefreshSessions() async throws {
+        let counter = SyncCounter()
+        let companionClient = CompanionClient(session: makeMockSession { request in
+            _ = counter.increment()
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, Data("[]".utf8))
+        })
+
+        let store = try await makeStore(
+            companionClient: companionClient,
+            companionURL: "http://test.local:8742"
+        )
+
+        await store.bootstrap()
+        let baseline = counter.snapshot()
+
+        await store.handle(event: .agentsChanged)
+
+        #expect(counter.snapshot() == baseline)
+    }
+
+    @Test
+    @MainActor
+    func handleConversationsChangedEventDoesNotRefreshSessions() async throws {
+        let counter = SyncCounter()
+        let companionClient = CompanionClient(session: makeMockSession { request in
+            _ = counter.increment()
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, Data("[]".utf8))
+        })
+
+        let store = try await makeStore(
+            companionClient: companionClient,
+            companionURL: "http://test.local:8742"
+        )
+
+        await store.bootstrap()
+        let baseline = counter.snapshot()
+
+        await store.handle(event: .conversationsChanged)
+
+        #expect(counter.snapshot() == baseline)
+    }
+
     // MARK: - Helpers
 
     @MainActor
@@ -290,5 +424,9 @@ private struct SyncCounter: Sendable {
             count += 1
             return count
         }
+    }
+
+    func snapshot() -> Int {
+        storage.withLock { $0 }
     }
 }

--- a/AgentBoardUI/Screens/AgentsScreen.swift
+++ b/AgentBoardUI/Screens/AgentsScreen.swift
@@ -62,6 +62,7 @@ struct AgentsScreen: View {
             LaunchSessionSheet(task: task)
                 .environment(appModel)
         }
+        .accessibilityIdentifier("screen_kanban")
     }
 
     private var header: some View {

--- a/AgentBoardUI/Screens/ChatScreen.swift
+++ b/AgentBoardUI/Screens/ChatScreen.swift
@@ -48,6 +48,7 @@ struct ChatScreen: View {
         }
         .agentBoardNavigationBarHidden(true)
         .agentBoardKeyboardDismissToolbar()
+        .accessibilityIdentifier("screen_chat")
         #if os(iOS)
             .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
                 Task { await appModel.chatStore.autoReconnectIfNeeded() }

--- a/AgentBoardUI/Screens/CreateIssueSheet.swift
+++ b/AgentBoardUI/Screens/CreateIssueSheet.swift
@@ -193,6 +193,7 @@ struct CreateIssueSheet: View {
                 pendingAttachments.append(attachment)
             }
         }
+        .accessibilityIdentifier("screen_create_issue")
     }
 
     // MARK: - Actions

--- a/AgentBoardUI/Screens/IssueDetailSheet.swift
+++ b/AgentBoardUI/Screens/IssueDetailSheet.swift
@@ -79,6 +79,7 @@ struct IssueDetailSheet: View {
                 pendingAttachments.append(attachment)
             }
         }
+        .accessibilityIdentifier("screen_issue_detail")
     }
 
     // MARK: - Read View

--- a/AgentBoardUI/Screens/SessionTerminalView.swift
+++ b/AgentBoardUI/Screens/SessionTerminalView.swift
@@ -43,6 +43,7 @@ struct SessionTerminalView: View {
                 }
             }
         }
+        .accessibilityIdentifier("screen_session_terminal")
     }
 
     // MARK: - Header

--- a/docs/PRD-issue-46.md
+++ b/docs/PRD-issue-46.md
@@ -1,0 +1,18 @@
+# PRD: Expand modern AgentBoard coverage for companion events and UI smoke flows
+
+## Issue
+#46 in jbcrane13/agentboard
+## Tasks
+- [ ] Implement Expand modern AgentBoard coverage for companion events and UI smoke flows
+- [ ] Handle edge cases and error states
+- [ ] Add accessibilityIdentifier to every interactive element
+- [ ] Build verify: xcodebuild -scheme AgentBoard -destination 'platform=macOS' build
+## Constraints
+- Swift 6 strict concurrency
+- @Observable not ObservableObject
+- accessibilityIdentifier on every interactive element
+
+## Anti-Stall Rules
+- Never wait for input. Never pause for confirmation. Keep moving.
+- When done: commit, push to feature branch, STOP.
+- Report: "DONE: [accomplished] | BLOCKED: [anything open]"

--- a/docs/PRD-issue-47.md
+++ b/docs/PRD-issue-47.md
@@ -1,0 +1,18 @@
+# PRD: Restore a clean strict SwiftLint gate around the Hermes migration
+
+## Issue
+#47 in jbcrane13/agentboard
+## Tasks
+- [x] Implement Restore a clean strict SwiftLint gate around the Hermes migration
+- [x] Handle edge cases and error states
+- [ ] Add accessibilityIdentifier to every interactive element
+- [ ] Build verify: xcodebuild -scheme AgentBoard -destination 'platform=macOS' build
+## Constraints
+- Swift 6 strict concurrency
+- @Observable not ObservableObject
+- accessibilityIdentifier on every interactive element
+
+## Anti-Stall Rules
+- Never wait for input. Never pause for confirmation. Keep moving.
+- When done: commit, push to feature branch, STOP.
+- Report: "DONE: [accomplished] | BLOCKED: [anything open]"


### PR DESCRIPTION
Add coverage for CompanionClient SSE parsing and session-related event handling (new CompanionClientEventsTests and expanded SessionsStoreTests), including SyncCounter snapshot helper. Register new test file in the Xcode project. Add accessibilityIdentifier to several screens (Agents, Chat, CreateIssue, IssueDetail, SessionTerminal) and extend AccessibilityIdentifierTests to assert identifiers for work, issue creation/detail, and session terminal views. Fix a variable naming inconsistency in CompanionSQLiteStore migrations (existingColumns -> sessionColumns) to avoid shadowing. Add PRD docs for issues 46 and 47 and update .ralphy/deferred.json metadata.