### PR TITLE
Use native SwiftUI app shells

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ Located in `SharedResources/Assets.xcassets/AppIcon.appiconset/`. All 10 macOS s
 ## Design decisions
 
 See `docs/ADR.md` for the full architecture decision record. Key recent ADRs:
+- **ADR-013** (2026-05-23): Native SwiftUI app shell controls
 - **ADR-011** (2026-05-01): Kanban.db as task backend
 - **ADR-010** (2026-04-23): Hermes-first shared SwiftUI rebuild
 
@@ -187,6 +188,10 @@ The older OpenClaw/beads/macOS-only prototype has been removed from the active s
 ## Activity — 2026-05-18
 - 9ecdf1d feat: complete companion sync for sessions and chat
 - beaf928 fix: keep sessions live when cache persistence fails (#90)
+
+## Activity — 2026-05-23
+- Native SwiftUI shell migration for #97-#100: macOS app shell now uses `NavigationSplitView`, source-list sidebar rows, toolbar actions, and a chat inspector; iOS root uses tagged SwiftUI `TabView(selection:)` without UIKit tab-bar overrides.
+- Added `NativeSwiftUIInterfaceTests` to guard the app-shell contracts and documented the decision in ADR-013.
 
 ## Imported Claude Cowork project instructions
 

--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		961E593801A91A1EE5E55F76 /* AttachmentViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2941E5B6C18CF76C4621BB /* AttachmentViews.swift */; };
 		96C502A1BD49F2AE81F03313 /* AttachmentModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376B52FEC631A3F6F0383459 /* AttachmentModelsTests.swift */; };
 		96EEFE83B762E77B78F99B90 /* AgentBoardCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; };
+		9781E0240F8A4C6FC3DC30B7 /* NativeSwiftUIInterfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5CC5206E88A59FBD80A856 /* NativeSwiftUIInterfaceTests.swift */; };
 		97BD3D8CCE198A034A5E0C2F /* AttachmentPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E3C09A95E37674D30B6072F /* AttachmentPicker.swift */; };
 		9A90C5EF45CA6630C7EA64CD /* SessionLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B1DC901AD1D60B3855D38 /* SessionLauncherTests.swift */; };
 		9EAAAF4FFBF10F8A576AF5BD /* SessionLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B7CE4C138A75D87781C1DB /* SessionLauncher.swift */; };
@@ -296,6 +297,7 @@
 		B56A44BC3ACA67014432FDD4 /* CompanionSQLiteStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionSQLiteStoreTests.swift; sourceTree = "<group>"; };
 		B7B2891F313F2E1804101D36 /* HermesGatewayClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesGatewayClient.swift; sourceTree = "<group>"; };
 		BA51DADAAAAFFE9B833D35E9 /* CompanionLocalProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionLocalProbe.swift; sourceTree = "<group>"; };
+		BB5CC5206E88A59FBD80A856 /* NativeSwiftUIInterfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeSwiftUIInterfaceTests.swift; sourceTree = "<group>"; };
 		BB9701D71214407E75807732 /* WorkStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkStoreTests.swift; sourceTree = "<group>"; };
 		BD2941E5B6C18CF76C4621BB /* AttachmentViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentViews.swift; sourceTree = "<group>"; };
 		BE362DDE00559E2C84434C13 /* AgentsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsScreen.swift; sourceTree = "<group>"; };
@@ -401,6 +403,7 @@
 				AE3F349D2B17FA90738CCDD5 /* KanbanModelsTests.swift */,
 				8562113DB3BC11316C4B4A50 /* LabelSchemaTests.swift */,
 				957114148477B05585A13D7C /* MockURLProtocol.swift */,
+				BB5CC5206E88A59FBD80A856 /* NativeSwiftUIInterfaceTests.swift */,
 				CE1B1DC901AD1D60B3855D38 /* SessionLauncherTests.swift */,
 				92E0CE9F3A8E9CA87A6C3B95 /* SessionsStoreTests.swift */,
 				B4813FBD80F9AC10D1A51841 /* SettingsStoreTests.swift */,
@@ -916,6 +919,7 @@
 				DAAA6677EBC51F4C7796E505 /* KanbanModelsTests.swift in Sources */,
 				E9D09CAC0D952EE1295DFA60 /* LabelSchemaTests.swift in Sources */,
 				38E1089316EEC57E444A6FB1 /* MockURLProtocol.swift in Sources */,
+				9781E0240F8A4C6FC3DC30B7 /* NativeSwiftUIInterfaceTests.swift in Sources */,
 				9A90C5EF45CA6630C7EA64CD /* SessionLauncherTests.swift in Sources */,
 				F18232EF1BD587C14FCCD06F /* SessionsStoreTests.swift in Sources */,
 				D4674853A5F6064FC3E65542 /* SettingsStoreTests.swift in Sources */,

--- a/AgentBoard/AgentBoardApp.swift
+++ b/AgentBoard/AgentBoardApp.swift
@@ -19,7 +19,6 @@ struct AgentBoardApp: App {
                 .environment(appModel)
                 .onAppear {
                     applyTheme(appModel.settingsStore.designTheme)
-                    hideTitleBar()
                 }
                 .onChange(of: appModel.settingsStore.designTheme) {
                     applyTheme(appModel.settingsStore.designTheme)
@@ -36,16 +35,6 @@ struct AgentBoardApp: App {
         NeuPalette.apply(designTheme)
         appliedTheme = designTheme
     }
-
-    #if os(macOS)
-        private func hideTitleBar() {
-            guard let window = NSApplication.shared.windows.first else { return }
-            window.titlebarAppearsTransparent = true
-            window.titleVisibility = .hidden
-            window.toolbar = nil
-            window.styleMask.insert(.fullSizeContentView)
-        }
-    #endif
 
     private static func logRuntimeConfiguration() {
         let bundleID = Bundle.main.bundleIdentifier ?? "unknown"

--- a/AgentBoard/DesktopRootView.swift
+++ b/AgentBoard/DesktopRootView.swift
@@ -3,108 +3,86 @@ import SwiftUI
 
 struct DesktopRootView: View {
     @Environment(AgentBoardAppModel.self) private var appModel
+    @State private var columnVisibility: NavigationSplitViewVisibility = .all
     @State private var activeTab: DesktopTab? = .work
     @State private var activeSessionTerminal: SessionLauncher.ActiveSession?
     @State private var isTerminalExpanded = false
-    @State private var isChatOnlyMode = false
-    @State private var savedWindowWidth: CGFloat?
+    @State private var isChatInspectorPresented = true
     @State private var isPresentingQuickLaunch = false
 
-    private static let chatOnlyWindowWidth: CGFloat = 380
-
-    private var sidePanelsHidden: Bool {
-        isTerminalExpanded || isChatOnlyMode
-    }
-
     var body: some View {
-        HStack(spacing: 0) {
-            if !sidePanelsHidden {
-                DesktopSidebar(
-                    activeTab: activeTab,
-                    onTabSelect: { tab in
-                        activeTab = tab
-                        activeSessionTerminal = nil
-                        isTerminalExpanded = false
-                    },
-                    onSessionTap: { session in activeSessionTerminal = session },
-                    onQuickLaunch: { isPresentingQuickLaunch = true }
-                )
-                .frame(width: 230)
-                .transition(.move(edge: .leading).combined(with: .opacity))
-            }
+        NavigationSplitView(columnVisibility: $columnVisibility) {
+            DesktopSidebar(
+                selection: tabSelection,
+                onSessionTap: { session in
+                    activeSessionTerminal = session
+                    isTerminalExpanded = false
+                },
+                onQuickLaunch: { isPresentingQuickLaunch = true }
+            )
+            .navigationSplitViewColumnWidth(min: 220, ideal: 250, max: 320)
+        } detail: {
+            centerPanel
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .navigationTitle(navigationTitle)
+                .toolbar {
+                    ToolbarItemGroup(placement: .primaryAction) {
+                        Button {
+                            isPresentingQuickLaunch = true
+                        } label: {
+                            Label("Quick Launch", systemImage: "plus")
+                        }
+                        .help("Launch a new agent session")
+                        .accessibilityIdentifier("toolbar_button_quick_launch")
 
-            if !isChatOnlyMode {
-                centerPanel
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(NeuPalette.background)
-            }
-
-            if !isTerminalExpanded {
-                ChatScreen(
-                    onToggleChatOnly: { toggleChatOnlyMode() },
-                    isChatOnlyMode: isChatOnlyMode
-                )
-                .frame(maxWidth: isChatOnlyMode ? .infinity : 360)
-                .frame(width: isChatOnlyMode ? nil : 360)
-                .background(NeuPalette.surface)
-                .overlay(alignment: .leading) {
-                    Rectangle()
-                        .fill(NeuPalette.borderSoft)
-                        .frame(width: 1)
+                        Button {
+                            isChatInspectorPresented.toggle()
+                        } label: {
+                            Label(
+                                isChatInspectorPresented ? "Hide Chat" : "Show Chat",
+                                systemImage: "sidebar.trailing"
+                            )
+                        }
+                        .disabled(isTerminalExpanded)
+                        .help(isChatInspectorPresented ? "Hide chat inspector" : "Show chat inspector")
+                        .accessibilityIdentifier("toolbar_button_toggle_chat_inspector")
+                    }
                 }
-                .transition(.move(edge: .trailing).combined(with: .opacity))
-            }
         }
-        .animation(.easeInOut(duration: 0.22), value: isTerminalExpanded)
-        .animation(.easeInOut(duration: 0.22), value: isChatOnlyMode)
-        .background(NeuBackground())
+        .inspector(isPresented: chatInspectorVisibility) {
+            ChatScreen()
+                .inspectorColumnWidth(min: 320, ideal: 360, max: 460)
+        }
         .sheet(isPresented: $isPresentingQuickLaunch) {
             QuickLaunchSheet()
                 .environment(appModel)
         }
     }
 
-    // MARK: - Chat-only Mode
-
-    private func toggleChatOnlyMode() {
-        #if os(macOS)
-            if isChatOnlyMode {
-                isChatOnlyMode = false
-                if let restoreWidth = savedWindowWidth {
-                    setWindowWidth(restoreWidth, animate: true)
-                }
-                savedWindowWidth = nil
-            } else {
-                if let window = primaryWindow() {
-                    savedWindowWidth = window.frame.width
-                }
-                isChatOnlyMode = true
-                setWindowWidth(Self.chatOnlyWindowWidth, animate: true)
-            }
-        #else
-            isChatOnlyMode.toggle()
-        #endif
+    private var tabSelection: Binding<DesktopTab?> {
+        Binding {
+            activeTab
+        } set: { newValue in
+            activeTab = newValue ?? .work
+            activeSessionTerminal = nil
+            isTerminalExpanded = false
+        }
     }
 
-    #if os(macOS)
-        private func primaryWindow() -> NSWindow? {
-            NSApp.keyWindow ?? NSApp.mainWindow ?? NSApp.windows.first(where: { $0.isVisible })
+    private var chatInspectorVisibility: Binding<Bool> {
+        Binding {
+            isChatInspectorPresented && !isTerminalExpanded
+        } set: { newValue in
+            isChatInspectorPresented = newValue
         }
+    }
 
-        private func setWindowWidth(_ width: CGFloat, animate: Bool) {
-            guard let window = primaryWindow() else { return }
-            // Allow the window to shrink below any prior contentMinSize.
-            window.contentMinSize = NSSize(width: min(width, window.contentMinSize.width), height: 0)
-            var frame = window.frame
-            let delta = frame.size.width - width
-            frame.size.width = width
-            // Keep the right edge of the window pinned so the chat column doesn't shift.
-            frame.origin.x += delta
-            window.setFrame(frame, display: true, animate: animate)
+    private var navigationTitle: String {
+        if activeSessionTerminal != nil {
+            return "Session Terminal"
         }
-    #endif
-
-    // MARK: - Center Panel
+        return (activeTab ?? .work).title
+    }
 
     @ViewBuilder
     private var centerPanel: some View {
@@ -127,46 +105,6 @@ struct DesktopRootView: View {
             case .settings:
                 SettingsScreen()
             }
-        }
-    }
-
-    // MARK: - Connection Status
-
-    private var connectionStatusChip: some View {
-        HStack(spacing: 6) {
-            Circle()
-                .fill(connectionDotColor)
-                .frame(width: 7, height: 7)
-            Text(connectionStatusText)
-                .font(.system(size: 11, weight: .medium, design: .monospaced))
-                .foregroundStyle(connectionDotColor)
-        }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .background(NeuPalette.inset)
-        .clipShape(Capsule())
-    }
-
-    private var connectionDotColor: Color {
-        switch appModel.chatStore.connectionState {
-        case .connected: NeuPalette.statusSuccess
-        case .connecting, .reconnecting: NeuPalette.accentOrange
-        case .failed: .red
-        case .disconnected: NeuPalette.textSecondary
-        }
-    }
-
-    private var activeRepositoryTitle: String {
-        appModel.settingsStore.repositories.first?.fullName ?? "no repository"
-    }
-
-    private var connectionStatusText: String {
-        switch appModel.chatStore.connectionState {
-        case .connected: "LIVE"
-        case .connecting: "CONNECTING"
-        case .reconnecting: "RECONNECTING"
-        case .failed: "ERROR"
-        case .disconnected: "OFFLINE"
         }
     }
 }

--- a/AgentBoardMobile/AgentBoardMobileApp.swift
+++ b/AgentBoardMobile/AgentBoardMobileApp.swift
@@ -32,7 +32,6 @@ struct AgentBoardMobileApp: App {
 
     private func applyTheme(_ designTheme: AgentBoardDesignTheme) {
         NeuPalette.apply(designTheme)
-        MobileRootView.applyTabBarAppearance(designTheme)
         appliedTheme = designTheme
     }
 

--- a/AgentBoardMobile/MobileRootView.swift
+++ b/AgentBoardMobile/MobileRootView.swift
@@ -2,86 +2,61 @@ import AgentBoardCore
 import SwiftUI
 
 struct MobileRootView: View {
-    @Environment(AgentBoardAppModel.self) private var appModel
-
-    init() {
-        Self.applyTabBarAppearance(.blue)
-    }
-
-    static func applyTabBarAppearance(_ designTheme: AgentBoardDesignTheme) {
-        let backgroundColor: UIColor
-        let selectedColor: UIColor
-        switch designTheme {
-        case .blue:
-            backgroundColor = UIColor(red: 0.086, green: 0.110, blue: 0.153, alpha: 1.0)
-            selectedColor = UIColor(red: 0.310, green: 0.851, blue: 0.773, alpha: 1.0)
-        case .grey:
-            backgroundColor = UIColor(red: 0.169, green: 0.180, blue: 0.196, alpha: 1.0)
-            selectedColor = UIColor(red: 0.910, green: 0.647, blue: 0.455, alpha: 1.0)
-        }
-
-        let appearance = UITabBarAppearance()
-        appearance.configureWithOpaqueBackground()
-        appearance.backgroundColor = backgroundColor
-
-        appearance.stackedLayoutAppearance.normal.iconColor = UIColor(red: 0.494, green: 0.522, blue: 0.584, alpha: 1.0)
-        appearance.stackedLayoutAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor(
-            red: 0.494,
-            green: 0.522,
-            blue: 0.584,
-            alpha: 1.0
-        )]
-
-        appearance.stackedLayoutAppearance.selected.iconColor = selectedColor
-        appearance.stackedLayoutAppearance.selected.titleTextAttributes = [.foregroundColor: selectedColor]
-
-        UITabBar.appearance().standardAppearance = appearance
-        UITabBar.appearance().scrollEdgeAppearance = appearance
-    }
+    @State private var selectedDestination: AppDestination = .chat
 
     var body: some View {
-        TabView {
+        TabView(selection: $selectedDestination) {
             NavigationStack {
                 ChatScreen()
+                    .navigationTitle(AppDestination.chat.title)
             }
             .tabItem {
                 Label(AppDestination.chat.title, systemImage: AppDestination.chat.systemImage)
             }
+            .tag(AppDestination.chat)
             .accessibilityIdentifier("mobile_tab_chat")
 
             NavigationStack {
                 WorkScreen()
+                    .navigationTitle(AppDestination.work.title)
             }
             .tabItem {
                 Label(AppDestination.work.title, systemImage: AppDestination.work.systemImage)
             }
+            .tag(AppDestination.work)
             .accessibilityIdentifier("mobile_tab_work")
 
             NavigationStack {
                 AgentsScreen()
+                    .navigationTitle(AppDestination.agents.title)
             }
             .tabItem {
                 Label(AppDestination.agents.title, systemImage: AppDestination.agents.systemImage)
             }
+            .tag(AppDestination.agents)
             .accessibilityIdentifier("mobile_tab_agents")
 
             NavigationStack {
                 SessionsScreen()
+                    .navigationTitle(AppDestination.sessions.title)
             }
             .tabItem {
                 Label(AppDestination.sessions.title, systemImage: AppDestination.sessions.systemImage)
             }
+            .tag(AppDestination.sessions)
             .accessibilityIdentifier("mobile_tab_sessions")
 
             NavigationStack {
                 SettingsScreen()
+                    .navigationTitle(AppDestination.settings.title)
             }
             .tabItem {
                 Label(AppDestination.settings.title, systemImage: AppDestination.settings.systemImage)
             }
+            .tag(AppDestination.settings)
             .accessibilityIdentifier("mobile_tab_settings")
         }
-        .tint(NeuPalette.accentCyan)
+        .tint(.accentColor)
         .accessibilityIdentifier("screen_mobileRoot")
     }
 }

--- a/AgentBoardTests/NativeSwiftUIInterfaceTests.swift
+++ b/AgentBoardTests/NativeSwiftUIInterfaceTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+
+struct NativeSwiftUIInterfaceTests {
+    @Test func macShellUsesNativeSplitViewToolbarAndInspector() throws {
+        let source = try Self.source("AgentBoard/DesktopRootView.swift")
+
+        #expect(source.contains("NavigationSplitView"))
+        #expect(source.contains(".toolbar"))
+        #expect(source.contains(".inspector("))
+        #expect(!source.contains("NeuBackground()"))
+        #expect(!source.contains("isChatOnlyMode"))
+    }
+
+    @Test func desktopSidebarUsesNativeListSections() throws {
+        let source = try Self.source("AgentBoardUI/Components/DesktopSidebar.swift")
+
+        #expect(source.contains("List(selection:"))
+        #expect(source.contains(".listStyle(.sidebar)"))
+        #expect(source.contains("Section(\"Views\")"))
+        #expect(source.contains("Section(\"Projects\")"))
+        #expect(source.contains("Section(\"Live Sessions\")"))
+        #expect(!source.contains("LinearGradient"))
+        #expect(!source.contains("NeuPalette"))
+    }
+
+    @Test func iosRootUsesNativeTabViewWithoutUIKitAppearanceOverrides() throws {
+        let rootSource = try Self.source("AgentBoardMobile/MobileRootView.swift")
+        let appSource = try Self.source("AgentBoardMobile/AgentBoardMobileApp.swift")
+
+        #expect(rootSource.contains("TabView(selection:"))
+        #expect(rootSource.contains(".tag(AppDestination.chat)"))
+        #expect(rootSource.contains(".tag(AppDestination.settings)"))
+        #expect(!rootSource.contains("UITabBarAppearance"))
+        #expect(!rootSource.contains("UITabBar.appearance()"))
+        #expect(!appSource.contains("applyTabBarAppearance"))
+    }
+
+    private static func source(_ relativePath: String) throws -> String {
+        try String(contentsOf: repositoryRoot.appending(path: relativePath), encoding: .utf8)
+    }
+
+    private static var repositoryRoot: URL {
+        var directory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+
+        while directory.path != "/" {
+            if FileManager.default.fileExists(atPath: directory.appending(path: "project.yml").path) {
+                return directory
+            }
+            directory.deleteLastPathComponent()
+        }
+
+        Issue.record("Unable to locate repository root from \(#filePath)")
+        return URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+    }
+}

--- a/AgentBoardUI/Components/DesktopSidebar.swift
+++ b/AgentBoardUI/Components/DesktopSidebar.swift
@@ -168,7 +168,7 @@ struct DesktopSidebar: View {
 
     private func projectColor(_ shortName: String) -> Color {
         let colors: [Color] = [.blue, .orange, .purple]
-        let index = abs(shortName.hashValue) % colors.count
+        let index = Int(shortName.hashValue.magnitude % UInt(colors.count))
         return colors[index]
     }
 

--- a/AgentBoardUI/Components/DesktopSidebar.swift
+++ b/AgentBoardUI/Components/DesktopSidebar.swift
@@ -3,164 +3,82 @@ import SwiftUI
 
 struct DesktopSidebar: View {
     @Environment(AgentBoardAppModel.self) private var appModel
-    let activeTab: DesktopTab?
-    let onTabSelect: (DesktopTab) -> Void
+    @Binding var selection: DesktopTab?
     let onSessionTap: (SessionLauncher.ActiveSession) -> Void
     let onQuickLaunch: () -> Void
 
     var body: some View {
-        ZStack {
-            LinearGradient(
-                colors: [
-                    NeuPalette.surface,
-                    NeuPalette.inset
-                ],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-
-            ScrollView {
-                VStack(alignment: .leading, spacing: 18) {
-                    viewsSection
-                    projectsSection
-                    liveSessionsSection
+        List(selection: $selection) {
+            Section("Views") {
+                ForEach(DesktopTab.allCases) { tab in
+                    tabRow(tab)
+                        .tag(tab)
+                        .accessibilityIdentifier("desktop_sidebar_tab_\(tab.rawValue)")
                 }
-                .padding(.horizontal, 10)
-                .padding(.vertical, 14)
             }
-        }
-        .overlay(alignment: .trailing) {
-            Rectangle()
-                .fill(NeuPalette.borderSoft)
-                .frame(width: 1)
-        }
-    }
 
-    // MARK: - Views Section
-
-    private var viewsSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            sidebarHeader("VIEWS")
-
-            ForEach(DesktopTab.allCases) { tab in
-                Button {
-                    onTabSelect(tab)
-                } label: {
-                    HStack(spacing: 10) {
-                        Image(systemName: tab.systemImage)
-                            .font(.system(size: 14, weight: .semibold))
-                            .frame(width: 18)
-                        Text(tab.title)
-                            .font(.system(size: 12.5, weight: .semibold))
-                        Spacer()
-                        if let count = tabCount(tab) {
-                            Text("\(count)")
-                                .font(.system(size: 10, weight: .medium, design: .monospaced))
-                                .foregroundStyle(NeuPalette.textTertiary)
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 2)
-                                .background(NeuPalette.inset)
-                                .clipShape(Capsule())
+            Section("Projects") {
+                if appModel.settingsStore.repositories.isEmpty {
+                    Text("No repositories")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(appModel.settingsStore.repositories) { repo in
+                        Label {
+                            HStack {
+                                Text(repo.shortName)
+                                Spacer()
+                                Text("\(itemsCount(for: repo))")
+                                    .foregroundStyle(.secondary)
+                                    .monospacedDigit()
+                            }
+                        } icon: {
+                            Image(systemName: "folder")
+                                .foregroundStyle(projectColor(repo.shortName))
                         }
                     }
-                    .foregroundStyle(activeTab == tab ? NeuPalette.accentCyanBright : NeuPalette
-                        .textSecondary)
-                    .padding(.horizontal, 11)
-                    .padding(.vertical, 7)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .fill(activeTab == tab ? NeuPalette.accentCyan.opacity(0.12) : .clear)
-                            .overlay {
-                                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                    .stroke(
-                                        activeTab == tab ? NeuPalette.accentCyan.opacity(0.25) : .clear,
-                                        lineWidth: 1
-                                    )
-                            }
-                    )
-                }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("desktop_sidebar_tab_\(tab.rawValue)")
-            }
-        }
-    }
-
-    // MARK: - Projects Section
-
-    private var projectsSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            sidebarHeader("PROJECTS")
-
-            if appModel.settingsStore.repositories.isEmpty {
-                Text("No repositories")
-                    .font(.caption)
-                    .foregroundStyle(NeuPalette.textSecondary)
-                    .padding(.horizontal, 8)
-            } else {
-                ForEach(appModel.settingsStore.repositories) { repo in
-                    HStack(spacing: 10) {
-                        RoundedRectangle(cornerRadius: 4, style: .continuous)
-                            .fill(projectColor(repo.shortName))
-                            .frame(width: 14, height: 14)
-                            .shadow(color: projectColor(repo.shortName).opacity(0.45), radius: 8)
-                        Text(repo.shortName)
-                            .font(.system(size: 12, weight: .medium, design: .monospaced))
-                            .foregroundStyle(NeuPalette.textSecondary)
-                        Spacer()
-                        Text("\(itemsCount(for: repo))")
-                            .font(.system(size: 10, weight: .medium, design: .monospaced))
-                            .foregroundStyle(NeuPalette.textTertiary)
-                    }
-                    .padding(.horizontal, 11)
-                    .padding(.vertical, 6)
                 }
             }
-        }
-    }
 
-    // MARK: - Live Sessions Section
-
-    private var liveSessionsSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                sidebarHeader("LIVE SESSIONS")
-                Spacer()
+            Section("Live Sessions") {
                 Button {
                     onQuickLaunch()
                 } label: {
-                    Image(systemName: "plus")
-                        .font(.system(size: 10, weight: .bold))
-                        .foregroundStyle(NeuPalette.textTertiary)
+                    Label("Quick Launch", systemImage: "plus")
                 }
-                .buttonStyle(.plain)
                 .accessibilityIdentifier("sidebar_quick_launch")
-            }
 
-            if allSidebarSessions.isEmpty && companionSessionsNotInLocal.isEmpty {
-                Text("No active sessions")
-                    .font(.caption)
-                    .foregroundStyle(NeuPalette.textSecondary)
-                    .padding(.horizontal, 8)
-            } else {
-                ForEach(allSidebarSessions) { session in
-                    Button {
-                        onSessionTap(session)
-                    } label: {
-                        locallyLaunchedSessionRow(session)
+                if allSidebarSessions.isEmpty && companionSessionsNotInLocal.isEmpty {
+                    Text("No active sessions")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(allSidebarSessions) { session in
+                        Button {
+                            onSessionTap(session)
+                        } label: {
+                            locallyLaunchedSessionRow(session)
+                        }
+                        .accessibilityIdentifier("sidebar_session_\(session.id)")
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityIdentifier("sidebar_session_\(session.id)")
-                }
 
-                ForEach(companionSessionsNotInLocal) { session in
-                    companionSessionRow(session)
-                        .accessibilityIdentifier("sidebar_companion_session_\(session.id)")
+                    ForEach(companionSessionsNotInLocal) { session in
+                        companionSessionRow(session)
+                            .accessibilityIdentifier("sidebar_companion_session_\(session.id)")
+                    }
                 }
             }
         }
+        .listStyle(.sidebar)
     }
 
-    // MARK: - Helpers
+    @ViewBuilder
+    private func tabRow(_ tab: DesktopTab) -> some View {
+        if let count = tabCount(tab) {
+            Label(tab.title, systemImage: tab.systemImage)
+                .badge(count)
+        } else {
+            Label(tab.title, systemImage: tab.systemImage)
+        }
+    }
 
     private var allSidebarSessions: [SessionLauncher.ActiveSession] {
         appModel.sessionLauncher.activeSessions
@@ -175,89 +93,68 @@ struct DesktopSidebar: View {
     }
 
     private func locallyLaunchedSessionRow(_ session: SessionLauncher.ActiveSession) -> some View {
-        VStack(alignment: .leading, spacing: 3) {
-            HStack(spacing: 7) {
-                Circle()
-                    .fill(localSessionStatusColor(session.status))
-                    .frame(width: 6, height: 6)
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
                 Text(session.agentType.displayName)
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(NeuPalette.accentOrange)
                     .lineLimit(1)
-                Spacer()
-                Text(session.status == .running ? "RUNNING" : session.status.description.uppercased())
-                    .font(.system(size: 9.5, weight: .semibold, design: .monospaced))
-                    .tracking(0.8)
-                    .foregroundStyle(NeuPalette.textTertiary)
-            }
-            HStack(spacing: 6) {
-                Text("#\(session.issueNumber)")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(NeuPalette.accentCyan)
-                Text(session.preset.rawValue)
-                    .font(.system(size: 10))
-                    .foregroundStyle(NeuPalette.textTertiary)
+                Text("#\(session.issueNumber) \(session.preset.rawValue)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
-            .padding(.leading, 13)
+        } icon: {
+            Image(systemName: session.status == .running ? "play.circle.fill" : "circle")
+                .foregroundStyle(localSessionStatusColor(session.status))
         }
-        .padding(.horizontal, 11)
-        .padding(.vertical, 8)
     }
 
     private func companionSessionRow(_ session: AgentSession) -> some View {
-        VStack(alignment: .leading, spacing: 3) {
-            HStack(spacing: 7) {
-                Circle()
-                    .fill(companionStatusColor(session.status))
-                    .frame(width: 6, height: 6)
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
                 Text(session.source)
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(NeuPalette.accentOrange)
                     .lineLimit(1)
-                Spacer()
-                Text(session.status.title.uppercased())
-                    .font(.system(size: 9.5, weight: .semibold, design: .monospaced))
-                    .tracking(0.8)
-                    .foregroundStyle(NeuPalette.textTertiary)
+                if let item = session.workItem {
+                    Text(item.issueReference)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                } else {
+                    Text(session.status.title)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
-            if let item = session.workItem {
-                Text(item.issueReference)
-                    .font(.system(size: 11))
-                    .foregroundStyle(NeuPalette.textTertiary)
-                    .lineLimit(1)
-                    .padding(.leading, 13)
-            }
+        } icon: {
+            Image(systemName: companionStatusImage(session.status))
+                .foregroundStyle(companionStatusColor(session.status))
         }
-        .padding(.horizontal, 11)
-        .padding(.vertical, 8)
     }
 
     private func localSessionStatusColor(_ status: SessionLauncher.ActiveSession.SessionStatus) -> Color {
         switch status {
-        case .running: NeuPalette.statusSuccess
-        case .completed: NeuPalette.statusClosed
+        case .running: .green
+        case .completed: .secondary
         case .failed: .red
-        case .stalled: NeuPalette.accentOrange
+        case .stalled: .orange
+        }
+    }
+
+    private func companionStatusImage(_ status: AgentSessionStatus) -> String {
+        switch status {
+        case .running: "play.circle.fill"
+        case .idle: "pause.circle"
+        case .stopped: "stop.circle"
+        case .error: "exclamationmark.triangle.fill"
         }
     }
 
     private func companionStatusColor(_ status: AgentSessionStatus) -> Color {
         switch status {
-        case .running: NeuPalette.statusSuccess
-        case .idle: NeuPalette.statusIdle
-        case .stopped: NeuPalette.textSecondary
+        case .running: .green
+        case .idle: .blue
+        case .stopped: .secondary
         case .error: .red
         }
-    }
-
-    private func sidebarHeader(_ label: String) -> some View {
-        Text(label)
-            .font(.system(size: 9.5, weight: .semibold, design: .monospaced))
-            .tracking(1.6)
-            .foregroundStyle(NeuPalette.textDisabled)
-            .padding(.horizontal, 11)
-            .padding(.bottom, 2)
     }
 
     private func tabCount(_ tab: DesktopTab) -> Int? {
@@ -270,7 +167,7 @@ struct DesktopSidebar: View {
     }
 
     private func projectColor(_ shortName: String) -> Color {
-        let colors = [NeuPalette.accentCyan, NeuPalette.accentOrange, NeuPalette.accentPurple]
+        let colors: [Color] = [.blue, .orange, .purple]
         let index = abs(shortName.hashValue) % colors.count
         return colors[index]
     }

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -179,4 +179,19 @@ Agents → CompanionServer → FSEvents + ps
 
 ---
 
+## ADR-013: Native SwiftUI app shell controls
+**Date:** 2026-05-23
+**Status:** Active
+**Decision:** Use platform-native SwiftUI shell controls for the macOS and iOS apps, and reserve bespoke styling for feature content rather than the app frame.
+
+**Context:** The Hermes-first rebuild shipped with a heavily custom app shell: manual desktop sidebars, custom tab buttons, UIKit tab-bar appearance overrides, and hidden macOS title-bar behavior. That visual direction made the app feel less native on both macOS and iOS and made shell-level regression coverage hard to state.
+
+**Consequences:**
+- `AgentBoard` uses `NavigationSplitView`, a source-list `List`, SwiftUI toolbar actions, and an inspector-style chat panel.
+- `AgentBoardMobile` uses tagged SwiftUI `TabView(selection:)` navigation and no UIKit tab-bar appearance override.
+- macOS keeps standard window chrome instead of hiding the title bar.
+- `NativeSwiftUIInterfaceTests` guards the shell-level native SwiftUI contracts.
+
+---
+
 *To add a new ADR: append with the next number, include date, status, decision, context, and consequences.*

--- a/docs/superpowers/plans/2026-05-23-native-swiftui-interface-elements.md
+++ b/docs/superpowers/plans/2026-05-23-native-swiftui-interface-elements.md
@@ -1,0 +1,198 @@
+# Native SwiftUI Interface Elements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the AgentBoard macOS and iOS app shells to native SwiftUI interface elements while keeping the existing Hermes-first screens and stores intact.
+
+**Architecture:** Replace bespoke app chrome at the shell boundary, not the product data layer. macOS moves to `NavigationSplitView`, source-list `List` sections, toolbar actions, and an inspector chat panel; iOS keeps `TabView` and `NavigationStack` but removes UIKit tab-bar appearance overrides. Source-level Swift Testing coverage guards the intended native SwiftUI shell choices.
+
+**Tech Stack:** Swift 6, SwiftUI, Swift Testing, XcodeGen-managed Xcode project, GitHub Issues #97-#100.
+
+---
+
+## File Structure
+
+- Modify: `AgentBoard/DesktopRootView.swift` - owns the macOS native split-view shell, toolbar actions, quick-launch sheet, terminal-detail routing, and chat inspector visibility.
+- Modify: `AgentBoardUI/Components/DesktopSidebar.swift` - replaces the custom gradient sidebar with a native source-list `List(selection:)` organized into SwiftUI `Section`s.
+- Modify: `AgentBoard/AgentBoardApp.swift` - removes custom title-bar hiding so the window keeps native macOS chrome.
+- Modify: `AgentBoardMobile/MobileRootView.swift` - removes UIKit tab-bar appearance work and adds a tagged SwiftUI `TabView(selection:)`.
+- Modify: `AgentBoardMobile/AgentBoardMobileApp.swift` - stops calling the removed UIKit appearance hook.
+- Create: `AgentBoardTests/NativeSwiftUIInterfaceTests.swift` - source-level regression tests for the native shell contracts.
+- Modify: `docs/ADR.md` - records the native SwiftUI shell decision.
+- Modify: `AGENTS.md` - adds the session activity entry after the work lands.
+
+## GitHub Tickets
+
+- #97 Convert AgentBoard to native SwiftUI interface elements
+- #98 Use native SwiftUI navigation for the macOS shell
+- #99 Use native SwiftUI tab navigation for iOS
+- #100 Guard native SwiftUI shell with tests and docs
+
+### Task 1: Add Native Shell Regression Tests
+
+**Files:**
+- Create: `AgentBoardTests/NativeSwiftUIInterfaceTests.swift`
+
+- [x] **Step 1: Write the failing tests**
+
+```swift
+import Foundation
+import Testing
+
+struct NativeSwiftUIInterfaceTests {
+    @Test func macShellUsesNativeSplitViewToolbarAndInspector() throws {
+        let source = try Self.source("AgentBoard/DesktopRootView.swift")
+
+        #expect(source.contains("NavigationSplitView"))
+        #expect(source.contains(".toolbar"))
+        #expect(source.contains(".inspector("))
+        #expect(!source.contains("NeuBackground()"))
+        #expect(!source.contains("isChatOnlyMode"))
+    }
+
+    @Test func desktopSidebarUsesNativeListSections() throws {
+        let source = try Self.source("AgentBoardUI/Components/DesktopSidebar.swift")
+
+        #expect(source.contains("List(selection:"))
+        #expect(source.contains(".listStyle(.sidebar)"))
+        #expect(source.contains("Section(\"Views\")"))
+        #expect(source.contains("Section(\"Projects\")"))
+        #expect(source.contains("Section(\"Live Sessions\")"))
+        #expect(!source.contains("LinearGradient"))
+        #expect(!source.contains("NeuPalette"))
+    }
+
+    @Test func iosRootUsesNativeTabViewWithoutUIKitAppearanceOverrides() throws {
+        let rootSource = try Self.source("AgentBoardMobile/MobileRootView.swift")
+        let appSource = try Self.source("AgentBoardMobile/AgentBoardMobileApp.swift")
+
+        #expect(rootSource.contains("TabView(selection:"))
+        #expect(rootSource.contains(".tag(AppDestination.chat)"))
+        #expect(rootSource.contains(".tag(AppDestination.settings)"))
+        #expect(!rootSource.contains("UITabBarAppearance"))
+        #expect(!rootSource.contains("UITabBar.appearance()"))
+        #expect(!appSource.contains("applyTabBarAppearance"))
+    }
+
+    private static func source(_ relativePath: String) throws -> String {
+        try String(contentsOf: repositoryRoot.appending(path: relativePath), encoding: .utf8)
+    }
+
+    private static var repositoryRoot: URL {
+        var directory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+
+        while directory.path != "/" {
+            if FileManager.default.fileExists(atPath: directory.appending(path: "project.yml").path) {
+                return directory
+            }
+            directory.deleteLastPathComponent()
+        }
+
+        Issue.record("Unable to locate repository root from \\(#filePath)")
+        return URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+    }
+}
+```
+
+- [x] **Step 2: Run the focused test and verify red**
+
+Run:
+
+```bash
+xcodebuild test -project AgentBoard.xcodeproj -scheme AgentBoard -destination 'platform=macOS' -only-testing:AgentBoardTests/NativeSwiftUIInterfaceTests CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: FAIL because the current desktop shell still uses custom chrome and the iOS root still contains `UITabBarAppearance`.
+
+### Task 2: Convert The macOS Shell To Native SwiftUI Navigation
+
+**Files:**
+- Modify: `AgentBoard/DesktopRootView.swift`
+- Modify: `AgentBoardUI/Components/DesktopSidebar.swift`
+- Modify: `AgentBoard/AgentBoardApp.swift`
+
+- [x] **Step 1: Implement the native macOS shell**
+
+Replace the manual root `HStack`, hidden-titlebar behavior, and custom desktop sidebar with:
+
+- `NavigationSplitView(columnVisibility:)` in `DesktopRootView`.
+- `DesktopSidebar(selection:onSessionTap:onQuickLaunch:)` as the sidebar column.
+- Detail content in the split-view detail column.
+- `.toolbar` actions for quick launch and chat visibility.
+- `.inspector(isPresented:)` hosting `ChatScreen`.
+- Native `List(selection:)`, `Section`, `Label`, and `.badge` in `DesktopSidebar`.
+
+- [x] **Step 2: Run the focused native shell test**
+
+Run:
+
+```bash
+xcodebuild test -project AgentBoard.xcodeproj -scheme AgentBoard -destination 'platform=macOS' -only-testing:AgentBoardTests/NativeSwiftUIInterfaceTests CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: macOS assertions pass; iOS root assertions still fail until Task 3.
+
+### Task 3: Convert The iOS Shell To Native SwiftUI Tabs
+
+**Files:**
+- Modify: `AgentBoardMobile/MobileRootView.swift`
+- Modify: `AgentBoardMobile/AgentBoardMobileApp.swift`
+
+- [x] **Step 1: Remove UIKit tab-bar styling**
+
+Delete `MobileRootView.applyTabBarAppearance(_:)`, remove the custom `init`, and stop calling that hook from `AgentBoardMobileApp.applyTheme(_:)`.
+
+- [x] **Step 2: Add stable native tab selection**
+
+Use `@State private var selectedDestination: AppDestination = .chat` and `TabView(selection: $selectedDestination)`, keeping each destination wrapped in its existing `NavigationStack`, `.tabItem`, `.tag(AppDestination.<case>)`, and accessibility identifier.
+
+- [x] **Step 3: Run the focused native shell test**
+
+Run:
+
+```bash
+xcodebuild test -project AgentBoard.xcodeproj -scheme AgentBoard -destination 'platform=macOS' -only-testing:AgentBoardTests/NativeSwiftUIInterfaceTests CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: PASS.
+
+### Task 4: Document And Verify The Conversion
+
+**Files:**
+- Modify: `docs/ADR.md`
+- Modify: `AGENTS.md`
+
+- [x] **Step 1: Record the decision**
+
+Add an ADR entry explaining that AgentBoard app shells use platform-native SwiftUI navigation controls and reserve custom visual styling for feature content.
+
+- [x] **Step 2: Add activity context**
+
+Add a 2026-05-23 activity entry to `AGENTS.md` with the issue numbers and summary of the native shell migration.
+
+- [x] **Step 3: Run quality gates**
+
+Run:
+
+```bash
+swiftlint lint --strict
+xcodebuild test -project AgentBoard.xcodeproj -scheme AgentBoard -destination 'platform=macOS' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+xcodebuild -project AgentBoard.xcodeproj -scheme AgentBoard -destination 'platform=macOS' build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+xcodebuild -project AgentBoard.xcodeproj -scheme AgentBoardMobile -destination 'generic/platform=iOS Simulator' build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+xcodebuild -project AgentBoard.xcodeproj -scheme AgentBoardCompanion -destination 'platform=macOS' build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: all commands exit 0. If any Xcode command stalls without producing build output, record it as unverified rather than treating it as success.
+
+- [ ] **Step 4: Commit, push, and update GitHub**
+
+Run:
+
+```bash
+git status --short
+git add AgentBoard/DesktopRootView.swift AgentBoard/AgentBoardApp.swift AgentBoardMobile/MobileRootView.swift AgentBoardMobile/AgentBoardMobileApp.swift AgentBoardUI/Components/DesktopSidebar.swift AgentBoardTests/NativeSwiftUIInterfaceTests.swift docs/ADR.md AGENTS.md docs/superpowers/plans/2026-05-23-native-swiftui-interface-elements.md
+git commit -m "feat: use native SwiftUI app shells"
+git push -u origin codex/native-swiftui-elements
+```
+
+Then close #98, #99, and #100 with verification notes, and update #97 with the branch and completion summary.


### PR DESCRIPTION
## Summary
- Convert the macOS shell to native SwiftUI structure with `NavigationSplitView`, a source-list sidebar, toolbar actions, and a chat inspector.
- Remove custom iOS `UITabBarAppearance` styling and use tagged SwiftUI `TabView(selection:)` navigation.
- Add `NativeSwiftUIInterfaceTests`, a Superpowers implementation plan, and ADR-013 documentation.

## Test Plan
- `swiftlint lint --strict`
- `xcodebuild test -project AgentBoard.xcodeproj -scheme AgentBoard -destination 'platform=macOS' -test-timeouts-enabled YES -maximum-test-execution-time-allowance 120 CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild -project AgentBoard.xcodeproj -scheme AgentBoard -destination 'platform=macOS' build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild -project AgentBoard.xcodeproj -scheme AgentBoardMobile -destination 'generic/platform=iOS Simulator' build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild -project AgentBoard.xcodeproj -scheme AgentBoardCompanion -destination 'platform=macOS' build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`

Closes #97.
Closes #98.
Closes #99.
Closes #100.
