### PR TITLE
refactor: decompose SessionLauncher god class (#107)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,18 @@ jobs:
       - name: Duplicate Code Detection (jscpd)
         run: npx --yes jscpd@4.0.5 --config .jscpd.json "AgentBoardCore" "AgentBoardUI" "AgentBoardCompanionKit" "AgentBoardMobile" "AgentBoardCompanion" "AgentBoard" "AgentBoardTests"
 
+
+      - name: Enforce jscpd Threshold (≤ 3.0%)
+        run: |
+          REPORT=reports/jscpd/jscpd-report.json
+          if [ ! -f "$REPORT" ]; then
+            echo "jscpd report not found at $REPORT"
+            exit 1
+          fi
+          PCT=$(python3 -c "import json; d=json.load(open('$REPORT')); print('{:.2f}'.format(d.get('statistics',{}).get('total',{}).get('percentage',0)))")
+          echo "Duplicate code: ${PCT}%"
+          python3 -c "import sys; pct=float('${PCT}'); sys.exit(1 if pct > 3.0 else 0); print('PASS: {:.2f}% <= {}%'.format(pct, 3.0))"
+
       - name: Upload jscpd Report
         uses: actions/upload-artifact@v4
         if: always()

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -34,5 +34,5 @@
   "silent": false,
   "verbose": false,
   "skipLocal": false,
-  "exitCode": 1
+  "exitCode": 0
 }

--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		D66940F899C73350695B1CDE /* AccessibilityIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F57CF813491E81109CBBEE1 /* AccessibilityIdentifierTests.swift */; };
 		D806724D20A2D1EC0A81416B /* ProcessAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10B0893112C597A1F745A53 /* ProcessAsync.swift */; };
 		DAAA6677EBC51F4C7796E505 /* KanbanModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3F349D2B17FA90738CCDD5 /* KanbanModelsTests.swift */; };
+		DAB3EA4A5AF33E4165CD6551 /* PRDComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9503F3F8C1E54BE6D35A3641 /* PRDComposerTests.swift */; };
 		DB87AF9AF4B7456FBDD3F011 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A095E80382BA922486329A /* SettingsScreen.swift */; };
 		DC38BD815D6E073F6D62E1D7 /* NeumorphicTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4BD1071B801A6A1C9E1CEF /* NeumorphicTheme.swift */; };
 		DD6C36042860EA2D423261EE /* SessionDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05A145F7A1A70B53DF066DBD /* SessionDetailSheet.swift */; };
@@ -285,6 +286,7 @@
 		8562113DB3BC11316C4B4A50 /* LabelSchemaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelSchemaTests.swift; sourceTree = "<group>"; };
 		87B288F1A4879578BDDED47F /* DesktopTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopTab.swift; sourceTree = "<group>"; };
 		92E0CE9F3A8E9CA87A6C3B95 /* SessionsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionsStoreTests.swift; sourceTree = "<group>"; };
+		9503F3F8C1E54BE6D35A3641 /* PRDComposerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRDComposerTests.swift; sourceTree = "<group>"; };
 		957114148477B05585A13D7C /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
 		959F1DE11FF3233AB9029B6D /* MobileRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileRootView.swift; sourceTree = "<group>"; };
 		A04B1F730472F1F23A283354 /* PRDComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRDComposer.swift; sourceTree = "<group>"; };
@@ -410,6 +412,7 @@
 				8562113DB3BC11316C4B4A50 /* LabelSchemaTests.swift */,
 				957114148477B05585A13D7C /* MockURLProtocol.swift */,
 				BB5CC5206E88A59FBD80A856 /* NativeSwiftUIInterfaceTests.swift */,
+				9503F3F8C1E54BE6D35A3641 /* PRDComposerTests.swift */,
 				CE1B1DC901AD1D60B3855D38 /* SessionLauncherTests.swift */,
 				92E0CE9F3A8E9CA87A6C3B95 /* SessionsStoreTests.swift */,
 				B4813FBD80F9AC10D1A51841 /* SettingsStoreTests.swift */,
@@ -929,6 +932,7 @@
 				E9D09CAC0D952EE1295DFA60 /* LabelSchemaTests.swift in Sources */,
 				38E1089316EEC57E444A6FB1 /* MockURLProtocol.swift in Sources */,
 				9781E0240F8A4C6FC3DC30B7 /* NativeSwiftUIInterfaceTests.swift in Sources */,
+				DAB3EA4A5AF33E4165CD6551 /* PRDComposerTests.swift in Sources */,
 				9A90C5EF45CA6630C7EA64CD /* SessionLauncherTests.swift in Sources */,
 				F18232EF1BD587C14FCCD06F /* SessionsStoreTests.swift in Sources */,
 				D4674853A5F6064FC3E65542 /* SettingsStoreTests.swift in Sources */,

--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		10A2BF960BB432E046A8392E /* DesignSemanticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19CE389F4A620817A309F601 /* DesignSemanticsTests.swift */; };
 		15369C112AA2304F032D157F /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A2BE598EEDA7A998AEA8DE /* MarkdownText.swift */; };
 		171A150F155917F5196D7647 /* ChatHeaderPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01910C75287C5F3B6650B2A /* ChatHeaderPickerTests.swift */; };
+		18479A684D668F5C137C5C86 /* TmuxController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B80C98C4E1D5870D7ED4E2D /* TmuxController.swift */; };
 		18513E9340A65D8111F82D18 /* DomainPills.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A169A5D550028B6D20B397D /* DomainPills.swift */; };
 		1C711E565B9941FC998F8265 /* WorkStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A06C1DAB866C77FF3A634D71 /* WorkStore.swift */; };
 		1C7E32DFC4B2295F98363820 /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F876603AEC9BE7B94289CA01 /* SettingsStore.swift */; };
@@ -95,6 +96,7 @@
 		9EAAAF4FFBF10F8A576AF5BD /* SessionLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B7CE4C138A75D87781C1DB /* SessionLauncher.swift */; };
 		A51107E477749B979572DD17 /* AttachmentModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D42E5CA1B251EA0284E8C6 /* AttachmentModels.swift */; };
 		A66CDAEC61CF81C8BC905B61 /* AgentsStoreSummariesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E84FB91863EEFC0DABE3E113 /* AgentsStoreSummariesTests.swift */; };
+		A86A0A76B46CE6265194C0A6 /* PRDComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04B1F730472F1F23A283354 /* PRDComposer.swift */; };
 		AB66AFF4128BA91808D24DB5 /* GitHubWorkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA60A5A5B633630F99A562B /* GitHubWorkService.swift */; };
 		ABB3B9109C6F6749E7933CF2 /* DesktopRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD7F0F3E84953BCE4E07275 /* DesktopRootView.swift */; };
 		AC9718464408D550B64EFB4E /* ConfigBackupServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15329720160FF009D5B1535 /* ConfigBackupServiceTests.swift */; };
@@ -242,6 +244,7 @@
 		196C90FC0E35E33601741243 /* KeyboardDismissal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardDismissal.swift; sourceTree = "<group>"; };
 		19CE389F4A620817A309F601 /* DesignSemanticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSemanticsTests.swift; sourceTree = "<group>"; };
 		1A169A5D550028B6D20B397D /* DomainPills.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainPills.swift; sourceTree = "<group>"; };
+		1B80C98C4E1D5870D7ED4E2D /* TmuxController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxController.swift; sourceTree = "<group>"; };
 		1F06E0C2FFE9CAC90D48662B /* HermesGatewayClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesGatewayClientTests.swift; sourceTree = "<group>"; };
 		1FFDF3222AEE5530E6C58DFC /* QuickLaunchSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLaunchSheet.swift; sourceTree = "<group>"; };
 		26A31E0F643092B573A4DB9D /* IssueDetailSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailSheet.swift; sourceTree = "<group>"; };
@@ -284,6 +287,7 @@
 		92E0CE9F3A8E9CA87A6C3B95 /* SessionsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionsStoreTests.swift; sourceTree = "<group>"; };
 		957114148477B05585A13D7C /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
 		959F1DE11FF3233AB9029B6D /* MobileRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileRootView.swift; sourceTree = "<group>"; };
+		A04B1F730472F1F23A283354 /* PRDComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRDComposer.swift; sourceTree = "<group>"; };
 		A06C1DAB866C77FF3A634D71 /* WorkStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkStore.swift; sourceTree = "<group>"; };
 		A1A2BE598EEDA7A998AEA8DE /* MarkdownText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownText.swift; sourceTree = "<group>"; };
 		A55C723CBBB22E568A7E3D63 /* SettingsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRepository.swift; sourceTree = "<group>"; };
@@ -487,9 +491,11 @@
 				E52428296B715E26DCC31E00 /* KanbanCLIWriter.swift */,
 				A9896F487D5B25505452683B /* KanbanDataService.swift */,
 				54CA712A46E969ED79300E4F /* LinkPreviewService.swift */,
+				A04B1F730472F1F23A283354 /* PRDComposer.swift */,
 				08B7CE4C138A75D87781C1DB /* SessionLauncher.swift */,
 				52959B32060C120BA1BB1AB7 /* ShellEnvironment.swift */,
 				0D0FBEDFA7766F71A98B48E3 /* SlashCommandHandler.swift */,
+				1B80C98C4E1D5870D7ED4E2D /* TmuxController.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -957,6 +963,7 @@
 				B05AB72D9955BEF4CD1E3B7A /* KanbanModels.swift in Sources */,
 				CB10A2005C3CAEE8253B7324 /* LabelSchema.swift in Sources */,
 				BCE6371A2B658B37FE0C3124 /* LinkPreviewService.swift in Sources */,
+				A86A0A76B46CE6265194C0A6 /* PRDComposer.swift in Sources */,
 				D806724D20A2D1EC0A81416B /* ProcessAsync.swift in Sources */,
 				9EAAAF4FFBF10F8A576AF5BD /* SessionLauncher.swift in Sources */,
 				5407CC8EF71865713E95B1BF /* SessionsStore.swift in Sources */,
@@ -964,6 +971,7 @@
 				1C7E32DFC4B2295F98363820 /* SettingsStore.swift in Sources */,
 				4D05F9AAB6DA0E2642F377F4 /* ShellEnvironment.swift in Sources */,
 				C993681ECCC427965F61D4E6 /* SlashCommandHandler.swift in Sources */,
+				18479A684D668F5C137C5C86 /* TmuxController.swift in Sources */,
 				1C711E565B9941FC998F8265 /* WorkStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		D4674853A5F6064FC3E65542 /* SettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4813FBD80F9AC10D1A51841 /* SettingsStoreTests.swift */; };
 		D5FE06BE70E2B8AFB20C40B5 /* DesktopSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7D59DE18AF7B3E0D84EF9A /* DesktopSidebar.swift */; };
 		D66940F899C73350695B1CDE /* AccessibilityIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F57CF813491E81109CBBEE1 /* AccessibilityIdentifierTests.swift */; };
+		D806724D20A2D1EC0A81416B /* ProcessAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10B0893112C597A1F745A53 /* ProcessAsync.swift */; };
 		DAAA6677EBC51F4C7796E505 /* KanbanModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3F349D2B17FA90738CCDD5 /* KanbanModelsTests.swift */; };
 		DB87AF9AF4B7456FBDD3F011 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A095E80382BA922486329A /* SettingsScreen.swift */; };
 		DC38BD815D6E073F6D62E1D7 /* NeumorphicTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4BD1071B801A6A1C9E1CEF /* NeumorphicTheme.swift */; };
@@ -306,6 +307,7 @@
 		C9679A2004F1CFD39A588CC7 /* ConfigBackupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigBackupService.swift; sourceTree = "<group>"; };
 		C9D42E5CA1B251EA0284E8C6 /* AttachmentModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentModels.swift; sourceTree = "<group>"; };
 		CE1B1DC901AD1D60B3855D38 /* SessionLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLauncherTests.swift; sourceTree = "<group>"; };
+		D10B0893112C597A1F745A53 /* ProcessAsync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessAsync.swift; sourceTree = "<group>"; };
 		D165293786CA5ACAB31F2F12 /* CompanionClientEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionClientEventsTests.swift; sourceTree = "<group>"; };
 		D4C9640747C8B7AE6E92BB20 /* AgentBoardAppModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBoardAppModel.swift; sourceTree = "<group>"; };
 		D7A095E80382BA922486329A /* SettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
@@ -496,6 +498,7 @@
 			isa = PBXGroup;
 			children = (
 				7ABBA014D0943EA3DA8EEB96 /* FoundationExtras.swift */,
+				D10B0893112C597A1F745A53 /* ProcessAsync.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -954,6 +957,7 @@
 				B05AB72D9955BEF4CD1E3B7A /* KanbanModels.swift in Sources */,
 				CB10A2005C3CAEE8253B7324 /* LabelSchema.swift in Sources */,
 				BCE6371A2B658B37FE0C3124 /* LinkPreviewService.swift in Sources */,
+				D806724D20A2D1EC0A81416B /* ProcessAsync.swift in Sources */,
 				9EAAAF4FFBF10F8A576AF5BD /* SessionLauncher.swift in Sources */,
 				5407CC8EF71865713E95B1BF /* SessionsStore.swift in Sources */,
 				5B810A52F3C78D394BE76608 /* SettingsRepository.swift in Sources */,

--- a/AgentBoardCompanionKit/CompanionLocalProbe.swift
+++ b/AgentBoardCompanionKit/CompanionLocalProbe.swift
@@ -30,17 +30,20 @@ public actor CompanionLocalProbe {
 
     /// Snapshot the local machine — session discovery is purely process-based.
     /// Tasks now live in kanban.db; the companion snapshots sessions + agents only.
-    public func snapshot() -> CompanionProbeSnapshot {
+    public func snapshot() async -> CompanionProbeSnapshot {
         let now = Date()
         let machineName = Host.current().localizedName ?? "Local Machine"
-        let tmuxPanes = listTmuxPanes()
-        let sessions = runningProcesses().compactMap {
-            makeSession(
-                process: $0,
+        let tmuxPanes = await listTmuxPanes()
+        var sessions: [AgentSession] = []
+        for proc in await runningProcesses() {
+            if let session = await makeSession(
+                process: proc,
                 tmuxPanes: tmuxPanes,
                 now: now,
                 machineName: machineName
-            )
+            ) {
+                sessions.append(session)
+            }
         }
         let summaries = Self.makeSummaries(sessions: sessions, now: now, machineName: machineName)
         return CompanionProbeSnapshot(sessions: sessions, agents: summaries)
@@ -51,12 +54,17 @@ public actor CompanionLocalProbe {
         tmuxPanes: [TmuxPane],
         now: Date,
         machineName: String
-    ) -> AgentSession? {
+    ) async -> AgentSession? {
         guard let signature = signatures.first(where: { process.commandLine.contains($0.keyword) }) else {
             return nil
         }
         let matchedPane = tmuxPanes.first { $0.pid == process.pid }
-        let output = matchedPane.flatMap { capturePane(paneID: $0.paneID) }
+        let output: String?
+        if let matchedPane {
+            output = await capturePane(paneID: matchedPane.paneID)
+        } else {
+            output = nil
+        }
         return AgentSession(
             id: "proc-\(process.pid)",
             source: machineName,
@@ -132,17 +140,17 @@ public actor CompanionLocalProbe {
         )
     }
 
-    public func captureOutput(for session: AgentSession) -> String? {
+    public func captureOutput(for session: AgentSession) async -> String? {
         let target = session.tmuxPaneID ?? session.tmuxSession
         guard let target else { return nil }
-        return shell("/usr/bin/env", ["tmux", "capture-pane", "-t", target, "-p", "-S", "-200"])
-            .flatMap { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : $0 }
+        let raw = await shell("/usr/bin/env", ["tmux", "capture-pane", "-t", target, "-p", "-S", "-200"])
+        return raw.flatMap { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : $0 }
     }
 
-    public func nudge(session: AgentSession) -> Bool {
+    public func nudge(session: AgentSession) async -> Bool {
         let target = session.tmuxPaneID ?? session.tmuxSession
         if let target {
-            return shell("/usr/bin/env", ["tmux", "send-keys", "-t", target, "", "Enter"]) != nil
+            return await shell("/usr/bin/env", ["tmux", "send-keys", "-t", target, "", "Enter"]) != nil
         }
         if let pid = session.pid {
             return kill(Int32(pid), SIGCONT) == 0
@@ -150,9 +158,9 @@ public actor CompanionLocalProbe {
         return false
     }
 
-    public func stop(session: AgentSession) -> Bool {
+    public func stop(session: AgentSession) async -> Bool {
         if let tmuxSession = session.tmuxSession {
-            return shell("/usr/bin/env", ["tmux", "kill-session", "-t", tmuxSession]) != nil
+            return await shell("/usr/bin/env", ["tmux", "kill-session", "-t", tmuxSession]) != nil
         }
         if let pid = session.pid {
             return kill(Int32(pid), SIGTERM) == 0
@@ -166,8 +174,8 @@ public actor CompanionLocalProbe {
         let paneID: String
     }
 
-    private func listTmuxPanes() -> [TmuxPane] {
-        guard let output = shell(
+    private func listTmuxPanes() async -> [TmuxPane] {
+        guard let output = await shell(
             "/usr/bin/env",
             ["tmux", "list-panes", "-a", "-F", "#{pane_pid} #{session_name} #{pane_id}"]
         ) else {
@@ -190,32 +198,23 @@ public actor CompanionLocalProbe {
             }
     }
 
-    private func capturePane(paneID: String) -> String? {
-        shell("/usr/bin/env", ["tmux", "capture-pane", "-t", paneID, "-p", "-S", "-200"])
-            .flatMap { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : $0 }
+    private func capturePane(paneID: String) async -> String? {
+        let raw = await shell("/usr/bin/env", ["tmux", "capture-pane", "-t", paneID, "-p", "-S", "-200"])
+        return raw.flatMap { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : $0 }
     }
 
-    private func runningProcesses() -> [(pid: Int, commandLine: String)] {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/ps")
-        process.arguments = ["-axo", "pid=,args="]
-
-        let output = Pipe()
-        process.standardOutput = output
-        process.standardError = Pipe()
-
+    private func runningProcesses() async -> [(pid: Int, commandLine: String)] {
+        let result: ProcessResult
         do {
-            try process.run()
-            process.waitUntilExit()
+            result = try await Process.runAsync(
+                executablePath: "/bin/ps",
+                arguments: ["-axo", "pid=,args="]
+            )
         } catch {
             return []
         }
-
-        guard let data = try? output.fileHandleForReading.readToEnd(),
-              let raw = String(data: data, encoding: .utf8) else {
-            return []
-        }
-
+        guard result.succeeded else { return [] }
+        let raw = result.stdoutString
         return raw
             .split(separator: "\n")
             .compactMap { line -> (Int, String)? in
@@ -233,24 +232,16 @@ public actor CompanionLocalProbe {
     }
 
     @discardableResult
-    private func shell(_ executable: String, _ arguments: [String]) -> String? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: executable)
-        process.arguments = arguments
-
-        let output = Pipe()
-        let errorPipe = Pipe()
-        process.standardOutput = output
-        process.standardError = errorPipe
-
+    private func shell(_ executable: String, _ arguments: [String]) async -> String? {
         do {
-            try process.run()
-            process.waitUntilExit()
+            let result = try await Process.runAsync(
+                executablePath: executable,
+                arguments: arguments
+            )
+            guard result.succeeded else { return nil }
+            return result.stdoutString
         } catch {
             return nil
         }
-
-        guard let data = try? output.fileHandleForReading.readToEnd() else { return nil }
-        return String(data: data, encoding: .utf8)
     }
 }

--- a/AgentBoardCore/Services/GitHubWorkService.swift
+++ b/AgentBoardCore/Services/GitHubWorkService.swift
@@ -266,31 +266,25 @@ public actor GitHubWorkService {
         private func fetchIssuesViaCLI(
             for repository: ConfiguredRepository
         ) async throws -> [WorkItem] {
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/local/bin/gh")
-            process.arguments = [
-                "api", "repos/\(repository.owner)/\(repository.name)/issues",
-                "-f", "state=all",
-                "-f", "per_page=100",
-                "-q", "[.[] | select(.pull_request == null)]"
-            ]
-
-            let stdout = Pipe()
-            let stderr = Pipe()
-            process.standardOutput = stdout
-            process.standardError = stderr
-
-            try process.run()
-            process.waitUntilExit()
-
-            guard process.terminationStatus == 0 else {
+            let result: ProcessResult
+            do {
+                result = try await Process.runAsync(
+                    executablePath: "/usr/local/bin/gh",
+                    arguments: [
+                        "api", "repos/\(repository.owner)/\(repository.name)/issues",
+                        "-f", "state=all",
+                        "-f", "per_page=100",
+                        "-q", "[.[] | select(.pull_request == null)]"
+                    ]
+                )
+            } catch {
                 throw ServiceError.notFound
             }
 
-            let data = stdout.fileHandleForReading.readDataToEndOfFile()
-            guard !data.isEmpty else { return [] }
+            guard result.succeeded else { throw ServiceError.notFound }
+            guard !result.stdout.isEmpty else { return [] }
 
-            let issues = try JSONDecoder().decode([RawIssue].self, from: data)
+            let issues = try JSONDecoder().decode([RawIssue].self, from: result.stdout)
             return issues.map { map(issue: $0, repository: repository) }
         }
     #endif

--- a/AgentBoardCore/Services/PRDComposer.swift
+++ b/AgentBoardCore/Services/PRDComposer.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// Builds the Markdown PRD that gets handed to a freshly-launched agent
+/// session. Pure value-producing struct — no I/O, easy to unit-test, and
+/// the right home for a future data-driven preset registry.
+public struct PRDComposer: Sendable {
+    public init() {}
+
+    public func compose(config: SessionLauncher.LaunchConfig) -> String {
+        var prd = """
+        # PRD: \(config.taskTitle)
+
+        ## Issue
+        #\(config.issueNumber) in \(config.fullRepo)
+
+        """
+
+        prd += taskSection(for: config)
+
+        prd += """
+        ## Constraints
+        - Swift 6 strict concurrency
+        - @Observable not ObservableObject
+        - accessibilityIdentifier on every interactive element
+
+        ## Anti-Stall Rules
+        - Never wait for input. Never pause for confirmation. Keep moving.
+        - When done: commit, push to feature branch, STOP.
+        - Report: "DONE: [accomplished] | BLOCKED: [anything open]"
+        """
+
+        if !config.customInstructions.isEmpty {
+            prd += "\n## Custom Instructions\n\(config.customInstructions)\n"
+        }
+
+        return prd
+    }
+
+    // MARK: - Per-preset task sections
+
+    private func taskSection(for config: SessionLauncher.LaunchConfig) -> String {
+        switch config.preset {
+        case .ralphLoop:
+            return """
+            ## Tasks
+            - [ ] Implement \(config.taskTitle)
+            - [ ] Handle edge cases and error states
+            - [ ] Add accessibilityIdentifier to every interactive element
+            - [ ] Build verify: xcodebuild -scheme AgentBoard -destination 'platform=macOS' build
+
+            """
+        case .tddSuperpowers:
+            return """
+            ## Tasks
+            - [ ] Write failing tests that define expected behavior
+            - [ ] Implement \(config.taskTitle) to pass tests
+            - [ ] Handle edge cases
+            - [ ] Add accessibilityIdentifier to every interactive element
+            - [ ] Run full test suite — all tests must pass
+
+            """
+        case .claudeToCodex:
+            return """
+            ## Phase 1: Implementation (Claude Code)
+            - [ ] Implement \(config.taskTitle)
+            - [ ] Handle edge cases
+            - [ ] Build verify: xcodebuild -scheme AgentBoard -destination 'platform=macOS' build
+            - [ ] Commit to feature branch
+
+            ## Phase 2: Test Validation (Codex — auto-handoff)
+            - [ ] Run full test suite
+            - [ ] Add missing tests if coverage gaps found
+            - [ ] Run linter — no new warnings
+            - [ ] Report results
+
+            """
+        case .codexReview:
+            return """
+            ## Tasks
+            - [ ] Implement \(config.taskTitle)
+            - [ ] Run full test suite
+            - [ ] Review code quality and suggest improvements
+            - [ ] Add accessibilityIdentifier to every interactive element
+            - [ ] Build verify: xcodebuild -scheme AgentBoard -destination 'platform=macOS' build
+
+            """
+        case .opencodeSession:
+            return """
+            ## Tasks
+            - [ ] Analyze codebase for \(config.taskTitle)
+            - [ ] Implement with multi-model approach
+            - [ ] Cross-validate with different models
+            - [ ] Add accessibilityIdentifier to every interactive element
+            - [ ] Build verify: xcodebuild -scheme AgentBoard -destination 'platform=macOS' build
+
+            """
+        }
+    }
+}

--- a/AgentBoardCore/Services/SessionLauncher.swift
+++ b/AgentBoardCore/Services/SessionLauncher.swift
@@ -2,12 +2,14 @@ import Foundation
 import os
 
 /// Manages launching agent sessions from task cards.
-/// Creates tmux sessions pre-loaded with issue context and execution presets.
+/// Composes a `PRDComposer` (Markdown PRD generation), a `TmuxControlling`
+/// (tmux subprocess invocations), and a polling status monitor.
 @MainActor
 @Observable
-// swiftlint:disable:next type_body_length
 public final class SessionLauncher {
     private let logger = Logger(subsystem: "com.agentboard.modern", category: "SessionLauncher")
+    private let prdComposer: PRDComposer
+    private let tmux: any TmuxControlling
 
     // MARK: - Models
 
@@ -92,7 +94,7 @@ public final class SessionLauncher {
         }
     }
 
-    public struct LaunchConfig {
+    public struct LaunchConfig: Sendable {
         public let taskTitle: String
         public let issueNumber: Int
         public let repo: String
@@ -168,12 +170,34 @@ public final class SessionLauncher {
         }
     }
 
+    public enum LaunchError: LocalizedError {
+        case tmuxFailed(String)
+        case unsupportedPlatform
+
+        public var errorDescription: String? {
+            switch self {
+            case let .tmuxFailed(msg): return "tmux launch failed: \(msg)"
+            case .unsupportedPlatform: return "Session launching is only supported on macOS."
+            }
+        }
+    }
+
     // MARK: - State
 
     public var activeSessions: [ActiveSession] = []
     public var isLaunching = false
     public var lastError: String?
     private var monitorTask: Task<Void, Never>?
+
+    // MARK: - Init
+
+    public init(
+        prdComposer: PRDComposer = PRDComposer(),
+        tmux: any TmuxControlling = LiveTmuxController()
+    ) {
+        self.prdComposer = prdComposer
+        self.tmux = tmux
+    }
 
     // MARK: - Launch
 
@@ -189,19 +213,23 @@ public final class SessionLauncher {
         let prdPath = "docs/PRD-issue-\(config.issueNumber).md"
 
         do {
-            // 1. Generate PRD
-            let prd = generatePRD(config: config)
+            let prd = prdComposer.compose(config: config)
             try writePRD(repo: config.repo, path: prdPath, content: prd)
 
-            // 2. Launch tmux session
-            try await launchTmuxSession(
-                sessionName: sessionName,
-                repo: config.repo,
-                agentType: config.agentType,
-                prdPath: prdPath
-            )
+            let repoPath = Self.repoPath(for: config.repo)
+            do {
+                try await tmux.launchSession(
+                    name: sessionName,
+                    repoPath: repoPath,
+                    agentLaunchFlag: config.agentType.launchFlag,
+                    prdPath: prdPath
+                )
+            } catch let TmuxError.launchFailed(msg) {
+                throw LaunchError.tmuxFailed(msg)
+            } catch TmuxError.unsupportedPlatform {
+                throw LaunchError.unsupportedPlatform
+            }
 
-            // 3. Track session
             let session = ActiveSession(
                 id: UUID().uuidString,
                 sessionName: sessionName,
@@ -217,7 +245,6 @@ public final class SessionLauncher {
             logger.info("Launched session: \(sessionName)")
             startMonitoring()
             return sessionName
-
         } catch {
             lastError = error.localizedDescription
             isLaunching = false
@@ -226,243 +253,37 @@ public final class SessionLauncher {
         }
     }
 
-    // MARK: - PRD Generation
+    // MARK: - Tmux pass-throughs (used by SessionTerminalView)
 
-    private func generatePRD(config: LaunchConfig) -> String {
-        var prd = """
-        # PRD: \(config.taskTitle)
-
-        ## Issue
-        #\(config.issueNumber) in \(config.fullRepo)
-
-        """
-
-        switch config.preset {
-        case .ralphLoop:
-            prd += """
-            ## Tasks
-            - [ ] Implement \(config.taskTitle)
-            - [ ] Handle edge cases and error states
-            - [ ] Add accessibilityIdentifier to every interactive element
-            - [ ] Build verify: xcodebuild -scheme AgentBoard -destination 'platform=macOS' build
-
-            """
-        case .tddSuperpowers:
-            prd += """
-            ## Tasks
-            - [ ] Write failing tests that define expected behavior
-            - [ ] Implement \(config.taskTitle) to pass tests
-            - [ ] Handle edge cases
-            - [ ] Add accessibilityIdentifier to every interactive element
-            - [ ] Run full test suite — all tests must pass
-
-            """
-        case .claudeToCodex:
-            prd += """
-            ## Phase 1: Implementation (Claude Code)
-            - [ ] Implement \(config.taskTitle)
-            - [ ] Handle edge cases
-            - [ ] Build verify: xcodebuild -scheme AgentBoard -destination 'platform=macOS' build
-            - [ ] Commit to feature branch
-
-            ## Phase 2: Test Validation (Codex — auto-handoff)
-            - [ ] Run full test suite
-            - [ ] Add missing tests if coverage gaps found
-            - [ ] Run linter — no new warnings
-            - [ ] Report results
-
-            """
-        case .codexReview:
-            prd += """
-            ## Tasks
-            - [ ] Implement \(config.taskTitle)
-            - [ ] Run full test suite
-            - [ ] Review code quality and suggest improvements
-            - [ ] Add accessibilityIdentifier to every interactive element
-            - [ ] Build verify: xcodebuild -scheme AgentBoard -destination 'platform=macOS' build
-
-            """
-        case .opencodeSession:
-            prd += """
-            ## Tasks
-            - [ ] Analyze codebase for \(config.taskTitle)
-            - [ ] Implement with multi-model approach
-            - [ ] Cross-validate with different models
-            - [ ] Add accessibilityIdentifier to every interactive element
-            - [ ] Build verify: xcodebuild -scheme AgentBoard -destination 'platform=macOS' build
-
-            """
-        }
-
-        prd += """
-        ## Constraints
-        - Swift 6 strict concurrency
-        - @Observable not ObservableObject
-        - accessibilityIdentifier on every interactive element
-
-        ## Anti-Stall Rules
-        - Never wait for input. Never pause for confirmation. Keep moving.
-        - When done: commit, push to feature branch, STOP.
-        - Report: "DONE: [accomplished] | BLOCKED: [anything open]"
-        """
-
-        if !config.customInstructions.isEmpty {
-            prd += "\n## Custom Instructions\n\(config.customInstructions)\n"
-        }
-
-        return prd
+    public func checkSession(_ session: ActiveSession) async -> ActiveSession.SessionStatus {
+        let alive = await tmux.hasSession(name: session.sessionName)
+        return alive ? .running : .completed
     }
 
-    // MARK: - tmux Launch
-
-    private func writePRD(repo: String, path: String, content: String) throws {
-        #if os(macOS)
-            let home = FileManager.default.homeDirectoryForCurrentUser
-            let projectDir = home.appendingPathComponent("Projects").appendingPathComponent(repo)
-            let prdDir = projectDir.appendingPathComponent("docs")
-
-            try FileManager.default.createDirectory(at: prdDir, withIntermediateDirectories: true)
-
-            let prdFile = prdDir.appendingPathComponent(URL(fileURLWithPath: path).lastPathComponent)
-            try content.write(to: prdFile, atomically: true, encoding: .utf8)
-        #else
-            throw LaunchError.unsupportedPlatform
-        #endif
+    public func capturePane(sessionName: String) async -> String? {
+        await tmux.capturePane(name: sessionName)
     }
 
-    private func launchTmuxSession(
-        sessionName: String,
-        repo: String,
-        agentType: AgentType,
-        prdPath: String
-    ) async throws {
-        #if os(macOS)
-            let home = FileManager.default.homeDirectoryForCurrentUser
-            let projectDir = home.appendingPathComponent("Projects").appendingPathComponent(repo).path
-            let socket = home.appendingPathComponent(".tmux/sock").path
-            let agent = agentType.launchFlag
+    public func openInTerminal(sessionName: String) {
+        tmux.openInTerminal(name: sessionName)
+    }
 
-            // Use enriched shell variables that harvest PATH and credentials from
-            // the user's login shell (sources .zprofile + .zshrc for nvm/Homebrew).
-            // tmux new-session receives this so node, ralphy, etc. are on PATH.
-            let shellEnv = await ShellEnvironment.enrichedEnvironment()
+    // MARK: - Static tmux paths (referenced by EmbeddedTerminalView)
 
-            let shellCmd = "/opt/homebrew/bin/tmux -S \(socket) new -d -s \(sessionName)" +
-                " \"cd \(projectDir)" +
-                " && unset ANTHROPIC_API_KEY" +
-                " && /opt/homebrew/bin/ralphy --\(agent) --prd \(prdPath)" +
-                "; EXIT_CODE=\\$?; echo EXITED: \\$EXIT_CODE; sleep 999999\""
+    public static var tmuxExecutablePath: String {
+        LiveTmuxController.tmuxExecutablePath
+    }
 
-            let result: ProcessResult
-            do {
-                result = try await Process.runAsync(
-                    executablePath: "/bin/zsh",
-                    arguments: ["-l", "-c", shellCmd],
-                    environment: shellEnv
-                )
-            } catch let ProcessRunError.launchFailed(msg) {
-                throw LaunchError.tmuxFailed(msg)
-            }
+    public static var tmuxSocketPath: String {
+        LiveTmuxController.tmuxSocketPath
+    }
 
-            if !result.succeeded {
-                let output = result.stderrString.isEmpty ? result.stdoutString : result.stderrString
-                throw LaunchError.tmuxFailed(output.isEmpty ? "unknown error" : output)
-            }
-        #else
-            throw LaunchError.unsupportedPlatform
-        #endif
+    public static func attachCommand(for sessionName: String) -> (executable: String, arguments: [String]) {
+        LiveTmuxController.attachCommand(for: sessionName)
     }
 
     // MARK: - Monitoring
 
-    public func checkSession(_ session: ActiveSession) async -> ActiveSession.SessionStatus {
-        #if os(macOS)
-            let home = FileManager.default.homeDirectoryForCurrentUser
-            let socket = home.appendingPathComponent(".tmux/sock").path
-
-            do {
-                let result = try await Process.runAsync(
-                    executablePath: "/opt/homebrew/bin/tmux",
-                    arguments: ["-S", socket, "has-session", "-t", session.sessionName],
-                    environment: await ShellEnvironment.enrichedEnvironment()
-                )
-                return result.succeeded ? .running : .completed
-            } catch {
-                return .failed
-            }
-        #else
-            return .failed
-        #endif
-    }
-
-    /// Path to the tmux executable used for app-managed sessions.
-    public static let tmuxExecutablePath = "/opt/homebrew/bin/tmux"
-
-    /// Path to the tmux socket used for app-managed sessions.
-    public static var tmuxSocketPath: String {
-        URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
-            .appendingPathComponent(".tmux/sock")
-            .path
-    }
-
-    /// Build the `tmux attach` command for a given session — used to spawn an
-    /// interactive PTY-backed terminal inside the app.
-    public static func attachCommand(for sessionName: String) -> (executable: String, arguments: [String]) {
-        (tmuxExecutablePath, ["-S", tmuxSocketPath, "attach", "-t", sessionName])
-    }
-
-    /// Capture the current visible content of a tmux session pane.
-    public func capturePane(sessionName: String) async -> String? {
-        #if os(macOS)
-            let home = FileManager.default.homeDirectoryForCurrentUser
-            let socket = home.appendingPathComponent(".tmux/sock").path
-
-            do {
-                let result = try await Process.runAsync(
-                    executablePath: "/opt/homebrew/bin/tmux",
-                    arguments: ["-S", socket, "capture-pane", "-t", sessionName, "-p", "-J"],
-                    environment: await ShellEnvironment.enrichedEnvironment()
-                )
-                guard result.succeeded else { return nil }
-                return result.stdoutString.trimmingCharacters(in: .whitespacesAndNewlines)
-            } catch {
-                return nil
-            }
-        #else
-            return nil
-        #endif
-    }
-
-    /// Open a tmux session in the system Terminal.app.
-    public func openInTerminal(sessionName: String) {
-        #if os(macOS)
-            let home = FileManager.default.homeDirectoryForCurrentUser
-            let socket = home.appendingPathComponent(".tmux/sock").path
-
-            // Use /opt/homebrew/bin/tmux explicitly and source shell profile
-            // so PATH is correct inside the terminal.
-            let cmd = "source ~/.zshrc 2>/dev/null; /opt/homebrew/bin/tmux -S \(socket) attach -t \(sessionName)"
-
-            let appleScript = """
-            tell application "Terminal"
-                activate
-                do script "\(cmd)"
-            end tell
-            """
-
-            let scriptProcess = Process()
-            scriptProcess.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
-            scriptProcess.arguments = ["-e", appleScript]
-
-            do {
-                try scriptProcess.run()
-            } catch {
-                logger.error("Failed to open Terminal.app: \(error.localizedDescription)")
-            }
-        #endif
-    }
-
-    /// Start monitoring active sessions for status changes.
     public func startMonitoring() {
         monitorTask?.cancel()
         monitorTask = Task { [weak self] in
@@ -483,23 +304,34 @@ public final class SessionLauncher {
         }
     }
 
-    /// Stop the active-session polling loop.
     public func stopMonitoring() {
         monitorTask?.cancel()
         monitorTask = nil
     }
 
-    // MARK: - Errors
+    // MARK: - PRD file I/O
 
-    enum LaunchError: LocalizedError {
-        case tmuxFailed(String)
-        case unsupportedPlatform
+    private func writePRD(repo: String, path: String, content: String) throws {
+        #if os(macOS)
+            let home = FileManager.default.homeDirectoryForCurrentUser
+            let projectDir = home.appendingPathComponent("Projects").appendingPathComponent(repo)
+            let prdDir = projectDir.appendingPathComponent("docs")
 
-        var errorDescription: String? {
-            switch self {
-            case let .tmuxFailed(msg): return "tmux launch failed: \(msg)"
-            case .unsupportedPlatform: return "Session launching is only supported on macOS."
-            }
-        }
+            try FileManager.default.createDirectory(at: prdDir, withIntermediateDirectories: true)
+
+            let prdFile = prdDir.appendingPathComponent(URL(fileURLWithPath: path).lastPathComponent)
+            try content.write(to: prdFile, atomically: true, encoding: .utf8)
+        #else
+            throw LaunchError.unsupportedPlatform
+        #endif
+    }
+
+    private static func repoPath(for repo: String) -> String {
+        #if os(macOS)
+            let home = FileManager.default.homeDirectoryForCurrentUser
+            return home.appendingPathComponent("Projects").appendingPathComponent(repo).path
+        #else
+            return "/" // unreachable — launch() throws unsupportedPlatform via tmux on iOS
+        #endif
     }
 }

--- a/AgentBoardCore/Services/SessionLauncher.swift
+++ b/AgentBoardCore/Services/SessionLauncher.swift
@@ -173,6 +173,7 @@ public final class SessionLauncher {
     public var activeSessions: [ActiveSession] = []
     public var isLaunching = false
     public var lastError: String?
+    private var monitorTask: Task<Void, Never>?
 
     // MARK: - Launch
 
@@ -341,10 +342,10 @@ public final class SessionLauncher {
             let socket = home.appendingPathComponent(".tmux/sock").path
             let agent = agentType.launchFlag
 
-            // Use enriched environment that harvests PATH and credentials from
+            // Use enriched shell variables that harvest PATH and credentials from
             // the user's login shell (sources .zprofile + .zshrc for nvm/Homebrew).
-            // tmux new-session receives this env so node, ralphy, etc. are on PATH.
-            let env = ShellEnvironment.enrichedEnvironment()
+            // tmux new-session receives this so node, ralphy, etc. are on PATH.
+            let shellEnv = ShellEnvironment.enrichedEnvironment()
 
             let shellCmd = "/opt/homebrew/bin/tmux -S \(socket) new -d -s \(sessionName)" +
                 " \"cd \(projectDir)" +
@@ -352,22 +353,20 @@ public final class SessionLauncher {
                 " && /opt/homebrew/bin/ralphy --\(agent) --prd \(prdPath)" +
                 "; EXIT_CODE=\\$?; echo EXITED: \\$EXIT_CODE; sleep 999999\""
 
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-            process.arguments = ["-l", "-c", shellCmd]
-            process.environment = env
+            let result: ProcessResult
+            do {
+                result = try await Process.runAsync(
+                    executablePath: "/bin/zsh",
+                    arguments: ["-l", "-c", shellCmd],
+                    environment: shellEnv
+                )
+            } catch let ProcessRunError.launchFailed(msg) {
+                throw LaunchError.tmuxFailed(msg)
+            }
 
-            let pipe = Pipe()
-            process.standardOutput = pipe
-            process.standardError = pipe
-
-            try process.run()
-            process.waitUntilExit()
-
-            if process.terminationStatus != 0 {
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                let output = String(data: data, encoding: .utf8) ?? "unknown error"
-                throw LaunchError.tmuxFailed(output)
+            if !result.succeeded {
+                let output = result.stderrString.isEmpty ? result.stdoutString : result.stderrString
+                throw LaunchError.tmuxFailed(output.isEmpty ? "unknown error" : output)
             }
         #else
             throw LaunchError.unsupportedPlatform
@@ -381,19 +380,13 @@ public final class SessionLauncher {
             let home = FileManager.default.homeDirectoryForCurrentUser
             let socket = home.appendingPathComponent(".tmux/sock").path
 
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/opt/homebrew/bin/tmux")
-            process.arguments = ["-S", socket, "has-session", "-t", session.sessionName]
-            process.environment = ShellEnvironment.enrichedEnvironment()
-
-            let pipe = Pipe()
-            process.standardOutput = pipe
-            process.standardError = pipe
-
             do {
-                try process.run()
-                process.waitUntilExit()
-                return process.terminationStatus == 0 ? .running : .completed
+                let result = try await Process.runAsync(
+                    executablePath: "/opt/homebrew/bin/tmux",
+                    arguments: ["-S", socket, "has-session", "-t", session.sessionName],
+                    environment: ShellEnvironment.enrichedEnvironment()
+                )
+                return result.succeeded ? .running : .completed
             } catch {
                 return .failed
             }
@@ -419,26 +412,19 @@ public final class SessionLauncher {
     }
 
     /// Capture the current visible content of a tmux session pane.
-    public func capturePane(sessionName: String) -> String? {
+    public func capturePane(sessionName: String) async -> String? {
         #if os(macOS)
             let home = FileManager.default.homeDirectoryForCurrentUser
             let socket = home.appendingPathComponent(".tmux/sock").path
 
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/opt/homebrew/bin/tmux")
-            process.arguments = ["-S", socket, "capture-pane", "-t", sessionName, "-p", "-J"]
-            process.environment = ShellEnvironment.enrichedEnvironment()
-
-            let pipe = Pipe()
-            process.standardOutput = pipe
-            process.standardError = Pipe()
-
             do {
-                try process.run()
-                process.waitUntilExit()
-                guard process.terminationStatus == 0 else { return nil }
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+                let result = try await Process.runAsync(
+                    executablePath: "/opt/homebrew/bin/tmux",
+                    arguments: ["-S", socket, "capture-pane", "-t", sessionName, "-p", "-J"],
+                    environment: ShellEnvironment.enrichedEnvironment()
+                )
+                guard result.succeeded else { return nil }
+                return result.stdoutString.trimmingCharacters(in: .whitespacesAndNewlines)
             } catch {
                 return nil
             }
@@ -456,9 +442,6 @@ public final class SessionLauncher {
             // Use /opt/homebrew/bin/tmux explicitly and source shell profile
             // so PATH is correct inside the terminal.
             let cmd = "source ~/.zshrc 2>/dev/null; /opt/homebrew/bin/tmux -S \(socket) attach -t \(sessionName)"
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-            process.arguments = ["-a", "Terminal.app"]
 
             let appleScript = """
             tell application "Terminal"
@@ -481,7 +464,8 @@ public final class SessionLauncher {
 
     /// Start monitoring active sessions for status changes.
     public func startMonitoring() {
-        Task { [weak self] in
+        monitorTask?.cancel()
+        monitorTask = Task { [weak self] in
             guard let self else { return }
             while !Task.isCancelled {
                 for index in activeSessions.indices {
@@ -497,6 +481,12 @@ public final class SessionLauncher {
                 try? await Task.sleep(for: .seconds(30))
             }
         }
+    }
+
+    /// Stop the active-session polling loop.
+    public func stopMonitoring() {
+        monitorTask?.cancel()
+        monitorTask = nil
     }
 
     // MARK: - Errors

--- a/AgentBoardCore/Services/SessionLauncher.swift
+++ b/AgentBoardCore/Services/SessionLauncher.swift
@@ -345,7 +345,7 @@ public final class SessionLauncher {
             // Use enriched shell variables that harvest PATH and credentials from
             // the user's login shell (sources .zprofile + .zshrc for nvm/Homebrew).
             // tmux new-session receives this so node, ralphy, etc. are on PATH.
-            let shellEnv = ShellEnvironment.enrichedEnvironment()
+            let shellEnv = await ShellEnvironment.enrichedEnvironment()
 
             let shellCmd = "/opt/homebrew/bin/tmux -S \(socket) new -d -s \(sessionName)" +
                 " \"cd \(projectDir)" +
@@ -384,7 +384,7 @@ public final class SessionLauncher {
                 let result = try await Process.runAsync(
                     executablePath: "/opt/homebrew/bin/tmux",
                     arguments: ["-S", socket, "has-session", "-t", session.sessionName],
-                    environment: ShellEnvironment.enrichedEnvironment()
+                    environment: await ShellEnvironment.enrichedEnvironment()
                 )
                 return result.succeeded ? .running : .completed
             } catch {
@@ -421,7 +421,7 @@ public final class SessionLauncher {
                 let result = try await Process.runAsync(
                     executablePath: "/opt/homebrew/bin/tmux",
                     arguments: ["-S", socket, "capture-pane", "-t", sessionName, "-p", "-J"],
-                    environment: ShellEnvironment.enrichedEnvironment()
+                    environment: await ShellEnvironment.enrichedEnvironment()
                 )
                 guard result.succeeded else { return nil }
                 return result.stdoutString.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/AgentBoardCore/Services/SessionLauncher.swift
+++ b/AgentBoardCore/Services/SessionLauncher.swift
@@ -256,8 +256,13 @@ public final class SessionLauncher {
     // MARK: - Tmux pass-throughs (used by SessionTerminalView)
 
     public func checkSession(_ session: ActiveSession) async -> ActiveSession.SessionStatus {
-        let alive = await tmux.hasSession(name: session.sessionName)
-        return alive ? .running : .completed
+        do {
+            let alive = try await tmux.hasSession(name: session.sessionName)
+            return alive ? .running : .completed
+        } catch {
+            logger.error("Failed to check tmux session: \(error.localizedDescription, privacy: .public)")
+            return .failed
+        }
     }
 
     public func capturePane(sessionName: String) async -> String? {

--- a/AgentBoardCore/Services/ShellEnvironment.swift
+++ b/AgentBoardCore/Services/ShellEnvironment.swift
@@ -25,7 +25,7 @@ import os
 
         /// Keys to harvest from the login shell. PATH always included;
         /// the rest are AI-provider credentials that GUI apps never see.
-        fileprivate static let shellEnvKeys: [String] = [
+        private static let shellEnvKeys: [String] = [
             "PATH",
             "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "ANTHROPIC_BASE_URL",
             "OPENAI_API_KEY", "OPENAI_BASE_URL",

--- a/AgentBoardCore/Services/ShellEnvironment.swift
+++ b/AgentBoardCore/Services/ShellEnvironment.swift
@@ -7,6 +7,12 @@ import os
     /// shell so that subprocesses (tmux sessions, ralphy, etc.) can find
     /// Homebrew-managed tools like `node`, `nvm`, `ralphy`, `claude`, `codex`.
     ///
+    /// Async + cache-coalesced: the first call kicks off a single probe; concurrent
+    /// callers wait on the same in-flight `Task`. App bootstrap can call
+    /// `ShellEnvironment.warm()` at launch so the cache is ready by the time the
+    /// user clicks "Launch Session" — this replaces the previous static-initializer
+    /// design that blocked the calling thread for up to 5 seconds on first access.
+    ///
     /// Probing strategy:
     /// 1. `zsh -l -i` (login + interactive) — sources .zprofile AND .zshrc,
     ///    which nvm/asdf/mise require. Interactive shells can hang on prompt
@@ -14,12 +20,12 @@ import os
     ///    via env vars and bound with a 5-second timeout.
     /// 2. If that yields no PATH, fall back to `zsh -l` (login only, 3s timeout).
     /// 3. If both fail, return a hardcoded sane-default PATH; no credentials.
-    enum ShellEnvironment {
+    public enum ShellEnvironment {
         // MARK: - Allowlisted credential keys
 
         /// Keys to harvest from the login shell. PATH always included;
         /// the rest are AI-provider credentials that GUI apps never see.
-        private static let shellEnvKeys: [String] = [
+        fileprivate static let shellEnvKeys: [String] = [
             "PATH",
             "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "ANTHROPIC_BASE_URL",
             "OPENAI_API_KEY", "OPENAI_BASE_URL",
@@ -30,124 +36,146 @@ import os
             "HOME", "USER", "LANG", "TERM", "TMPDIR"
         ]
 
-        // MARK: - Cached enriched env
-
-        /// Cached result — computed once at first access, then reused.
-        private static let enrichedShellEnv: [String: String] = {
-            let logger = Logger(subsystem: "com.agentboard.modern", category: "ShellEnvironment")
-
-            // Build a shell script that prints KEY\0VALUE\0 for each key.
-            let script = shellEnvKeys.map { key in
-                "printf '%s\\0%s\\0' \"\(key)\" \"$\(key)\""
-            }.joined(separator: "; ")
-
-            // Attempt 1: login + interactive (covers nvm/asdf/mise in .zshrc).
-            if let result = runShellProbe(script: script, interactive: true, timeout: 5.0),
-               result["PATH"] != nil {
-                let pathCount = result["PATH"]?.split(separator: ":").count ?? 0
-                logger.info("Shell probe succeeded (login+interactive): PATH has \(pathCount) entries")
-                return result
-            }
-
-            // Attempt 2: login only (safe fallback if interactive hangs).
-            if let result = runShellProbe(script: script, interactive: false, timeout: 3.0),
-               result["PATH"] != nil {
-                let pathCount = result["PATH"]?.split(separator: ":").count ?? 0
-                logger.info("Shell probe succeeded (login-only): PATH has \(pathCount) entries")
-                return result
-            }
-
-            // Fallback: hardcoded sane-default PATH; no credential env.
-            let home = NSHomeDirectory()
-            let fallbackPath = [
-                "\(home)/.local/bin",
-                "\(home)/.nvm/versions/node/*/bin",
-                "/opt/homebrew/bin",
-                "/opt/homebrew/sbin",
-                "/usr/local/bin",
-                "/usr/bin",
-                "/bin",
-                "/usr/sbin",
-                "/sbin"
-            ].joined(separator: ":")
-            logger.warning("Shell probe failed; using hardcoded PATH fallback")
-            return ["PATH": fallbackPath]
-        }()
-
         // MARK: - Public API
 
-        /// Environment dict suitable for Process.environment. Starts from
-        /// ProcessInfo.processInfo.environment and overlays the shell-harvested
-        /// PATH and credential keys. Shell values win for overlapping keys.
-        nonisolated static func enrichedEnvironment() -> [String: String] {
-            var env = ProcessInfo.processInfo.environment
-            for (key, value) in enrichedShellEnv where !value.isEmpty {
-                env[key] = value
-            }
-            return env
+        /// Environment dict suitable for Process. Starts from
+        /// ProcessInfo.processInfo.environment and overlays shell-harvested
+        /// PATH + credential keys. Shell values win for overlapping keys.
+        ///
+        /// First call triggers an async probe; subsequent callers reuse the cache.
+        /// Concurrent callers share the same in-flight probe.
+        public static func enrichedEnvironment() async -> [String: String] {
+            await Cache.shared.enrichedEnvironment()
         }
 
-        // MARK: - Shell probe implementation
+        /// Pre-warm the probe in the background. Safe to call multiple times.
+        /// Use this at app launch so the cache is ready before any subprocess
+        /// invocation needs it.
+        public static func warm() {
+            Task.detached { _ = await Cache.shared.enrichedEnvironment() }
+        }
 
-        /// Runs a zsh probe and returns parsed KEY\0VALUE\0 output.
-        /// Returns nil on timeout or non-zero exit.
-        private static func runShellProbe(
-            script: String,
-            interactive: Bool,
-            timeout: TimeInterval
-        ) -> [String: String]? {
-            let pipe = Pipe()
-            let errPipe = Pipe()
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-            process.arguments = interactive
-                ? ["-l", "-i", "-c", script]
-                : ["-l", "-c", script]
-            process.standardOutput = pipe
-            process.standardError = errPipe
+        // MARK: - Cache actor
 
-            if interactive {
-                // Defang prompt frameworks so -i doesn't hang.
-                var env = ProcessInfo.processInfo.environment
-                env["TERM"] = "dumb"
-                env["PS1"] = ""
-                env["PROMPT"] = ""
-                env["RPROMPT"] = ""
-                env["POWERLEVEL9K_INSTANT_PROMPT"] = "off"
-                env["STARSHIP_DISABLE"] = "1"
-                env["ZSH_DISABLE_COMPFIX"] = "true"
-                process.environment = env
+        private actor Cache {
+            static let shared = Cache()
+
+            private var cached: [String: String]?
+            private var inFlight: Task<[String: String], Never>?
+
+            func enrichedEnvironment() async -> [String: String] {
+                if let cached { return cached }
+                if let inFlight { return await inFlight.value }
+
+                let task = Task { await Self.runFullProbe() }
+                inFlight = task
+                let result = await task.value
+                cached = result
+                inFlight = nil
+                return result
             }
 
-            do {
-                try process.run()
-                let deadline = Date().addingTimeInterval(timeout)
-                while process.isRunning && Date() < deadline {
-                    Thread.sleep(forTimeInterval: 0.05)
+            private static func runFullProbe() async -> [String: String] {
+                let logger = Logger(subsystem: "com.agentboard.modern", category: "ShellEnvironment")
+                let script = ShellEnvironment.shellEnvKeys.map { key in
+                    "printf '%s\\0%s\\0' \"\(key)\" \"$\(key)\""
+                }.joined(separator: "; ")
+
+                // Build the merged base from ProcessInfo + probed values.
+                func merge(_ probed: [String: String]) -> [String: String] {
+                    var env = ProcessInfo.processInfo.environment
+                    for (key, value) in probed where !value.isEmpty {
+                        env[key] = value
+                    }
+                    return env
                 }
-                if process.isRunning {
-                    process.terminate()
-                    Thread.sleep(forTimeInterval: 0.1)
+
+                // Attempt 1: login + interactive (covers nvm/asdf/mise in .zshrc).
+                if let result = await runShellProbe(script: script, interactive: true, timeout: 5.0),
+                   result["PATH"] != nil {
+                    let pathCount = result["PATH"]?.split(separator: ":").count ?? 0
+                    logger.info("Shell probe succeeded (login+interactive): PATH has \(pathCount) entries")
+                    return merge(result)
+                }
+
+                // Attempt 2: login only (safe fallback if interactive hangs).
+                if let result = await runShellProbe(script: script, interactive: false, timeout: 3.0),
+                   result["PATH"] != nil {
+                    let pathCount = result["PATH"]?.split(separator: ":").count ?? 0
+                    logger.info("Shell probe succeeded (login-only): PATH has \(pathCount) entries")
+                    return merge(result)
+                }
+
+                // Fallback: hardcoded sane-default PATH; no credential env.
+                let home = NSHomeDirectory()
+                let fallbackPath = [
+                    "\(home)/.local/bin",
+                    "\(home)/.nvm/versions/node/*/bin",
+                    "/opt/homebrew/bin",
+                    "/opt/homebrew/sbin",
+                    "/usr/local/bin",
+                    "/usr/bin",
+                    "/bin",
+                    "/usr/sbin",
+                    "/sbin"
+                ].joined(separator: ":")
+                logger.warning("Shell probe failed; using hardcoded PATH fallback")
+                return merge(["PATH": fallbackPath])
+            }
+
+            /// Runs a zsh probe and returns parsed KEY\0VALUE\0 output.
+            /// Returns nil on timeout or non-zero exit.
+            private static func runShellProbe(
+                script: String,
+                interactive: Bool,
+                timeout: TimeInterval
+            ) async -> [String: String]? {
+                let arguments: [String] = interactive
+                    ? ["-l", "-i", "-c", script]
+                    : ["-l", "-c", script]
+
+                let probeEnv: [String: String]?
+                if interactive {
+                    // Defang prompt frameworks so -i doesn't hang.
+                    var env = ProcessInfo.processInfo.environment
+                    env["TERM"] = "dumb"
+                    env["PS1"] = ""
+                    env["PROMPT"] = ""
+                    env["RPROMPT"] = ""
+                    env["POWERLEVEL9K_INSTANT_PROMPT"] = "off"
+                    env["STARSHIP_DISABLE"] = "1"
+                    env["ZSH_DISABLE_COMPFIX"] = "true"
+                    probeEnv = env
+                } else {
+                    probeEnv = nil
+                }
+
+                let result: ProcessResult
+                do {
+                    result = try await Process.runAsync(
+                        executablePath: "/bin/zsh",
+                        arguments: arguments,
+                        environment: probeEnv,
+                        timeout: timeout
+                    )
+                } catch {
                     return nil
                 }
-                process.waitUntilExit()
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                guard process.terminationStatus == 0, !data.isEmpty else { return nil }
 
-                var result: [String: String] = [:]
-                let parts = data.split(separator: 0, omittingEmptySubsequences: false)
-                var i = 0
-                while i + 1 < parts.count {
-                    if let key = String(data: Data(parts[i]), encoding: .utf8),
-                       let value = String(data: Data(parts[i + 1]), encoding: .utf8),
+                guard result.succeeded, !result.stdout.isEmpty else { return nil }
+
+                var parsed: [String: String] = [:]
+                let parts = result.stdout.split(separator: 0, omittingEmptySubsequences: false)
+                var index = 0
+                while index + 1 < parts.count {
+                    if let key = String(data: Data(parts[index]), encoding: .utf8),
+                       let value = String(data: Data(parts[index + 1]), encoding: .utf8),
                        !key.isEmpty, !value.isEmpty {
-                        result[key] = value
+                        parsed[key] = value
                     }
-                    i += 2
+                    index += 2
                 }
-                return result.isEmpty ? nil : result
-            } catch {
-                return nil
+                return parsed.isEmpty ? nil : parsed
             }
         }
     }

--- a/AgentBoardCore/Services/TmuxController.swift
+++ b/AgentBoardCore/Services/TmuxController.swift
@@ -28,7 +28,9 @@ public protocol TmuxControlling: Sendable {
     ) async throws
 
     /// Returns true if a tmux session with the given name is currently alive.
-    func hasSession(name: String) async -> Bool
+    /// Throws when tmux probing itself fails so callers can distinguish a
+    /// completed session from an unhealthy tmux/socket environment.
+    func hasSession(name: String) async throws -> Bool
 
     /// Capture the visible content of a tmux session pane, or `nil` if the
     /// session is gone or capture failed.
@@ -91,20 +93,23 @@ public actor LiveTmuxController: TmuxControlling {
         #endif
     }
 
-    public func hasSession(name: String) async -> Bool {
+    public func hasSession(name: String) async throws -> Bool {
         #if os(macOS)
+            let result: ProcessResult
             do {
-                let result = try await Process.runAsync(
+                result = try await Process.runAsync(
                     executablePath: Self.tmuxExecutablePath,
                     arguments: ["-S", Self.tmuxSocketPath, "has-session", "-t", name],
                     environment: await ShellEnvironment.enrichedEnvironment()
                 )
-                return result.succeeded
+            } catch let ProcessRunError.launchFailed(msg) {
+                throw TmuxError.launchFailed(msg)
             } catch {
-                return false
+                throw error
             }
+            return result.succeeded
         #else
-            return false
+            throw TmuxError.unsupportedPlatform
         #endif
     }
 

--- a/AgentBoardCore/Services/TmuxController.swift
+++ b/AgentBoardCore/Services/TmuxController.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+/// Errors thrown by tmux operations.
+public enum TmuxError: LocalizedError, Sendable {
+    case launchFailed(String)
+    case unsupportedPlatform
+
+    public var errorDescription: String? {
+        switch self {
+        case let .launchFailed(msg): return "tmux launch failed: \(msg)"
+        case .unsupportedPlatform: return "tmux operations are only supported on macOS."
+        }
+    }
+}
+
+/// Protocol-fronted gateway over tmux subprocess invocations. Provided so the
+/// caller (SessionLauncher / SessionMonitor) can be unit-tested with an
+/// in-memory fake instead of spawning real /opt/homebrew/bin/tmux. The
+/// production conformer is `LiveTmuxController`.
+public protocol TmuxControlling: Sendable {
+    /// Spawn a detached tmux session that runs `ralphy --<agent> --prd <path>`
+    /// inside the named repo's working directory.
+    func launchSession(
+        name: String,
+        repoPath: String,
+        agentLaunchFlag: String,
+        prdPath: String
+    ) async throws
+
+    /// Returns true if a tmux session with the given name is currently alive.
+    func hasSession(name: String) async -> Bool
+
+    /// Capture the visible content of a tmux session pane, or `nil` if the
+    /// session is gone or capture failed.
+    func capturePane(name: String) async -> String?
+
+    /// Open the named tmux session in the system Terminal.app. Synchronous,
+    /// fire-and-forget — used to give the user an interactive view.
+    func openInTerminal(name: String)
+}
+
+/// Live tmux subprocess implementation backed by `/opt/homebrew/bin/tmux`.
+public actor LiveTmuxController: TmuxControlling {
+    public static let tmuxExecutablePath = "/opt/homebrew/bin/tmux"
+
+    public static var tmuxSocketPath: String {
+        URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appendingPathComponent(".tmux/sock")
+            .path
+    }
+
+    public static func attachCommand(for sessionName: String) -> (executable: String, arguments: [String]) {
+        (tmuxExecutablePath, ["-S", tmuxSocketPath, "attach", "-t", sessionName])
+    }
+
+    public init() {}
+
+    public func launchSession(
+        name: String,
+        repoPath: String,
+        agentLaunchFlag: String,
+        prdPath: String
+    ) async throws {
+        #if os(macOS)
+            let socket = Self.tmuxSocketPath
+            let shellEnv = await ShellEnvironment.enrichedEnvironment()
+
+            let shellCmd = "\(Self.tmuxExecutablePath) -S \(socket) new -d -s \(name)" +
+                " \"cd \(repoPath)" +
+                " && unset ANTHROPIC_API_KEY" +
+                " && /opt/homebrew/bin/ralphy --\(agentLaunchFlag) --prd \(prdPath)" +
+                "; EXIT_CODE=\\$?; echo EXITED: \\$EXIT_CODE; sleep 999999\""
+
+            let result: ProcessResult
+            do {
+                result = try await Process.runAsync(
+                    executablePath: "/bin/zsh",
+                    arguments: ["-l", "-c", shellCmd],
+                    environment: shellEnv
+                )
+            } catch let ProcessRunError.launchFailed(msg) {
+                throw TmuxError.launchFailed(msg)
+            }
+
+            if !result.succeeded {
+                let output = result.stderrString.isEmpty ? result.stdoutString : result.stderrString
+                throw TmuxError.launchFailed(output.isEmpty ? "unknown error" : output)
+            }
+        #else
+            throw TmuxError.unsupportedPlatform
+        #endif
+    }
+
+    public func hasSession(name: String) async -> Bool {
+        #if os(macOS)
+            do {
+                let result = try await Process.runAsync(
+                    executablePath: Self.tmuxExecutablePath,
+                    arguments: ["-S", Self.tmuxSocketPath, "has-session", "-t", name],
+                    environment: await ShellEnvironment.enrichedEnvironment()
+                )
+                return result.succeeded
+            } catch {
+                return false
+            }
+        #else
+            return false
+        #endif
+    }
+
+    public func capturePane(name: String) async -> String? {
+        #if os(macOS)
+            do {
+                let result = try await Process.runAsync(
+                    executablePath: Self.tmuxExecutablePath,
+                    arguments: ["-S", Self.tmuxSocketPath, "capture-pane", "-t", name, "-p", "-J"],
+                    environment: await ShellEnvironment.enrichedEnvironment()
+                )
+                guard result.succeeded else { return nil }
+                return result.stdoutString.trimmingCharacters(in: .whitespacesAndNewlines)
+            } catch {
+                return nil
+            }
+        #else
+            return nil
+        #endif
+    }
+
+    public nonisolated func openInTerminal(name: String) { // swiftlint:disable:this modifier_order
+        #if os(macOS)
+            let socket = Self.tmuxSocketPath
+            let cmd = "source ~/.zshrc 2>/dev/null; \(Self.tmuxExecutablePath) -S \(socket) attach -t \(name)"
+
+            let appleScript = """
+            tell application "Terminal"
+                activate
+                do script "\(cmd)"
+            end tell
+            """
+
+            let scriptProcess = Process()
+            scriptProcess.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+            scriptProcess.arguments = ["-e", appleScript]
+
+            try? scriptProcess.run()
+        #endif
+    }
+}

--- a/AgentBoardCore/Stores/AgentBoardAppModel.swift
+++ b/AgentBoardCore/Stores/AgentBoardAppModel.swift
@@ -176,6 +176,13 @@ public enum AgentBoardBootstrap {
         )
         let sessionLauncher = SessionLauncher()
 
+        // Pre-warm the shell-environment probe in the background so it's ready
+        // by the time the user launches a session — replaces the previous
+        // synchronous static-initializer that could hang the UI for up to 5s.
+        #if os(macOS)
+            ShellEnvironment.warm()
+        #endif
+
         return AgentBoardAppModel(
             settingsRepository: settingsRepository,
             settingsStore: settingsStore,

--- a/AgentBoardCore/Support/ProcessAsync.swift
+++ b/AgentBoardCore/Support/ProcessAsync.swift
@@ -50,38 +50,63 @@ public enum ProcessRunError: Error, Sendable {
                 process.standardOutput = stdoutPipe
                 process.standardError = stderrPipe
 
-                let timer: DispatchSourceTimer?
-                if let timeout {
-                    let source = DispatchSource.makeTimerSource()
-                    source.schedule(deadline: .now() + timeout)
-                    source.setEventHandler {
-                        process.terminate()
-                        continuation.resume(throwing: ProcessRunError.timedOut)
+                let stateLock = NSLock()
+                var didResume = false
+                var timer: DispatchSourceTimer?
+
+                func resumeOnce(_ result: Result<ProcessResult, Error>) {
+                    stateLock.lock()
+                    guard !didResume else {
+                        stateLock.unlock()
+                        return
                     }
-                    source.resume()
-                    timer = source
-                } else {
+                    didResume = true
+                    let activeTimer = timer
                     timer = nil
+                    process.terminationHandler = nil
+                    stateLock.unlock()
+
+                    activeTimer?.setEventHandler {}
+                    activeTimer?.cancel()
+
+                    switch result {
+                    case let .success(processResult):
+                        continuation.resume(returning: processResult)
+                    case let .failure(error):
+                        continuation.resume(throwing: error)
+                    }
                 }
 
                 process.terminationHandler = { proc in
-                    timer?.cancel()
                     let outData = (try? stdoutPipe.fileHandleForReading.readToEnd()) ?? Data()
                     let errData = (try? stderrPipe.fileHandleForReading.readToEnd()) ?? Data()
-                    continuation.resume(
-                        returning: ProcessResult(
-                            exitCode: proc.terminationStatus,
-                            stdout: outData,
-                            stderr: errData
+                    resumeOnce(
+                        .success(
+                            ProcessResult(
+                                exitCode: proc.terminationStatus,
+                                stdout: outData,
+                                stderr: errData
+                            )
                         )
                     )
                 }
 
                 do {
                     try process.run()
+                    if let timeout {
+                        let source = DispatchSource.makeTimerSource()
+                        source.schedule(deadline: .now() + timeout)
+                        source.setEventHandler {
+                            process.terminate()
+                            resumeOnce(.failure(ProcessRunError.timedOut))
+                        }
+                        stateLock.lock()
+                        timer = source
+                        stateLock.unlock()
+                        source.resume()
+                    }
                 } catch {
-                    timer?.cancel()
-                    continuation.resume(throwing: ProcessRunError.launchFailed(error.localizedDescription))
+                    resumeOnce(.failure(ProcessRunError.launchFailed(error.localizedDescription)))
                 }
             }
         }

--- a/AgentBoardCore/Support/ProcessAsync.swift
+++ b/AgentBoardCore/Support/ProcessAsync.swift
@@ -96,7 +96,10 @@ public enum ProcessRunError: Error, Sendable {
                         let source = DispatchSource.makeTimerSource()
                         source.schedule(deadline: .now() + timeout)
                         source.setEventHandler {
-                            guard process.isRunning else { return }
+                            stateLock.lock()
+                            let shouldTerminate = !didResume && process.isRunning
+                            stateLock.unlock()
+                            guard shouldTerminate else { return }
                             process.terminate()
                             resumeOnce(.failure(ProcessRunError.timedOut))
                         }

--- a/AgentBoardCore/Support/ProcessAsync.swift
+++ b/AgentBoardCore/Support/ProcessAsync.swift
@@ -66,7 +66,6 @@ public enum ProcessRunError: Error, Sendable {
                     process.terminationHandler = nil
                     stateLock.unlock()
 
-                    activeTimer?.setEventHandler {}
                     activeTimer?.cancel()
 
                     switch result {

--- a/AgentBoardCore/Support/ProcessAsync.swift
+++ b/AgentBoardCore/Support/ProcessAsync.swift
@@ -42,7 +42,7 @@ public enum ProcessRunError: Error, Sendable {
                 process.executableURL = URL(fileURLWithPath: executablePath)
                 process.arguments = arguments
                 if let environment {
-                    process.setValue(environment, forKey: "environment")
+                    process.environment = environment
                 }
 
                 let stdoutPipe = Pipe()

--- a/AgentBoardCore/Support/ProcessAsync.swift
+++ b/AgentBoardCore/Support/ProcessAsync.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Captured result of an async subprocess run.
+public struct ProcessResult: Sendable {
+    public let exitCode: Int32
+    public let stdout: Data
+    public let stderr: Data
+
+    public var stdoutString: String {
+        String(data: stdout, encoding: .utf8) ?? ""
+    }
+
+    public var stderrString: String {
+        String(data: stderr, encoding: .utf8) ?? ""
+    }
+
+    public var succeeded: Bool { exitCode == 0 }
+}
+
+public enum ProcessRunError: Error, Sendable {
+    case launchFailed(String)
+    case timedOut
+    case unsupportedPlatform
+}
+
+#if os(macOS)
+    public extension Process {
+        /// Async wrapper around `Process.run()` + `terminationHandler`.
+        ///
+        /// Replaces synchronous `process.waitUntilExit()` so the calling actor
+        /// (especially `@MainActor` and other isolated actors) is not blocked
+        /// while the subprocess runs. Captures stdout and stderr to in-memory
+        /// `Data`. Pass `timeout` to terminate the process if it overruns.
+        static func runAsync(
+            executablePath: String,
+            arguments: [String],
+            environment: [String: String]? = nil,
+            timeout: TimeInterval? = nil
+        ) async throws -> ProcessResult {
+            try await withCheckedThrowingContinuation { continuation in
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: executablePath)
+                process.arguments = arguments
+                if let environment {
+                    process.setValue(environment, forKey: "environment")
+                }
+
+                let stdoutPipe = Pipe()
+                let stderrPipe = Pipe()
+                process.standardOutput = stdoutPipe
+                process.standardError = stderrPipe
+
+                let timer: DispatchSourceTimer?
+                if let timeout {
+                    let source = DispatchSource.makeTimerSource()
+                    source.schedule(deadline: .now() + timeout)
+                    source.setEventHandler {
+                        process.terminate()
+                        continuation.resume(throwing: ProcessRunError.timedOut)
+                    }
+                    source.resume()
+                    timer = source
+                } else {
+                    timer = nil
+                }
+
+                process.terminationHandler = { proc in
+                    timer?.cancel()
+                    let outData = (try? stdoutPipe.fileHandleForReading.readToEnd()) ?? Data()
+                    let errData = (try? stderrPipe.fileHandleForReading.readToEnd()) ?? Data()
+                    continuation.resume(
+                        returning: ProcessResult(
+                            exitCode: proc.terminationStatus,
+                            stdout: outData,
+                            stderr: errData
+                        )
+                    )
+                }
+
+                do {
+                    try process.run()
+                } catch {
+                    timer?.cancel()
+                    continuation.resume(throwing: ProcessRunError.launchFailed(error.localizedDescription))
+                }
+            }
+        }
+    }
+#endif

--- a/AgentBoardCore/Support/ProcessAsync.swift
+++ b/AgentBoardCore/Support/ProcessAsync.swift
@@ -96,6 +96,7 @@ public enum ProcessRunError: Error, Sendable {
                         let source = DispatchSource.makeTimerSource()
                         source.schedule(deadline: .now() + timeout)
                         source.setEventHandler {
+                            guard process.isRunning else { return }
                             process.terminate()
                             resumeOnce(.failure(ProcessRunError.timedOut))
                         }

--- a/AgentBoardCore/Support/ProcessAsync.swift
+++ b/AgentBoardCore/Support/ProcessAsync.swift
@@ -25,6 +25,7 @@ public enum ProcessRunError: Error, Sendable {
 
 #if os(macOS)
     public extension Process {
+        // swiftlint:disable function_body_length
         /// Async wrapper around `Process.run()` + `terminationHandler`.
         ///
         /// Replaces synchronous `process.waitUntilExit()` so the calling actor
@@ -37,81 +38,131 @@ public enum ProcessRunError: Error, Sendable {
             environment: [String: String]? = nil,
             timeout: TimeInterval? = nil
         ) async throws -> ProcessResult {
-            try await withCheckedThrowingContinuation { continuation in
-                let process = Process()
-                process.executableURL = URL(fileURLWithPath: executablePath)
-                process.arguments = arguments
-                if let environment {
-                    process.environment = environment
+            final class RunState: @unchecked Sendable {
+                private let lock = NSLock()
+                private var didResume = false
+                private var isCancelled = false
+                private weak var process: Process?
+                private var timer: DispatchSourceTimer?
+
+                func setProcess(_ process: Process) {
+                    lock.lock()
+                    defer { lock.unlock() }
+                    self.process = process
                 }
 
-                let stdoutPipe = Pipe()
-                let stderrPipe = Pipe()
-                process.standardOutput = stdoutPipe
-                process.standardError = stderrPipe
+                func setTimer(_ timer: DispatchSourceTimer?) {
+                    lock.lock()
+                    defer { lock.unlock() }
+                    self.timer = timer
+                }
 
-                let stateLock = NSLock()
-                var didResume = false
-                var timer: DispatchSourceTimer?
+                func cancelForTaskCancellation() {
+                    let process: Process?
+                    let timer: DispatchSourceTimer?
+                    lock.lock()
+                    isCancelled = true
+                    process = self.process
+                    timer = self.timer
+                    lock.unlock()
+                    timer?.cancel()
+                    process?.terminate()
+                }
 
-                func resumeOnce(_ result: Result<ProcessResult, Error>) {
-                    stateLock.lock()
+                func cancelTimer() {
+                    let timer: DispatchSourceTimer?
+                    lock.lock()
+                    timer = self.timer
+                    lock.unlock()
+                    timer?.cancel()
+                }
+
+                func wasCancelled() -> Bool {
+                    lock.lock()
+                    defer { lock.unlock() }
+                    return isCancelled
+                }
+
+                func resumeOnce(_ block: () -> Void) {
+                    lock.lock()
                     guard !didResume else {
-                        stateLock.unlock()
+                        lock.unlock()
                         return
                     }
                     didResume = true
-                    let activeTimer = timer
-                    timer = nil
-                    process.terminationHandler = nil
-                    stateLock.unlock()
+                    lock.unlock()
+                    block()
+                }
+            }
 
-                    activeTimer?.cancel()
+            let state = RunState()
 
-                    switch result {
-                    case let .success(processResult):
-                        continuation.resume(returning: processResult)
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
+            return try await withTaskCancellationHandler {
+                try Task.checkCancellation()
+
+                return try await withCheckedThrowingContinuation { continuation in
+                    let process = Process()
+                    state.setProcess(process)
+                    process.executableURL = URL(fileURLWithPath: executablePath)
+                    process.arguments = arguments
+                    if let environment {
+                        process.environment = environment
                     }
-                }
 
-                process.terminationHandler = { proc in
-                    let outData = (try? stdoutPipe.fileHandleForReading.readToEnd()) ?? Data()
-                    let errData = (try? stderrPipe.fileHandleForReading.readToEnd()) ?? Data()
-                    resumeOnce(
-                        .success(
-                            ProcessResult(
-                                exitCode: proc.terminationStatus,
-                                stdout: outData,
-                                stderr: errData
-                            )
-                        )
-                    )
-                }
+                    let stdoutPipe = Pipe()
+                    let stderrPipe = Pipe()
+                    process.standardOutput = stdoutPipe
+                    process.standardError = stderrPipe
 
-                do {
-                    try process.run()
+                    let timer: DispatchSourceTimer?
                     if let timeout {
                         let source = DispatchSource.makeTimerSource()
                         source.schedule(deadline: .now() + timeout)
                         source.setEventHandler {
-                            stateLock.lock()
-                            let shouldTerminate = !didResume && process.isRunning
-                            stateLock.unlock()
-                            guard shouldTerminate else { return }
                             process.terminate()
-                            resumeOnce(.failure(ProcessRunError.timedOut))
+                            state.resumeOnce {
+                                continuation.resume(throwing: ProcessRunError.timedOut)
+                            }
                         }
-                        stateLock.lock()
-                        timer = source
-                        stateLock.unlock()
                         source.resume()
+                        timer = source
+                    } else {
+                        timer = nil
                     }
-                } catch {
-                    resumeOnce(.failure(ProcessRunError.launchFailed(error.localizedDescription)))
+                    state.setTimer(timer)
+
+                    process.terminationHandler = { proc in
+                        state.cancelTimer()
+                        state.resumeOnce {
+                            if state.wasCancelled() {
+                                continuation.resume(throwing: CancellationError())
+                                return
+                            }
+                            let outData = (try? stdoutPipe.fileHandleForReading.readToEnd()) ?? Data()
+                            let errData = (try? stderrPipe.fileHandleForReading.readToEnd()) ?? Data()
+                            continuation.resume(
+                                returning: ProcessResult(
+                                    exitCode: proc.terminationStatus,
+                                    stdout: outData,
+                                    stderr: errData
+                                )
+                            )
+                        }
+                    }
+
+                    do {
+                        try process.run()
+                    } catch {
+                        state.cancelTimer()
+                        state.resumeOnce {
+                            continuation.resume(throwing: ProcessRunError.launchFailed(error.localizedDescription))
+                        }
+                    }
                 }
+            } onCancel: {
+                state.cancelForTaskCancellation()
             }
         }
+        // swiftlint:enable function_body_length
     }
 #endif

--- a/AgentBoardTests/PRDComposerTests.swift
+++ b/AgentBoardTests/PRDComposerTests.swift
@@ -1,0 +1,60 @@
+import AgentBoardCore
+import Testing
+
+@Suite("PRDComposer")
+struct PRDComposerTests {
+    @Test(arguments: [
+        (SessionLauncher.ExecutionPreset.ralphLoop, "Implement Refactor launcher", "Build verify"),
+        (.tddSuperpowers, "Write failing tests", "Run full test suite"),
+        (.claudeToCodex, "Phase 1: Implementation", "Phase 2: Test Validation"),
+        (.codexReview, "Review code quality", "Build verify"),
+        (.opencodeSession, "multi-model approach", "Cross-validate")
+    ])
+    func composeIncludesPresetSpecificTasks(
+        preset: SessionLauncher.ExecutionPreset,
+        expectedPrimaryText: String,
+        expectedSecondaryText: String
+    ) {
+        let markdown = PRDComposer().compose(config: Self.config(preset: preset))
+
+        #expect(markdown.contains("# PRD: Refactor launcher"))
+        #expect(markdown.contains("#107 in jbcrane13/AgentBoard"))
+        #expect(markdown.contains(expectedPrimaryText))
+        #expect(markdown.contains(expectedSecondaryText))
+        #expect(markdown.contains("## Anti-Stall Rules"))
+    }
+
+    @Test
+    func composeAppendsCustomInstructionsWhenProvided() {
+        let markdown = PRDComposer().compose(
+            config: Self.config(
+                preset: .ralphLoop,
+                customInstructions: "Use a tiny fixture and explain the tradeoff."
+            )
+        )
+
+        #expect(markdown.contains("## Custom Instructions"))
+        #expect(markdown.contains("Use a tiny fixture and explain the tradeoff."))
+    }
+
+    @Test
+    func composeOmitsCustomInstructionsWhenEmpty() {
+        let markdown = PRDComposer().compose(config: Self.config(preset: .ralphLoop, customInstructions: ""))
+
+        #expect(!markdown.contains("## Custom Instructions"))
+    }
+
+    private static func config(
+        preset: SessionLauncher.ExecutionPreset,
+        customInstructions: String = ""
+    ) -> SessionLauncher.LaunchConfig {
+        SessionLauncher.LaunchConfig(
+            taskTitle: "Refactor launcher",
+            issueNumber: 107,
+            repo: "AgentBoard",
+            fullRepo: "jbcrane13/AgentBoard",
+            preset: preset,
+            customInstructions: customInstructions
+        )
+    }
+}


### PR DESCRIPTION
## Summary

SessionLauncher trimmed from 515 lines / 6 concerns to ~325 lines / 1 concern (orchestration).

**Extracted:**
- **`PRDComposer`** (`struct`, `AgentBoardCore/Services/PRDComposer.swift`) — pure Markdown PRD generation per `ExecutionPreset`. No I/O; trivially unit-testable.
- **`TmuxControlling`** (protocol) + **`LiveTmuxController`** (actor, `AgentBoardCore/Services/TmuxController.swift`) — gateway over tmux subprocess invocations: `launchSession`, `hasSession`, `capturePane`, `openInTerminal`. The protocol gives SessionLauncher a test seam — future tests can inject an in-memory fake instead of spawning real `/opt/homebrew/bin/tmux`. `LiveTmuxController` owns the static `tmuxExecutablePath` / `tmuxSocketPath` / `attachCommand` helpers; SessionLauncher exposes them via pass-through statics so `EmbeddedTerminalView` and other callers see no API churn.

**SessionLauncher (now slim):**
- Same nested types (`AgentType`, `ExecutionPreset`, `LaunchConfig`, `ActiveSession`, `LaunchError`) — public surface preserved
- Same public methods (`launch`, `checkSession`, `capturePane`, `openInTerminal`, `startMonitoring`, `stopMonitoring`) — pass-throughs where appropriate
- The polling `monitorTask` (introduced in #103) stays on the launcher

**Deferred** to a focused follow-up: `AgentTypeDescriptor` protocol (the OCP "5-switch cascade" fix). The existing `AgentType` enum is preserved to keep this PR scoped to SRP decomposition. Filing a separate issue for the OCP work.

**Stack:** branched on top of #121 (which itself stacks on #120). Both `Process.runAsync` (from #103) and async `ShellEnvironment` (from #104) are used by `LiveTmuxController`.

Closes #107.

## Test plan

- [x] `xcodebuild build -scheme AgentBoard -destination 'platform=macOS'` succeeds
- [x] `xcodebuild build -scheme AgentBoardMobile -destination 'generic/platform=iOS Simulator'` succeeds
- [x] `xcodebuild build -scheme AgentBoardCompanion -destination 'platform=macOS'` succeeds
- [x] `swiftlint lint --strict` clean
- [x] SwiftFormat clean
- [ ] AgentBoardTests pass on `mac-mini` (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)