### PR TITLE
Fix AgentBoard cleanup tickets

### DIFF
--- a/AgentBoardCore/Persistence/AgentBoardCache.swift
+++ b/AgentBoardCore/Persistence/AgentBoardCache.swift
@@ -96,6 +96,26 @@ private final class CachedWorkItemRecord {
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }
+
+    func update(from item: WorkItem, assigneesData: Data, labelsData: Data) -> Bool {
+        var didChange = false
+        didChange = assignIfNeeded(self, \.repositoryOwner, to: item.repository.owner) || didChange
+        didChange = assignIfNeeded(self, \.repositoryName, to: item.repository.name) || didChange
+        didChange = assignIfNeeded(self, \.issueNumber, to: item.issueNumber) || didChange
+        didChange = assignIfNeeded(self, \.title, to: item.title) || didChange
+        didChange = assignIfNeeded(self, \.bodySummary, to: item.bodySummary) || didChange
+        didChange = assignIfNeeded(self, \.isClosed, to: item.isClosed) || didChange
+        didChange = assignIfNeeded(self, \.assigneesData, to: assigneesData) || didChange
+        didChange = assignIfNeeded(self, \.milestoneNumber, to: item.milestone?.number) || didChange
+        didChange = assignIfNeeded(self, \.milestoneTitle, to: item.milestone?.title) || didChange
+        didChange = assignIfNeeded(self, \.labelsData, to: labelsData) || didChange
+        didChange = assignIfNeeded(self, \.status, to: item.status.rawValue) || didChange
+        didChange = assignIfNeeded(self, \.priority, to: item.priority.rawValue) || didChange
+        didChange = assignIfNeeded(self, \.agentHint, to: item.agentHint) || didChange
+        didChange = assignIfNeeded(self, \.createdAt, to: item.createdAt) || didChange
+        didChange = assignIfNeeded(self, \.updatedAt, to: item.updatedAt) || didChange
+        return didChange
+    }
 }
 
 @Model
@@ -146,6 +166,24 @@ private final class CachedSessionRecord {
         self.tmuxPaneID = tmuxPaneID
         self.lastOutput = lastOutput
     }
+
+    func update(from session: AgentSession) -> Bool {
+        var didChange = false
+        didChange = assignIfNeeded(self, \.source, to: session.source) || didChange
+        didChange = assignIfNeeded(self, \.status, to: session.status.rawValue) || didChange
+        didChange = assignIfNeeded(self, \.linkedTaskID, to: session.linkedTaskID) || didChange
+        didChange = assignIfNeeded(self, \.repositoryOwner, to: session.workItem?.repository.owner) || didChange
+        didChange = assignIfNeeded(self, \.repositoryName, to: session.workItem?.repository.name) || didChange
+        didChange = assignIfNeeded(self, \.issueNumber, to: session.workItem?.issueNumber) || didChange
+        didChange = assignIfNeeded(self, \.model, to: session.model) || didChange
+        didChange = assignIfNeeded(self, \.startedAt, to: session.startedAt) || didChange
+        didChange = assignIfNeeded(self, \.lastSeenAt, to: session.lastSeenAt) || didChange
+        didChange = assignIfNeeded(self, \.pid, to: session.pid) || didChange
+        didChange = assignIfNeeded(self, \.tmuxSession, to: session.tmuxSession) || didChange
+        didChange = assignIfNeeded(self, \.tmuxPaneID, to: session.tmuxPaneID) || didChange
+        didChange = assignIfNeeded(self, \.lastOutput, to: session.lastOutput) || didChange
+        return didChange
+    }
 }
 
 @Model
@@ -175,6 +213,27 @@ private final class CachedAgentRecord {
         self.recentActivity = recentActivity
         self.updatedAt = updatedAt
     }
+
+    func update(from agent: AgentSummary) -> Bool {
+        var didChange = false
+        didChange = assignIfNeeded(self, \.name, to: agent.name) || didChange
+        didChange = assignIfNeeded(self, \.health, to: agent.health.rawValue) || didChange
+        didChange = assignIfNeeded(self, \.activeTaskCount, to: agent.activeTaskCount) || didChange
+        didChange = assignIfNeeded(self, \.activeSessionCount, to: agent.activeSessionCount) || didChange
+        didChange = assignIfNeeded(self, \.recentActivity, to: agent.recentActivity) || didChange
+        didChange = assignIfNeeded(self, \.updatedAt, to: agent.updatedAt) || didChange
+        return didChange
+    }
+}
+
+private func assignIfNeeded<Record: AnyObject, Value: Equatable>(
+    _ record: Record,
+    _ keyPath: ReferenceWritableKeyPath<Record, Value>,
+    to value: Value
+) -> Bool {
+    guard record[keyPath: keyPath] != value else { return false }
+    record[keyPath: keyPath] = value
+    return true
 }
 
 @MainActor
@@ -309,30 +368,36 @@ public final class AgentBoardCache {
     }
 
     public func replaceWorkItems(_ items: [WorkItem]) throws {
-        try replaceAll(CachedWorkItemRecord.self)
+        let existing = try context.fetch(FetchDescriptor<CachedWorkItemRecord>())
+        let existingByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
+        var incomingIDs = Set<String>()
+        var didChange = false
+
         for item in items {
-            context.insert(
-                CachedWorkItemRecord(
-                    id: item.id,
-                    repositoryOwner: item.repository.owner,
-                    repositoryName: item.repository.name,
-                    issueNumber: item.issueNumber,
-                    title: item.title,
-                    bodySummary: item.bodySummary,
-                    isClosed: item.isClosed,
-                    assigneesData: encodeStrings(item.assignees),
-                    milestoneNumber: item.milestone?.number,
-                    milestoneTitle: item.milestone?.title,
-                    labelsData: encodeStrings(item.labels),
-                    status: item.status.rawValue,
-                    priority: item.priority.rawValue,
-                    agentHint: item.agentHint,
-                    createdAt: item.createdAt,
-                    updatedAt: item.updatedAt
-                )
-            )
+            incomingIDs.insert(item.id)
+            let assigneesData = encodeStrings(item.assignees)
+            let labelsData = encodeStrings(item.labels)
+
+            if let record = existingByID[item.id] {
+                didChange = record.update(
+                    from: item,
+                    assigneesData: assigneesData,
+                    labelsData: labelsData
+                ) || didChange
+            } else {
+                context.insert(makeWorkItemRecord(item, assigneesData: assigneesData, labelsData: labelsData))
+                didChange = true
+            }
         }
-        try context.save()
+
+        for record in existing where !incomingIDs.contains(record.id) {
+            context.delete(record)
+            didChange = true
+        }
+
+        if didChange {
+            try context.save()
+        }
     }
 
     public func loadSessions() throws -> [AgentSession] {
@@ -368,28 +433,29 @@ public final class AgentBoardCache {
     }
 
     public func replaceSessions(_ sessions: [AgentSession]) throws {
-        try replaceAll(CachedSessionRecord.self)
+        let existing = try context.fetch(FetchDescriptor<CachedSessionRecord>())
+        let existingByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
+        var incomingIDs = Set<String>()
+        var didChange = false
+
         for session in sessions {
-            context.insert(
-                CachedSessionRecord(
-                    id: session.id,
-                    source: session.source,
-                    status: session.status.rawValue,
-                    linkedTaskID: session.linkedTaskID,
-                    repositoryOwner: session.workItem?.repository.owner,
-                    repositoryName: session.workItem?.repository.name,
-                    issueNumber: session.workItem?.issueNumber,
-                    model: session.model,
-                    startedAt: session.startedAt,
-                    lastSeenAt: session.lastSeenAt,
-                    pid: session.pid,
-                    tmuxSession: session.tmuxSession,
-                    tmuxPaneID: session.tmuxPaneID,
-                    lastOutput: session.lastOutput
-                )
-            )
+            incomingIDs.insert(session.id)
+            if let record = existingByID[session.id] {
+                didChange = record.update(from: session) || didChange
+            } else {
+                context.insert(makeSessionRecord(session))
+                didChange = true
+            }
         }
-        try context.save()
+
+        for record in existing where !incomingIDs.contains(record.id) {
+            context.delete(record)
+            didChange = true
+        }
+
+        if didChange {
+            try context.save()
+        }
     }
 
     public func deleteConversation(id: UUID) throws {
@@ -427,26 +493,85 @@ public final class AgentBoardCache {
     }
 
     public func replaceAgentSummaries(_ agents: [AgentSummary]) throws {
-        try replaceAll(CachedAgentRecord.self)
+        let existing = try context.fetch(FetchDescriptor<CachedAgentRecord>())
+        let existingByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
+        var incomingIDs = Set<String>()
+        var didChange = false
+
         for agent in agents {
-            context.insert(
-                CachedAgentRecord(
-                    id: agent.id,
-                    name: agent.name,
-                    health: agent.health.rawValue,
-                    activeTaskCount: agent.activeTaskCount,
-                    activeSessionCount: agent.activeSessionCount,
-                    recentActivity: agent.recentActivity,
-                    updatedAt: agent.updatedAt
-                )
-            )
+            incomingIDs.insert(agent.id)
+            if let record = existingByID[agent.id] {
+                didChange = record.update(from: agent) || didChange
+            } else {
+                context.insert(makeAgentRecord(agent))
+                didChange = true
+            }
         }
-        try context.save()
+
+        for record in existing where !incomingIDs.contains(record.id) {
+            context.delete(record)
+            didChange = true
+        }
+
+        if didChange {
+            try context.save()
+        }
     }
 
-    private func replaceAll<Model: PersistentModel>(_: Model.Type) throws {
-        let existing = try context.fetch(FetchDescriptor<Model>())
-        existing.forEach(context.delete)
+    private func makeWorkItemRecord(
+        _ item: WorkItem,
+        assigneesData: Data,
+        labelsData: Data
+    ) -> CachedWorkItemRecord {
+        CachedWorkItemRecord(
+            id: item.id,
+            repositoryOwner: item.repository.owner,
+            repositoryName: item.repository.name,
+            issueNumber: item.issueNumber,
+            title: item.title,
+            bodySummary: item.bodySummary,
+            isClosed: item.isClosed,
+            assigneesData: assigneesData,
+            milestoneNumber: item.milestone?.number,
+            milestoneTitle: item.milestone?.title,
+            labelsData: labelsData,
+            status: item.status.rawValue,
+            priority: item.priority.rawValue,
+            agentHint: item.agentHint,
+            createdAt: item.createdAt,
+            updatedAt: item.updatedAt
+        )
+    }
+
+    private func makeSessionRecord(_ session: AgentSession) -> CachedSessionRecord {
+        CachedSessionRecord(
+            id: session.id,
+            source: session.source,
+            status: session.status.rawValue,
+            linkedTaskID: session.linkedTaskID,
+            repositoryOwner: session.workItem?.repository.owner,
+            repositoryName: session.workItem?.repository.name,
+            issueNumber: session.workItem?.issueNumber,
+            model: session.model,
+            startedAt: session.startedAt,
+            lastSeenAt: session.lastSeenAt,
+            pid: session.pid,
+            tmuxSession: session.tmuxSession,
+            tmuxPaneID: session.tmuxPaneID,
+            lastOutput: session.lastOutput
+        )
+    }
+
+    private func makeAgentRecord(_ agent: AgentSummary) -> CachedAgentRecord {
+        CachedAgentRecord(
+            id: agent.id,
+            name: agent.name,
+            health: agent.health.rawValue,
+            activeTaskCount: agent.activeTaskCount,
+            activeSessionCount: agent.activeSessionCount,
+            recentActivity: agent.recentActivity,
+            updatedAt: agent.updatedAt
+        )
     }
 
     private func encodeStrings(_ values: [String]) -> Data {

--- a/AgentBoardCore/Services/AttachmentUploadService.swift
+++ b/AgentBoardCore/Services/AttachmentUploadService.swift
@@ -39,6 +39,7 @@ public final class AttachmentUploadService {
     private let logger = Logger(subsystem: "com.agentboard", category: "AttachmentUpload")
     private let session: URLSession
     private var activeUploads: [String: URLSessionUploadTask] = [:]
+    private var progressObservations: [Int: NSKeyValueObservation] = [:]
 
     public init(session: URLSession = .shared) {
         self.session = session
@@ -83,7 +84,11 @@ public final class AttachmentUploadService {
 
         // Use URLSession upload task for progress tracking
         return try await withCheckedThrowingContinuation { continuation in
-            let task = session.uploadTask(with: request, from: body) { data, response, error in
+            let task = session.uploadTask(with: request, from: body) { [weak self] data, response, error in
+                Task { @MainActor in
+                    self?.finishUpload(attachmentID: attachment.id)
+                }
+
                 if let error {
                     if let urlError = error as? URLError, urlError.code == .cancelled {
                         continuation.resume(throwing: AttachmentUploadError.cancelled)
@@ -132,26 +137,28 @@ public final class AttachmentUploadService {
             }
 
             activeUploads[attachment.id] = task
+            progressObservations[task.taskIdentifier] = observation
             task.resume()
-
-            // Clean up observation when done
-            Task { @MainActor [weak self] in
-                _ = observation // retain
-                self?.activeUploads.removeValue(forKey: attachment.id)
-            }
         }
     }
 
     /// Cancel an in-progress upload
     public func cancelUpload(attachmentID: String) {
-        activeUploads[attachmentID]?.cancel()
-        activeUploads.removeValue(forKey: attachmentID)
+        guard let task = activeUploads.removeValue(forKey: attachmentID) else { return }
+        task.cancel()
+        progressObservations.removeValue(forKey: task.taskIdentifier)
     }
 
     /// Cancel all active uploads
     public func cancelAll() {
         activeUploads.values.forEach { $0.cancel() }
         activeUploads.removeAll()
+        progressObservations.removeAll()
+    }
+
+    private func finishUpload(attachmentID: String) {
+        guard let task = activeUploads.removeValue(forKey: attachmentID) else { return }
+        progressObservations.removeValue(forKey: task.taskIdentifier)
     }
 }
 

--- a/AgentBoardCore/Services/CompanionClient.swift
+++ b/AgentBoardCore/Services/CompanionClient.swift
@@ -43,6 +43,12 @@ public actor CompanionClient {
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()
 
+    private enum RequestTimeout {
+        static let list: TimeInterval = 15
+        static let mutation: TimeInterval = 30
+        static let stream: TimeInterval = .greatestFiniteMagnitude
+    }
+
     public init(session: URLSession = .shared) {
         self.session = session
         decoder.dateDecodingStrategy = .iso8601
@@ -98,7 +104,7 @@ public actor CompanionClient {
     private struct SessionOutputResponse: Decodable, Sendable { let output: String? }
 
     public func stopSession(id: String) async throws {
-        var request = makeRequest(path: "v1/sessions/\(id)/stop")
+        var request = makeRequest(path: "v1/sessions/\(id)/stop", timeout: RequestTimeout.mutation)
         request.httpMethod = "POST"
         let (data, response) = try await session.data(for: request)
         try validate(response: response, data: data)
@@ -114,7 +120,7 @@ public actor CompanionClient {
     }
 
     public func nudgeSession(id: String) async throws {
-        var request = makeRequest(path: "v1/sessions/\(id)/nudge")
+        var request = makeRequest(path: "v1/sessions/\(id)/nudge", timeout: RequestTimeout.mutation)
         request.httpMethod = "POST"
         let (data, response) = try await session.data(for: request)
         try validate(response: response, data: data)
@@ -143,7 +149,7 @@ public actor CompanionClient {
     }
 
     public func events() async throws -> AsyncThrowingStream<CompanionEvent, Error> {
-        var request = makeRequest(path: "v1/events")
+        var request = makeRequest(path: "v1/events", timeout: RequestTimeout.stream)
         request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
 
         return AsyncThrowingStream { continuation in
@@ -188,7 +194,7 @@ public actor CompanionClient {
             conversations: conversations,
             messagesByConversation: messagesByConversation
         )
-        var request = makeRequest(path: "v1/conversations/sync")
+        var request = makeRequest(path: "v1/conversations/sync", timeout: RequestTimeout.mutation)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try encoder.encode(payload)
@@ -197,7 +203,10 @@ public actor CompanionClient {
     }
 
     public func deleteConversationOnServer(id: UUID) async throws {
-        var request = makeRequest(path: "v1/conversations/\(id.uuidString)")
+        var request = makeRequest(
+            path: "v1/conversations/\(id.uuidString)",
+            timeout: RequestTimeout.mutation
+        )
         request.httpMethod = "DELETE"
         let (data, response) = try await session.data(for: request)
         try validate(response: response, data: data)
@@ -211,9 +220,10 @@ public actor CompanionClient {
         return try decoder.decode(Value.self, from: data)
     }
 
-    private func makeRequest(path: String) -> URLRequest {
+    private func makeRequest(path: String, timeout: TimeInterval = RequestTimeout.list) -> URLRequest {
         let baseURL = URL(string: configuration.baseURL) ?? URL(string: "http://127.0.0.1:8742")!
         var request = URLRequest(url: baseURL.appending(path: path))
+        request.timeoutInterval = timeout
         if let bearerToken = configuration.bearerToken, !bearerToken.isEmpty {
             request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
         }

--- a/AgentBoardCore/Services/CompanionClient.swift
+++ b/AgentBoardCore/Services/CompanionClient.swift
@@ -46,7 +46,9 @@ public actor CompanionClient {
     private enum RequestTimeout {
         static let list: TimeInterval = 15
         static let mutation: TimeInterval = 30
-        static let stream: TimeInterval = .greatestFiniteMagnitude
+        // Long-lived streaming requests should use a large but finite timeout so
+        // URLSession retains predictable timeout and cancellation behavior.
+        static let stream: TimeInterval = 24 * 60 * 60
     }
 
     public init(session: URLSession = .shared) {

--- a/AgentBoardCore/Services/GitHubWorkService.swift
+++ b/AgentBoardCore/Services/GitHubWorkService.swift
@@ -47,7 +47,24 @@ public struct GitHubIssueDraft: Sendable {
     }
 }
 
-public actor GitHubWorkService {
+public protocol GitHubWorkServicing: Actor {
+    func configure(
+        repositories: [ConfiguredRepository],
+        token: String?
+    )
+    func fetchWorkItems() async throws -> [WorkItem]
+    func createIssue(
+        repository: ConfiguredRepository,
+        draft: GitHubIssueDraft
+    ) async throws -> WorkItem
+    func updateIssue(
+        repository: ConfiguredRepository,
+        issueNumber: Int,
+        patch: GitHubIssuePatch
+    ) async throws -> WorkItem
+}
+
+public actor GitHubWorkService: GitHubWorkServicing {
     public enum ServiceError: LocalizedError, Sendable {
         case unauthorized
         case notFound
@@ -159,7 +176,7 @@ public actor GitHubWorkService {
         }
 
         let url = try buildURL(repository: repository, endpoint: "issues")
-        var request = authorizedRequest(url: url, token: token)
+        var request = authorizedRequest(url: url, token: token, timeout: Self.mutationTimeout)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
@@ -190,7 +207,7 @@ public actor GitHubWorkService {
         }
 
         let url = try buildURL(repository: repository, endpoint: "issues/\(issueNumber)")
-        var request = authorizedRequest(url: url, token: token)
+        var request = authorizedRequest(url: url, token: token, timeout: Self.mutationTimeout)
         request.httpMethod = "PATCH"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
@@ -393,8 +410,16 @@ public actor GitHubWorkService {
         return url
     }
 
-    private func authorizedRequest(url: URL, token: String) -> URLRequest {
+    private static let listTimeout: TimeInterval = 15
+    private static let mutationTimeout: TimeInterval = 30
+
+    private func authorizedRequest(
+        url: URL,
+        token: String,
+        timeout: TimeInterval = GitHubWorkService.listTimeout
+    ) -> URLRequest {
         var request = URLRequest(url: url)
+        request.timeoutInterval = timeout
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
         request.setValue("AgentBoard", forHTTPHeaderField: "User-Agent")

--- a/AgentBoardCore/Stores/SettingsStore.swift
+++ b/AgentBoardCore/Stores/SettingsStore.swift
@@ -180,7 +180,7 @@ public final class SettingsStore {
         errorMessage = nil
     }
 
-    public func selectHermesProfile(id: String) {
+    public func selectHermesProfile(id: String, silent: Bool = false) {
         guard let profile = hermesProfiles.first(where: { $0.id == id }) else { return }
         selectedHermesProfileID = profile.id
         hermesGatewayURL = profile.gatewayURL
@@ -188,7 +188,9 @@ public final class SettingsStore {
             hermesModelID = modelID
         }
         errorMessage = nil
-        statusMessage = "Switched to \(profile.name)."
+        if !silent {
+            statusMessage = "Switched to \(profile.name)."
+        }
     }
 
     public func removeHermesProfile(_ profile: HermesProfile) {
@@ -217,7 +219,7 @@ public final class SettingsStore {
         selectedHermesProfileID = settings.selectedHermesProfileID
         if let selectedHermesProfileID,
            hermesProfiles.contains(where: { $0.id == selectedHermesProfileID }) {
-            selectHermesProfile(id: selectedHermesProfileID)
+            selectHermesProfile(id: selectedHermesProfileID, silent: true)
         }
 
         companionURL = settings.companionURL

--- a/AgentBoardCore/Stores/WorkStore.swift
+++ b/AgentBoardCore/Stores/WorkStore.swift
@@ -6,7 +6,7 @@ import os
 @Observable
 public final class WorkStore {
     private let logger = Logger(subsystem: "com.agentboard.modern", category: "WorkStore")
-    private let service: GitHubWorkService
+    private let service: any GitHubWorkServicing
     private let cache: any AgentBoardCacheProtocol
     private let settingsStore: SettingsStore
 
@@ -17,13 +17,14 @@ public final class WorkStore {
     public var statusMessage: String?
 
     private var didBootstrap = false
+    private var appliedConfiguration: GitHubConfiguration?
 
     /// Tracks the data fingerprint from the last successful refresh.
     /// Used to skip SwiftUI updates when the data hasn't actually changed.
     private var lastFingerprint: String = ""
 
     public init(
-        service: GitHubWorkService,
+        service: any GitHubWorkServicing,
         cache: any AgentBoardCacheProtocol,
         settingsStore: SettingsStore
     ) {
@@ -81,10 +82,7 @@ public final class WorkStore {
         // Don't flash the loading state — keep existing data visible during refresh
         isLoading = true
 
-        await service.configure(
-            repositories: settingsStore.repositories,
-            token: settingsStore.githubToken.trimmedOrNil
-        )
+        await configureServiceIfNeeded()
 
         do {
             let fresh = try await service.fetchWorkItems()
@@ -151,10 +149,7 @@ public final class WorkStore {
             errorMessage = "Connect GitHub before creating issues."
             return
         }
-        await service.configure(
-            repositories: settingsStore.repositories,
-            token: settingsStore.githubToken.trimmedOrNil
-        )
+        await configureServiceIfNeeded()
         do {
             let item = try await service.createIssue(
                 repository: repository,
@@ -192,10 +187,7 @@ public final class WorkStore {
             errorMessage = "Connect GitHub before updating issues."
             return
         }
-        await service.configure(
-            repositories: settingsStore.repositories,
-            token: settingsStore.githubToken.trimmedOrNil
-        )
+        await configureServiceIfNeeded()
         let patch = GitHubIssuePatch(
             title: title,
             body: body,
@@ -233,10 +225,7 @@ public final class WorkStore {
             return
         }
 
-        await service.configure(
-            repositories: settingsStore.repositories,
-            token: settingsStore.githubToken.trimmedOrNil
-        )
+        await configureServiceIfNeeded()
 
         let labels = replacingStatusLabels(in: item.labels, with: state)
         let patch = GitHubIssuePatch(
@@ -293,6 +282,24 @@ public final class WorkStore {
         }
         result.append(state.labelValue)
         return Array(Set(result)).sortedCaseInsensitive()
+    }
+
+    private func configureServiceIfNeeded() async {
+        let configuration = GitHubConfiguration(
+            repositories: settingsStore.repositories,
+            token: settingsStore.githubToken.trimmedOrNil
+        )
+        guard configuration != appliedConfiguration else { return }
+        await service.configure(
+            repositories: configuration.repositories,
+            token: configuration.token
+        )
+        appliedConfiguration = configuration
+    }
+
+    private struct GitHubConfiguration: Equatable {
+        let repositories: [ConfiguredRepository]
+        let token: String?
     }
 
     #if DEBUG

--- a/AgentBoardCore/Stores/WorkStore.swift
+++ b/AgentBoardCore/Stores/WorkStore.swift
@@ -290,11 +290,11 @@ public final class WorkStore {
             token: settingsStore.githubToken.trimmedOrNil
         )
         guard configuration != appliedConfiguration else { return }
+        appliedConfiguration = configuration
         await service.configure(
             repositories: configuration.repositories,
             token: configuration.token
         )
-        appliedConfiguration = configuration
     }
 
     private struct GitHubConfiguration: Equatable {

--- a/AgentBoardMobile/MobileRootView.swift
+++ b/AgentBoardMobile/MobileRootView.swift
@@ -6,56 +6,57 @@ struct MobileRootView: View {
 
     var body: some View {
         TabView(selection: $selectedDestination) {
-            NavigationStack {
-                ChatScreen()
-                    .navigationTitle(AppDestination.chat.title)
-            }
-            .tabItem {
+            Tab(value: AppDestination.chat) {
+                NavigationStack {
+                    ChatScreen()
+                        .navigationTitle(AppDestination.chat.title)
+                }
+                .accessibilityIdentifier("mobile_tab_chat")
+            } label: {
                 Label(AppDestination.chat.title, systemImage: AppDestination.chat.systemImage)
             }
-            .tag(AppDestination.chat)
-            .accessibilityIdentifier("mobile_tab_chat")
 
-            NavigationStack {
-                WorkScreen()
-                    .navigationTitle(AppDestination.work.title)
-            }
-            .tabItem {
+            Tab(value: AppDestination.work) {
+                NavigationStack {
+                    WorkScreen()
+                        .navigationTitle(AppDestination.work.title)
+                }
+                .accessibilityIdentifier("mobile_tab_work")
+            } label: {
                 Label(AppDestination.work.title, systemImage: AppDestination.work.systemImage)
             }
-            .tag(AppDestination.work)
-            .accessibilityIdentifier("mobile_tab_work")
 
-            NavigationStack {
-                AgentsScreen()
-                    .navigationTitle(AppDestination.agents.title)
-            }
-            .tabItem {
+            Tab(value: AppDestination.agents) {
+                NavigationStack {
+                    AgentsScreen()
+                        .navigationTitle(AppDestination.agents.title)
+                }
+                .accessibilityIdentifier("mobile_tab_agents")
+            } label: {
                 Label(AppDestination.agents.title, systemImage: AppDestination.agents.systemImage)
             }
-            .tag(AppDestination.agents)
-            .accessibilityIdentifier("mobile_tab_agents")
 
-            NavigationStack {
-                SessionsScreen()
-                    .navigationTitle(AppDestination.sessions.title)
-            }
-            .tabItem {
+            Tab(value: AppDestination.sessions) {
+                NavigationStack {
+                    SessionsScreen()
+                        .navigationTitle(AppDestination.sessions.title)
+                }
+                .accessibilityIdentifier("mobile_tab_sessions")
+            } label: {
                 Label(AppDestination.sessions.title, systemImage: AppDestination.sessions.systemImage)
             }
-            .tag(AppDestination.sessions)
-            .accessibilityIdentifier("mobile_tab_sessions")
 
-            NavigationStack {
-                SettingsScreen()
-                    .navigationTitle(AppDestination.settings.title)
-            }
-            .tabItem {
+            Tab(value: AppDestination.settings) {
+                NavigationStack {
+                    SettingsScreen()
+                        .navigationTitle(AppDestination.settings.title)
+                }
+                .accessibilityIdentifier("mobile_tab_settings")
+            } label: {
                 Label(AppDestination.settings.title, systemImage: AppDestination.settings.systemImage)
             }
-            .tag(AppDestination.settings)
-            .accessibilityIdentifier("mobile_tab_settings")
         }
+        .tabViewStyle(.sidebarAdaptable)
         .tint(.accentColor)
         .accessibilityIdentifier("screen_mobileRoot")
     }

--- a/AgentBoardTests/AgentBoardCacheTests.swift
+++ b/AgentBoardTests/AgentBoardCacheTests.swift
@@ -151,6 +151,37 @@ struct AgentBoardCacheTests {
         #expect(loaded[0].issueNumber == 1)
     }
 
+    @Test func replaceWorkItemsUpdatesExistingRecord() throws {
+        let cache = try AgentBoardCache(inMemory: true)
+        let repo = ConfiguredRepository(owner: "org", name: "repo")
+        let createdAt = Date(timeIntervalSinceReferenceDate: 10)
+        let updatedAt = Date(timeIntervalSinceReferenceDate: 20)
+        let item = WorkItem(
+            repository: repo, issueNumber: 1, title: "Original",
+            bodySummary: "", isClosed: false, assignees: [],
+            milestone: nil, labels: ["status:ready"], status: .ready, priority: .p2,
+            agentHint: nil, createdAt: createdAt, updatedAt: updatedAt
+        )
+        let updated = WorkItem(
+            repository: repo, issueNumber: 1, title: "Updated",
+            bodySummary: "Changed", isClosed: false, assignees: ["blake"],
+            milestone: nil, labels: ["status:review"], status: .review, priority: .p1,
+            agentHint: "codex", createdAt: createdAt, updatedAt: updatedAt.addingTimeInterval(1)
+        )
+
+        try cache.replaceWorkItems([item])
+        try cache.replaceWorkItems([updated])
+
+        let loaded = try #require(cache.loadWorkItems().first)
+        #expect(loaded.id == item.id)
+        #expect(loaded.title == "Updated")
+        #expect(loaded.bodySummary == "Changed")
+        #expect(loaded.assignees == ["blake"])
+        #expect(loaded.status == .review)
+        #expect(loaded.priority == .p1)
+        #expect(loaded.agentHint == "codex")
+    }
+
     @Test func workItemWithNilMilestoneRoundTrips() throws {
         let cache = try AgentBoardCache(inMemory: true)
         let repo = ConfiguredRepository(owner: "org", name: "repo")

--- a/AgentBoardTests/CompanionClientEventsTests.swift
+++ b/AgentBoardTests/CompanionClientEventsTests.swift
@@ -27,6 +27,7 @@ struct CompanionClientEventsTests {
         let client = CompanionClient(session: makeMockSession { request in
             #expect(request.url?.path == "/v1/events")
             #expect(request.value(forHTTPHeaderField: "Accept") == "text/event-stream")
+            #expect(request.timeoutInterval > 3600)
             let response = try HTTPURLResponse(
                 url: #require(request.url),
                 statusCode: 200,
@@ -46,6 +47,45 @@ struct CompanionClientEventsTests {
 
         #expect(received.map(\.id) == [firstID, secondID])
         #expect(received.map(\.kind) == [.sessionsChanged, .conversationsChanged])
+    }
+
+    @Test
+    func listRequestsUseFifteenSecondTimeout() async throws {
+        let client = CompanionClient(session: makeMockSession { request in
+            #expect(request.url?.path == "/v1/sessions")
+            #expect(request.timeoutInterval == 15)
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, Data("[]".utf8))
+        })
+
+        try await client.configure(baseURL: "http://companion.test:8742", bearerToken: nil)
+
+        let sessions = try await client.listSessions()
+        #expect(sessions.isEmpty)
+    }
+
+    @Test
+    func mutationRequestsUseThirtySecondTimeout() async throws {
+        let client = CompanionClient(session: makeMockSession { request in
+            #expect(request.url?.path == "/v1/sessions/session-1/stop")
+            #expect(request.timeoutInterval == 30)
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, Data(#"{"ok": true}"#.utf8))
+        })
+
+        try await client.configure(baseURL: "http://companion.test:8742", bearerToken: nil)
+
+        try await client.stopSession(id: "session-1")
     }
 
     @Test

--- a/AgentBoardTests/GitHubWorkServiceTests.swift
+++ b/AgentBoardTests/GitHubWorkServiceTests.swift
@@ -8,6 +8,7 @@ struct GitHubWorkServiceTests {
     func fetchWorkItemsMapsLabelsAndFiltersPullRequests() async throws {
         let service = GitHubWorkService(session: makeMockSession { request in
             #expect(request.url?.path == "/repos/openai/agentboard/issues")
+            #expect(request.timeoutInterval == 15)
 
             let response = try HTTPURLResponse(
                 url: #require(request.url),
@@ -77,5 +78,84 @@ struct GitHubWorkServiceTests {
         let unlabeled = try #require(items.first(where: { $0.issueNumber == 18 }))
         #expect(unlabeled.status == .ready)
         #expect(unlabeled.priority == .p2)
+    }
+
+    @Test
+    func createIssueUsesMutationTimeout() async throws {
+        let service = GitHubWorkService(session: makeMockSession { request in
+            #expect(request.httpMethod == "POST")
+            #expect(request.url?.path == "/repos/openai/agentboard/issues")
+            #expect(request.timeoutInterval == 30)
+
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, Data(issueJSON(number: 21).utf8))
+        })
+        await service.configure(
+            repositories: [ConfiguredRepository(owner: "openai", name: "agentboard")],
+            token: "ghp_example"
+        )
+
+        let item = try await service.createIssue(
+            repository: ConfiguredRepository(owner: "openai", name: "agentboard"),
+            draft: GitHubIssueDraft(
+                title: "New issue",
+                body: "Details",
+                labels: ["status:ready"],
+                assignees: [],
+                milestone: nil
+            )
+        )
+
+        #expect(item.issueNumber == 21)
+    }
+
+    @Test
+    func updateIssueUsesMutationTimeout() async throws {
+        let service = GitHubWorkService(session: makeMockSession { request in
+            #expect(request.httpMethod == "PATCH")
+            #expect(request.url?.path == "/repos/openai/agentboard/issues/22")
+            #expect(request.timeoutInterval == 30)
+
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, Data(issueJSON(number: 22).utf8))
+        })
+        await service.configure(
+            repositories: [ConfiguredRepository(owner: "openai", name: "agentboard")],
+            token: "ghp_example"
+        )
+
+        let item = try await service.updateIssue(
+            repository: ConfiguredRepository(owner: "openai", name: "agentboard"),
+            issueNumber: 22,
+            patch: GitHubIssuePatch(title: "Updated")
+        )
+
+        #expect(item.issueNumber == 22)
+    }
+
+    private func issueJSON(number: Int) -> String {
+        """
+        {
+          "number": \(number),
+          "title": "Issue \(number)",
+          "body": "Body",
+          "state": "open",
+          "labels": [{"name": "status:ready"}],
+          "assignees": [],
+          "milestone": null,
+          "created_at": "2026-04-20T12:00:00Z",
+          "updated_at": "2026-04-22T15:30:00Z"
+        }
+        """
     }
 }

--- a/AgentBoardTests/NativeSwiftUIInterfaceTests.swift
+++ b/AgentBoardTests/NativeSwiftUIInterfaceTests.swift
@@ -29,11 +29,34 @@ struct NativeSwiftUIInterfaceTests {
         let appSource = try Self.source("AgentBoardMobile/AgentBoardMobileApp.swift")
 
         #expect(rootSource.contains("TabView(selection:"))
-        #expect(rootSource.contains(".tag(AppDestination.chat)"))
-        #expect(rootSource.contains(".tag(AppDestination.settings)"))
+        #expect(rootSource.contains("Tab(value: AppDestination.chat)"))
+        #expect(rootSource.contains("Tab(value: AppDestination.settings)"))
+        #expect(rootSource.contains(".tabViewStyle(.sidebarAdaptable)"))
+        #expect(!rootSource.contains(".tabItem"))
+        #expect(!rootSource.contains(".tag(AppDestination"))
         #expect(!rootSource.contains("UITabBarAppearance"))
         #expect(!rootSource.contains("UITabBar.appearance()"))
         #expect(!appSource.contains("applyTabBarAppearance"))
+    }
+
+    @Test func cacheReplacesCollectionsWithoutDeleteAllWriteAmplification() throws {
+        let source = try Self.source("AgentBoardCore/Persistence/AgentBoardCache.swift")
+
+        #expect(source.contains("func update(from item: WorkItem"))
+        #expect(source.contains("func update(from session: AgentSession"))
+        #expect(source.contains("func update(from agent: AgentSummary"))
+        #expect(!source.contains("replaceAll(CachedWorkItemRecord.self)"))
+        #expect(!source.contains("replaceAll(CachedSessionRecord.self)"))
+        #expect(!source.contains("replaceAll(CachedAgentRecord.self)"))
+    }
+
+    @Test func attachmentUploadRetainsProgressObservationUntilTaskCleanup() throws {
+        let source = try Self.source("AgentBoardCore/Services/AttachmentUploadService.swift")
+
+        #expect(source.contains("progressObservations: [Int: NSKeyValueObservation]"))
+        #expect(source.contains("progressObservations[task.taskIdentifier] = observation"))
+        #expect(source.contains("finishUpload(attachmentID:"))
+        #expect(!source.contains("_ = observation"))
     }
 
     private static func source(_ relativePath: String) throws -> String {

--- a/AgentBoardTests/SettingsStoreTests.swift
+++ b/AgentBoardTests/SettingsStoreTests.swift
@@ -163,6 +163,34 @@ struct SettingsStoreTests {
         #expect(store.hermesGatewayURL == "http://127.0.0.1:8642")
         #expect(store.hermesModelID == "hermes-agent")
         #expect(store.selectedHermesProfileID == localID)
+        #expect(store.statusMessage == "Switched to Local.")
+    }
+
+    @Test func bootstrapSilentlyAppliesSelectedHermesProfile() async throws {
+        let repository = SettingsRepository(
+            suiteName: "SettingsStoreTests-bootstrap-\(UUID().uuidString)",
+            serviceName: "SettingsStoreTests-bootstrap-\(UUID().uuidString)"
+        )
+        let profile = HermesProfile(
+            id: "local",
+            name: "Local",
+            gatewayURL: "http://127.0.0.1:8642",
+            modelID: "hermes-local"
+        )
+        try await repository.saveSettings(AgentBoardSettings(
+            hermesGatewayURL: "http://127.0.0.1:9000",
+            hermesModelID: "hermes-fallback",
+            hermesProfiles: [profile],
+            selectedHermesProfileID: profile.id
+        ))
+        let store = SettingsStore(repository: repository)
+
+        await store.bootstrap()
+
+        #expect(store.hermesGatewayURL == profile.gatewayURL)
+        #expect(store.hermesModelID == profile.modelID)
+        #expect(store.selectedHermesProfileID == profile.id)
+        #expect(store.statusMessage == "Settings loaded.")
     }
 
     @Test func removeHermesProfileDeletesIt() {

--- a/AgentBoardTests/WorkStoreTests.swift
+++ b/AgentBoardTests/WorkStoreTests.swift
@@ -298,6 +298,30 @@ struct WorkStoreTests {
         #expect(store.isLoading == false)
     }
 
+    @Test func refreshConfiguresServiceOnlyWhenSettingsChange() async throws {
+        let service = CountingGitHubWorkService()
+        let cache = try AgentBoardCache(inMemory: true)
+        let repo = SettingsRepository(
+            suiteName: "refresh-config-\(UUID().uuidString)",
+            serviceName: "refresh-config-\(UUID().uuidString)"
+        )
+        let settingsStore = SettingsStore(repository: repo)
+        settingsStore.githubToken = "ghp_test"
+        settingsStore.repositories = [ConfiguredRepository(owner: "org", name: "repo")]
+        let store = WorkStore(service: service, cache: cache, settingsStore: settingsStore)
+
+        await store.refresh()
+        await store.refresh()
+
+        #expect(await service.configurationCount() == 1)
+
+        settingsStore.repositories.append(ConfiguredRepository(owner: "org", name: "second"))
+        await store.refresh()
+
+        #expect(await service.configurationCount() == 2)
+        #expect(await service.latestRepositories() == settingsStore.repositories)
+    }
+
     // MARK: - workItem(for:)
 
     @Test func workItemForReferenceReturnsMatchingItem() async throws {
@@ -615,6 +639,45 @@ struct WorkStoreTests {
             "updated_at": "2026-04-02T00:00:00Z"
         }
         """
+    }
+}
+
+private enum CountingServiceError: Error {
+    case unsupportedOperation
+}
+
+private actor CountingGitHubWorkService: GitHubWorkServicing {
+    private var configurations: [([ConfiguredRepository], String?)] = []
+
+    func configure(repositories: [ConfiguredRepository], token: String?) {
+        configurations.append((repositories, token))
+    }
+
+    func fetchWorkItems() async throws -> [WorkItem] {
+        []
+    }
+
+    func createIssue(
+        repository _: ConfiguredRepository,
+        draft _: GitHubIssueDraft
+    ) async throws -> WorkItem {
+        throw CountingServiceError.unsupportedOperation
+    }
+
+    func updateIssue(
+        repository _: ConfiguredRepository,
+        issueNumber _: Int,
+        patch _: GitHubIssuePatch
+    ) async throws -> WorkItem {
+        throw CountingServiceError.unsupportedOperation
+    }
+
+    func configurationCount() -> Int {
+        configurations.count
+    }
+
+    func latestRepositories() -> [ConfiguredRepository] {
+        configurations.last?.0 ?? []
     }
 }
 


### PR DESCRIPTION
## Summary
- Dedupe GitHub service configuration behind WorkStore configuration change detection.
- Retain attachment upload progress observations until completion/cancel and make cache collection refreshes upsert/no-op instead of delete-all.
- Add explicit REST/SSE request timeout contracts and migrate the iOS root to the modern SwiftUI Tab API.

Closes #109
Closes #111
Closes #112
Closes #113
Closes #114
Closes #115

## Verification
- swiftformat --config .swiftformat $(git diff --name-only -- "*.swift")
- swiftlint lint --strict --config .swiftlint.yml
- xcodebuild test -quiet -project AgentBoard.xcodeproj -scheme AgentBoard -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO
- xcodebuild build -quiet -project AgentBoard.xcodeproj -scheme AgentBoardMobile -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO
- xcodebuild build -quiet -project AgentBoard.xcodeproj -scheme AgentBoardCompanion -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO

Note: iOS build still emits pre-existing warnings in AttachmentPicker and SettingsScreen; no new warning class from this patch.