### PR TITLE
feat: add LifeOps executive assistant scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Xcode
 build/
 DerivedData/
+.swiftlint-cache/
 *.xcworkspace
 !*.xcodeproj/project.pbxproj
 !*.xcodeproj/xcshareddata/

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,6 +4,8 @@ disabled_rules:
   - force_try                 # acceptable in test contexts
   - large_tuple               # used in existing service APIs
 
+cache_path: .swiftlint-cache
+
 opt_in_rules:
   - array_init
   - closure_spacing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ Located in `SharedResources/Assets.xcassets/AppIcon.appiconset/`. All 10 macOS s
 ## Design decisions
 
 See `docs/ADR.md` for the full architecture decision record. Key recent ADRs:
+- **ADR-014** (2026-05-27): Planned LifeOps executive assistant module for ADHD-oriented personal/family/job-search task support
 - **ADR-013** (2026-05-23): Native SwiftUI app shell controls
 - **ADR-011** (2026-05-01): Kanban.db as task backend
 - **ADR-010** (2026-04-23): Hermes-first shared SwiftUI rebuild
@@ -202,3 +203,9 @@ fix the ui theme
 
 ## Activity — 2026-05-25
 - Fixed open ticket batch #130-#133: Work board repository selection now persists per scene and seeds create-issue sheets; create issue dismisses based on a successful created item; launched sessions auto-open the terminal; tmux `EXITED:` output now drives completed/failed state; companion-backed session details expose an interactive terminal tab when a tmux session is available.
+
+## Activity — 2026-05-26
+- (no commits)
+
+## Activity — 2026-05-27
+- Planned LifeOps executive assistant module: PRD/design/implementation plan for ADHD-oriented task support, job-search pipeline, Sarah/family iMessage intake, macOS dashboard, and iOS companion app.

--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		0CE0E873675F3D87FC974CB1 /* AttachmentUploadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E035F81810040D898374ACEF /* AttachmentUploadService.swift */; };
 		0D4B6287FB492E255C4E927C /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = 8E67F37D82C33338077E4371 /* Nuke */; };
 		0E24BCCE3258BA3081DFB21D /* VoiceViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEBA7BFDBBBF6316B340FAA /* VoiceViews.swift */; };
+		0F3379D776A776D7FC37FB0A /* LifeOpsQuickCaptureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E91243457FA160EE3EF18 /* LifeOpsQuickCaptureView.swift */; };
 		10A2BF960BB432E046A8392E /* DesignSemanticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19CE389F4A620817A309F601 /* DesignSemanticsTests.swift */; };
 		15369C112AA2304F032D157F /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A2BE598EEDA7A998AEA8DE /* MarkdownText.swift */; };
 		171A150F155917F5196D7647 /* ChatHeaderPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01910C75287C5F3B6650B2A /* ChatHeaderPickerTests.swift */; };
@@ -28,6 +29,7 @@
 		1F824DF6C0CFA67F11902759 /* CompanionLocalProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA51DADAAAAFFE9B833D35E9 /* CompanionLocalProbe.swift */; };
 		1F9726A41234F9B401F973B1 /* AgentBoardCompanionKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DB3E71CE348AC298EB4048DE /* AgentBoardCompanionKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		21BD68D1C8793B9DA7441B08 /* AgentsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE362DDE00559E2C84434C13 /* AgentsScreen.swift */; };
+		220B76E01334A43189260311 /* LifeOpsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A24AA816CAE107FF4A68B21 /* LifeOpsModels.swift */; };
 		22AD45AE145021107CD2C0AA /* IssueDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A31E0F643092B573A4DB9D /* IssueDetailSheet.swift */; };
 		248C1EBCB463381663C02F10 /* KanbanDataReading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C9688956A467F60F3B9B34 /* KanbanDataReading.swift */; };
 		24E370A50876A2DF880E9481 /* ChatStore+SlashCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066AD427D541EBD8687B6276 /* ChatStore+SlashCommands.swift */; };
@@ -35,11 +37,13 @@
 		27A53DE53D6AC0A8E55FBC88 /* SessionsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A654F28E691A722E5B4F02 /* SessionsScreen.swift */; };
 		287C52CFEE7CDAF30B54A224 /* AgentsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE362DDE00559E2C84434C13 /* AgentsScreen.swift */; };
 		293FC2DA4D1A99F6056A3C91 /* WorkStoreCRUDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7863E93C0B04059321066BCD /* WorkStoreCRUDTests.swift */; };
+		2C39844BC0F23C5D21F674E8 /* LifeOpsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D311FAD1176FC18B72CA9D96 /* LifeOpsStoreTests.swift */; };
 		2DC5A28990E375C68274D794 /* KanbanCLIWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52428296B715E26DCC31E00 /* KanbanCLIWriter.swift */; };
 		2E95ECA2CB484B2089146AD0 /* QuickLaunchSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FFDF3222AEE5530E6C58DFC /* QuickLaunchSheet.swift */; };
 		2EFC8887C151538585798677 /* SessionDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05A145F7A1A70B53DF066DBD /* SessionDetailSheet.swift */; };
 		30B2D9B7D1BFC77B6964A96C /* AgentBoardDesignTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4542E208AACDF95595A0B0D4 /* AgentBoardDesignTheme.swift */; };
 		31F4BD470BD142ABB72D00E8 /* AgentsStoreCreateTaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C500C7AF3B484DBB847E3A /* AgentsStoreCreateTaskTests.swift */; };
+		3305DBAA628920B658A1AB1D /* LifeOpsQuickCaptureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E91243457FA160EE3EF18 /* LifeOpsQuickCaptureView.swift */; };
 		34C9CEDCDFB2E84348A0EDB4 /* ChatEndpointValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FC87E1E7EE82E2FE4C749F /* ChatEndpointValidatorTests.swift */; };
 		37F82839F098968527158CC9 /* EmbeddedTerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A978B41E9572538A1E74E5C /* EmbeddedTerminalView.swift */; };
 		38E1089316EEC57E444A6FB1 /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957114148477B05585A13D7C /* MockURLProtocol.swift */; };
@@ -66,8 +70,10 @@
 		637450D78114326A95AE3D39 /* CompanionServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0117F7D499C266663690C9B6 /* CompanionServer.swift */; };
 		64B8644401E5AFE74A627388 /* KeyboardDismissal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196C90FC0E35E33601741243 /* KeyboardDismissal.swift */; };
 		663041B8ACBF6F3819DE44A6 /* AgentBoardCompanionMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06CD1EF1E211EE615B37F28B /* AgentBoardCompanionMain.swift */; };
+		6772C9DCB36D8C2BEAAEBA9C /* LifeOpsModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F4472A5CC5478A23642FA6 /* LifeOpsModelsTests.swift */; };
 		680A624F6E9ED591E1F63DA2 /* ChatStreamCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40E2B4B6D9AD354BA23C3BF /* ChatStreamCoordinator.swift */; };
 		69807B75BA17F5A303D50067 /* DomainModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C233996F081109570393D6FA /* DomainModelsTests.swift */; };
+		69ADFC49254CC4ECDC4A7C3A /* LifeOpsTaskRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3694C97E5D277D7504AA129 /* LifeOpsTaskRow.swift */; };
 		6A4091B95B722862F973E0BC /* MobileRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 959F1DE11FF3233AB9029B6D /* MobileRootView.swift */; };
 		6AD44EB0146CC268B39C27E1 /* ChatScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FDDFF5030B377E6973E969 /* ChatScreen.swift */; };
 		6C01165BC7D2080055198DFB /* ChatComposeBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA4419D691667740AA51BAC /* ChatComposeBar.swift */; };
@@ -112,21 +118,27 @@
 		B01C8989FACCB9D76DD46CDF /* ChatStoreSlashCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0551DF2CA889DD84A9EFF3B7 /* ChatStoreSlashCommandTests.swift */; };
 		B05AB72D9955BEF4CD1E3B7A /* KanbanModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A55930915B4E8B29ECFC5DD /* KanbanModels.swift */; };
 		B32E7225FAA8967B580A58A1 /* CreateIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 702A0D71A27F07711AF96C4A /* CreateIssueSheet.swift */; };
+		B35C1F94F54826B92D201563 /* LifeOpsFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18F42FECD0587F7572937405 /* LifeOpsFixtures.swift */; };
 		B51F9A6B9302EDD7F2EB1437 /* BoardChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D736CF52ACD4E2BD9D3ADC /* BoardChrome.swift */; };
 		B87AB9550FF94448824BFFB2 /* ChatHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82BF95164B1DFE66D15CB770 /* ChatHeader.swift */; };
 		BAFAE9A54D7EB126DB951F33 /* AgentBoardCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8ECD5A8D1C4F9C4099CBB9C /* AgentBoardCacheTests.swift */; };
 		BB98957985B7A8398A87A372 /* TaskDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651B64AF0921713BAE550D2D /* TaskDetailSheet.swift */; };
 		BC1CCDB452C13C403BFA1460 /* DomainPills.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A169A5D550028B6D20B397D /* DomainPills.swift */; };
+		BCE2869164B04BA406132ADA /* LifeOpsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A474A7C20D60672BD8A3ACC /* LifeOpsScreen.swift */; };
 		BCE6371A2B658B37FE0C3124 /* LinkPreviewService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54CA712A46E969ED79300E4F /* LinkPreviewService.swift */; };
 		C03DE2AB570D615F55142A44 /* AgentBoardCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3024AF0B4A66DE64BDB27E15 /* AgentBoardCache.swift */; };
 		C23BCB5CF1615F000459D9E7 /* HermesGatewayClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7B2891F313F2E1804101D36 /* HermesGatewayClient.swift */; };
 		C32F8741DFBEF1D329D356E0 /* KanbanDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9896F487D5B25505452683B /* KanbanDataService.swift */; };
+		C61D27FFF251CAEE057AC51E /* LifeOpsTaskRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3694C97E5D277D7504AA129 /* LifeOpsTaskRow.swift */; };
 		C6A73DFEFD3440E23C5AE028 /* ChatStoreAdditionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30366B0DAB9553F53ACE2BE6 /* ChatStoreAdditionalTests.swift */; };
 		C6F5E2BE0559A438785BBCF8 /* FoundationExtras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ABBA014D0943EA3DA8EEB96 /* FoundationExtras.swift */; };
+		C7B9D6D466E12EB4039BBE0A /* LifeOpsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A474A7C20D60672BD8A3ACC /* LifeOpsScreen.swift */; };
 		C94A55ED7CCDD9540A5BF068 /* ChatMessageList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F872D9728B5938D841130C /* ChatMessageList.swift */; };
 		C951731D05F7310888D29149 /* ChatComposeBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA4419D691667740AA51BAC /* ChatComposeBar.swift */; };
 		C993681ECCC427965F61D4E6 /* SlashCommandHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D0FBEDFA7766F71A98B48E3 /* SlashCommandHandler.swift */; };
 		CB10A2005C3CAEE8253B7324 /* LabelSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2A97A08B0556443C6746EC /* LabelSchema.swift */; };
+		CE306EF59A1ACACB7346FDFD /* LifeOpsPriorityBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B5308FD6983C11F2DBDF3B /* LifeOpsPriorityBadge.swift */; };
+		CF0AA2F6693104AA61E2D210 /* LifeOpsPriorityBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B5308FD6983C11F2DBDF3B /* LifeOpsPriorityBadge.swift */; };
 		D2F03218C8433B59598A04D5 /* GitHubWorkServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0ED2A504BC7E3CA18E4094 /* GitHubWorkServiceTests.swift */; };
 		D4674853A5F6064FC3E65542 /* SettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4813FBD80F9AC10D1A51841 /* SettingsStoreTests.swift */; };
 		D5FE06BE70E2B8AFB20C40B5 /* DesktopSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7D59DE18AF7B3E0D84EF9A /* DesktopSidebar.swift */; };
@@ -144,6 +156,7 @@
 		E4EEFF2D183520968ACAA803 /* ChatStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3736AF6A2D292014811DA50A /* ChatStore.swift */; };
 		E79388194D430DAEC6569944 /* ChatStore+Internals.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86007C1F74BD16FE6181012 /* ChatStore+Internals.swift */; };
 		E931C3D8A3044AEA6C7F36BD /* AppDestinationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FCC4B5C12958567A1D6D69E /* AppDestinationTests.swift */; };
+		E947BD9BB4EBBD20070CBB35 /* LifeOpsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B71824F2D5E3AA95FE16AA /* LifeOpsStore.swift */; };
 		E9D09CAC0D952EE1295DFA60 /* LabelSchemaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8562113DB3BC11316C4B4A50 /* LabelSchemaTests.swift */; };
 		EB912DFB4FD8ED106AE6C02C /* ChatBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFBB71134457F46E6F2B247 /* ChatBubble.swift */; };
 		EEE501D250CCB4E6D2D60418 /* NukeUI in Frameworks */ = {isa = PBXBuildFile; productRef = 28BE44876742C1F619FDD2CA /* NukeUI */; };
@@ -153,6 +166,7 @@
 		F3D458595223FE83DD26EDC5 /* NukeUI in Frameworks */ = {isa = PBXBuildFile; productRef = AA403A62FC0CC3B341A2D00B /* NukeUI */; };
 		F595A9354548F0B6A8A8F2E3 /* AgentBoardCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; };
 		F78742DD742A458919E091C0 /* AgentBoardCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		FA0E509F0C7CD9997210C4DF /* LifeOpsInterfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7B035C7133EE37FF7717372 /* LifeOpsInterfaceTests.swift */; };
 		FD03671AAB65C52CE827D3DA /* AgentBoardCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; };
 		FD05A98C162D7CC536D93096 /* AgentBoardApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC92FF930020DC82D470A002 /* AgentBoardApp.swift */; };
 		FE8D645DBA85A27F0139427B /* AttachmentInteractions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31C11E46072F7E4A9FFADDB /* AttachmentInteractions.swift */; };
@@ -251,6 +265,7 @@
 		066AD427D541EBD8687B6276 /* ChatStore+SlashCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatStore+SlashCommands.swift"; sourceTree = "<group>"; };
 		06C0FE6A5C6D69E553E904D0 /* CompanionSQLiteStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionSQLiteStore.swift; sourceTree = "<group>"; };
 		06CD1EF1E211EE615B37F28B /* AgentBoardCompanionMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBoardCompanionMain.swift; sourceTree = "<group>"; };
+		08B71824F2D5E3AA95FE16AA /* LifeOpsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeOpsStore.swift; sourceTree = "<group>"; };
 		08B7CE4C138A75D87781C1DB /* SessionLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLauncher.swift; sourceTree = "<group>"; };
 		08C9688956A467F60F3B9B34 /* KanbanDataReading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanDataReading.swift; sourceTree = "<group>"; };
 		08FC87E1E7EE82E2FE4C749F /* ChatEndpointValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatEndpointValidatorTests.swift; sourceTree = "<group>"; };
@@ -259,9 +274,11 @@
 		0D0FBEDFA7766F71A98B48E3 /* SlashCommandHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandHandler.swift; sourceTree = "<group>"; };
 		132785F0427381E3DB05BD8E /* ChatEndpointValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatEndpointValidator.swift; sourceTree = "<group>"; };
 		17F872D9728B5938D841130C /* ChatMessageList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageList.swift; sourceTree = "<group>"; };
+		18F42FECD0587F7572937405 /* LifeOpsFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeOpsFixtures.swift; sourceTree = "<group>"; };
 		196C90FC0E35E33601741243 /* KeyboardDismissal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardDismissal.swift; sourceTree = "<group>"; };
 		19CE389F4A620817A309F601 /* DesignSemanticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSemanticsTests.swift; sourceTree = "<group>"; };
 		1A169A5D550028B6D20B397D /* DomainPills.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainPills.swift; sourceTree = "<group>"; };
+		1A474A7C20D60672BD8A3ACC /* LifeOpsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeOpsScreen.swift; sourceTree = "<group>"; };
 		1B80C98C4E1D5870D7ED4E2D /* TmuxController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxController.swift; sourceTree = "<group>"; };
 		1F06E0C2FFE9CAC90D48662B /* HermesGatewayClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesGatewayClientTests.swift; sourceTree = "<group>"; };
 		1FFDF3222AEE5530E6C58DFC /* QuickLaunchSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLaunchSheet.swift; sourceTree = "<group>"; };
@@ -273,6 +290,7 @@
 		30366B0DAB9553F53ACE2BE6 /* ChatStoreAdditionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStoreAdditionalTests.swift; sourceTree = "<group>"; };
 		33A654F28E691A722E5B4F02 /* SessionsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionsScreen.swift; sourceTree = "<group>"; };
 		33A8E745C7552F0B5FDF7C25 /* MediaViewerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaViewerView.swift; sourceTree = "<group>"; };
+		33F4472A5CC5478A23642FA6 /* LifeOpsModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeOpsModelsTests.swift; sourceTree = "<group>"; };
 		34D736CF52ACD4E2BD9D3ADC /* BoardChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardChrome.swift; sourceTree = "<group>"; };
 		351F53C221B69731A024B864 /* AgentBoard.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AgentBoard.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3736AF6A2D292014811DA50A /* ChatStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStore.swift; sourceTree = "<group>"; };
@@ -282,11 +300,13 @@
 		3B9B576059ADDC3B5D219868 /* FoundationExtrasTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationExtrasTests.swift; sourceTree = "<group>"; };
 		3E3C09A95E37674D30B6072F /* AttachmentPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentPicker.swift; sourceTree = "<group>"; };
 		3FEBA7BFDBBBF6316B340FAA /* VoiceViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceViews.swift; sourceTree = "<group>"; };
+		42B5308FD6983C11F2DBDF3B /* LifeOpsPriorityBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeOpsPriorityBadge.swift; sourceTree = "<group>"; };
 		4542E208AACDF95595A0B0D4 /* AgentBoardDesignTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBoardDesignTheme.swift; sourceTree = "<group>"; };
 		4A978B41E9572538A1E74E5C /* EmbeddedTerminalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedTerminalView.swift; sourceTree = "<group>"; };
 		4F7D59DE18AF7B3E0D84EF9A /* DesktopSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopSidebar.swift; sourceTree = "<group>"; };
 		52959B32060C120BA1BB1AB7 /* ShellEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvironment.swift; sourceTree = "<group>"; };
 		54CA712A46E969ED79300E4F /* LinkPreviewService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkPreviewService.swift; sourceTree = "<group>"; };
+		5A24AA816CAE107FF4A68B21 /* LifeOpsModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeOpsModels.swift; sourceTree = "<group>"; };
 		5F60733BA5BCAD5BD388E855 /* AgentBoardMobile.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AgentBoardMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		63376B7513D3E5CFE45372D6 /* BoardPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardPalette.swift; sourceTree = "<group>"; };
 		651B64AF0921713BAE550D2D /* TaskDetailSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailSheet.swift; sourceTree = "<group>"; };
@@ -328,7 +348,9 @@
 		BB9701D71214407E75807732 /* WorkStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkStoreTests.swift; sourceTree = "<group>"; };
 		BD2941E5B6C18CF76C4621BB /* AttachmentViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentViews.swift; sourceTree = "<group>"; };
 		BE362DDE00559E2C84434C13 /* AgentsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsScreen.swift; sourceTree = "<group>"; };
+		BF7E91243457FA160EE3EF18 /* LifeOpsQuickCaptureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeOpsQuickCaptureView.swift; sourceTree = "<group>"; };
 		C233996F081109570393D6FA /* DomainModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainModelsTests.swift; sourceTree = "<group>"; };
+		C3694C97E5D277D7504AA129 /* LifeOpsTaskRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeOpsTaskRow.swift; sourceTree = "<group>"; };
 		C86007C1F74BD16FE6181012 /* ChatStore+Internals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatStore+Internals.swift"; sourceTree = "<group>"; };
 		C8ECD5A8D1C4F9C4099CBB9C /* AgentBoardCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBoardCacheTests.swift; sourceTree = "<group>"; };
 		C9679A2004F1CFD39A588CC7 /* ConfigBackupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigBackupService.swift; sourceTree = "<group>"; };
@@ -336,9 +358,11 @@
 		CE1B1DC901AD1D60B3855D38 /* SessionLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLauncherTests.swift; sourceTree = "<group>"; };
 		D10B0893112C597A1F745A53 /* ProcessAsync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessAsync.swift; sourceTree = "<group>"; };
 		D165293786CA5ACAB31F2F12 /* CompanionClientEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionClientEventsTests.swift; sourceTree = "<group>"; };
+		D311FAD1176FC18B72CA9D96 /* LifeOpsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeOpsStoreTests.swift; sourceTree = "<group>"; };
 		D3A2A89ABC8C35C2FB32C909 /* AgentBoardCacheProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBoardCacheProtocol.swift; sourceTree = "<group>"; };
 		D4C9640747C8B7AE6E92BB20 /* AgentBoardAppModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBoardAppModel.swift; sourceTree = "<group>"; };
 		D7A095E80382BA922486329A /* SettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
+		D7B035C7133EE37FF7717372 /* LifeOpsInterfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeOpsInterfaceTests.swift; sourceTree = "<group>"; };
 		DB3E71CE348AC298EB4048DE /* AgentBoardCompanionKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AgentBoardCompanionKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DBD5578CD361B8A4976B9A0A /* AgentBoardCompanion */ = {isa = PBXFileReference; includeInIndex = 0; path = AgentBoardCompanion; sourceTree = BUILT_PRODUCTS_DIR; };
 		DEDFAB3DEE21BBA70FAF2EBD /* SessionTerminalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTerminalView.swift; sourceTree = "<group>"; };
@@ -433,6 +457,9 @@
 				6A0D9C21BA312AB952D0E48B /* KanbanAssigneePickerTests.swift */,
 				AE3F349D2B17FA90738CCDD5 /* KanbanModelsTests.swift */,
 				8562113DB3BC11316C4B4A50 /* LabelSchemaTests.swift */,
+				D7B035C7133EE37FF7717372 /* LifeOpsInterfaceTests.swift */,
+				33F4472A5CC5478A23642FA6 /* LifeOpsModelsTests.swift */,
+				D311FAD1176FC18B72CA9D96 /* LifeOpsStoreTests.swift */,
 				957114148477B05585A13D7C /* MockURLProtocol.swift */,
 				BB5CC5206E88A59FBD80A856 /* NativeSwiftUIInterfaceTests.swift */,
 				9503F3F8C1E54BE6D35A3641 /* PRDComposerTests.swift */,
@@ -456,6 +483,7 @@
 				043C2F07C2F7E6DFBC165E9A /* DomainModels.swift */,
 				0A55930915B4E8B29ECFC5DD /* KanbanModels.swift */,
 				AE2A97A08B0556443C6746EC /* LabelSchema.swift */,
+				5A24AA816CAE107FF4A68B21 /* LifeOpsModels.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -518,6 +546,7 @@
 				E52428296B715E26DCC31E00 /* KanbanCLIWriter.swift */,
 				08C9688956A467F60F3B9B34 /* KanbanDataReading.swift */,
 				A9896F487D5B25505452683B /* KanbanDataService.swift */,
+				18F42FECD0587F7572937405 /* LifeOpsFixtures.swift */,
 				54CA712A46E969ED79300E4F /* LinkPreviewService.swift */,
 				A04B1F730472F1F23A283354 /* PRDComposer.swift */,
 				08B7CE4C138A75D87781C1DB /* SessionLauncher.swift */,
@@ -548,6 +577,7 @@
 				702A0D71A27F07711AF96C4A /* CreateIssueSheet.swift */,
 				26A31E0F643092B573A4DB9D /* IssueDetailSheet.swift */,
 				03AD61915721952F19190205 /* LaunchSessionSheet.swift */,
+				1A474A7C20D60672BD8A3ACC /* LifeOpsScreen.swift */,
 				1FFDF3222AEE5530E6C58DFC /* QuickLaunchSheet.swift */,
 				05A145F7A1A70B53DF066DBD /* SessionDetailSheet.swift */,
 				33A654F28E691A722E5B4F02 /* SessionsScreen.swift */,
@@ -616,6 +646,9 @@
 				4F7D59DE18AF7B3E0D84EF9A /* DesktopSidebar.swift */,
 				1A169A5D550028B6D20B397D /* DomainPills.swift */,
 				4A978B41E9572538A1E74E5C /* EmbeddedTerminalView.swift */,
+				42B5308FD6983C11F2DBDF3B /* LifeOpsPriorityBadge.swift */,
+				BF7E91243457FA160EE3EF18 /* LifeOpsQuickCaptureView.swift */,
+				C3694C97E5D277D7504AA129 /* LifeOpsTaskRow.swift */,
 				A1A2BE598EEDA7A998AEA8DE /* MarkdownText.swift */,
 				CF5FFC325775B34533A9C6F1 /* Attachments */,
 			);
@@ -632,6 +665,7 @@
 				C86007C1F74BD16FE6181012 /* ChatStore+Internals.swift */,
 				066AD427D541EBD8687B6276 /* ChatStore+SlashCommands.swift */,
 				A40E2B4B6D9AD354BA23C3BF /* ChatStreamCoordinator.swift */,
+				08B71824F2D5E3AA95FE16AA /* LifeOpsStore.swift */,
 				A5B9C06C17BE65937A00661D /* SessionsStore.swift */,
 				F876603AEC9BE7B94289CA01 /* SettingsStore.swift */,
 				A06C1DAB866C77FF3A634D71 /* WorkStore.swift */,
@@ -917,6 +951,10 @@
 				1DBE4EB751A629F1664040D8 /* IssueDetailSheet.swift in Sources */,
 				64B8644401E5AFE74A627388 /* KeyboardDismissal.swift in Sources */,
 				7E6D512A772F03628C275D52 /* LaunchSessionSheet.swift in Sources */,
+				CF0AA2F6693104AA61E2D210 /* LifeOpsPriorityBadge.swift in Sources */,
+				3305DBAA628920B658A1AB1D /* LifeOpsQuickCaptureView.swift in Sources */,
+				C7B9D6D466E12EB4039BBE0A /* LifeOpsScreen.swift in Sources */,
+				C61D27FFF251CAEE057AC51E /* LifeOpsTaskRow.swift in Sources */,
 				DE5629641FE81BB20A7186A9 /* MarkdownText.swift in Sources */,
 				62B59C34430276AC70136C6D /* MediaViewerView.swift in Sources */,
 				624514151F83E5FC8A4EB2F2 /* NeumorphicTheme.swift in Sources */,
@@ -965,6 +1003,9 @@
 				0B3C6DC24A36FE8A19357506 /* KanbanAssigneePickerTests.swift in Sources */,
 				DAAA6677EBC51F4C7796E505 /* KanbanModelsTests.swift in Sources */,
 				E9D09CAC0D952EE1295DFA60 /* LabelSchemaTests.swift in Sources */,
+				FA0E509F0C7CD9997210C4DF /* LifeOpsInterfaceTests.swift in Sources */,
+				6772C9DCB36D8C2BEAAEBA9C /* LifeOpsModelsTests.swift in Sources */,
+				2C39844BC0F23C5D21F674E8 /* LifeOpsStoreTests.swift in Sources */,
 				38E1089316EEC57E444A6FB1 /* MockURLProtocol.swift in Sources */,
 				9781E0240F8A4C6FC3DC30B7 /* NativeSwiftUIInterfaceTests.swift in Sources */,
 				DAB3EA4A5AF33E4165CD6551 /* PRDComposerTests.swift in Sources */,
@@ -1008,6 +1049,9 @@
 				C32F8741DFBEF1D329D356E0 /* KanbanDataService.swift in Sources */,
 				B05AB72D9955BEF4CD1E3B7A /* KanbanModels.swift in Sources */,
 				CB10A2005C3CAEE8253B7324 /* LabelSchema.swift in Sources */,
+				B35C1F94F54826B92D201563 /* LifeOpsFixtures.swift in Sources */,
+				220B76E01334A43189260311 /* LifeOpsModels.swift in Sources */,
+				E947BD9BB4EBBD20070CBB35 /* LifeOpsStore.swift in Sources */,
 				BCE6371A2B658B37FE0C3124 /* LinkPreviewService.swift in Sources */,
 				A86A0A76B46CE6265194C0A6 /* PRDComposer.swift in Sources */,
 				D806724D20A2D1EC0A81416B /* ProcessAsync.swift in Sources */,
@@ -1045,6 +1089,10 @@
 				22AD45AE145021107CD2C0AA /* IssueDetailSheet.swift in Sources */,
 				736771D2489A4C0C6FBB4A83 /* KeyboardDismissal.swift in Sources */,
 				891566BE5B53801826DE8CF0 /* LaunchSessionSheet.swift in Sources */,
+				CE306EF59A1ACACB7346FDFD /* LifeOpsPriorityBadge.swift in Sources */,
+				0F3379D776A776D7FC37FB0A /* LifeOpsQuickCaptureView.swift in Sources */,
+				BCE2869164B04BA406132ADA /* LifeOpsScreen.swift in Sources */,
+				69ADFC49254CC4ECDC4A7C3A /* LifeOpsTaskRow.swift in Sources */,
 				15369C112AA2304F032D157F /* MarkdownText.swift in Sources */,
 				8AD4D2CC8A4C831C10AD484D /* MediaViewerView.swift in Sources */,
 				6A4091B95B722862F973E0BC /* MobileRootView.swift in Sources */,

--- a/AgentBoard/DesktopRootView.swift
+++ b/AgentBoard/DesktopRootView.swift
@@ -102,6 +102,8 @@ struct DesktopRootView: View {
             }
         } else {
             switch desktopDestination(for: appModel.selectedDestination) {
+            case .lifeOps:
+                LifeOpsScreen(store: appModel.lifeOpsStore, mode: .dashboard)
             case .work:
                 WorkScreen()
             case .agents:

--- a/AgentBoardCore/Models/AppDestination.swift
+++ b/AgentBoardCore/Models/AppDestination.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public enum AppDestination: String, CaseIterable, Identifiable, Sendable {
     case chat
+    case lifeOps
     case work
     case agents
     case sessions
@@ -14,6 +15,7 @@ public enum AppDestination: String, CaseIterable, Identifiable, Sendable {
     public var title: String {
         switch self {
         case .chat: "Chat"
+        case .lifeOps: "LifeOps"
         case .work: "Work"
         case .agents: "Agents"
         case .sessions: "Sessions"
@@ -24,6 +26,7 @@ public enum AppDestination: String, CaseIterable, Identifiable, Sendable {
     public var systemImage: String {
         switch self {
         case .chat: "bubble.left.and.bubble.right"
+        case .lifeOps: "checklist"
         case .work: "square.grid.2x2"
         case .agents: "person.3.sequence"
         case .sessions: "bolt.horizontal.circle"
@@ -32,6 +35,6 @@ public enum AppDestination: String, CaseIterable, Identifiable, Sendable {
     }
 
     public static var desktopTabs: [AppDestination] {
-        [.work, .agents, .sessions, .settings]
+        [.lifeOps, .work, .agents, .sessions, .settings]
     }
 }

--- a/AgentBoardCore/Models/LifeOpsModels.swift
+++ b/AgentBoardCore/Models/LifeOpsModels.swift
@@ -1,0 +1,486 @@
+import Foundation
+
+// The PRD names priorities P0 through P3, so these case names intentionally match it.
+// swiftlint:disable identifier_name
+public enum LifePriority: String, Codable, CaseIterable, Identifiable, Sendable {
+    case p0
+    case p1
+    case p2
+    case p3
+
+    public var id: String {
+        rawValue
+    }
+
+    public var displayName: String {
+        switch self {
+        case .p0: "P0"
+        case .p1: "P1"
+        case .p2: "P2"
+        case .p3: "P3"
+        }
+    }
+
+    public var sortRank: Int {
+        switch self {
+        case .p0: 0
+        case .p1: 1
+        case .p2: 2
+        case .p3: 3
+        }
+    }
+
+    public static var displayOrder: [LifePriority] {
+        [.p0, .p1, .p2, .p3]
+    }
+}
+// swiftlint:enable identifier_name
+
+public enum LifeTaskCategory: String, Codable, CaseIterable, Identifiable, Sendable {
+    case email
+    case calendar
+    case messages
+    case jobSearch
+    case family
+    case admin
+    case personal
+    case finance
+    case health
+    case project
+    case waitingOn
+    case approval
+
+    public var id: String {
+        rawValue
+    }
+
+    public var title: String {
+        switch self {
+        case .email: "Email"
+        case .calendar: "Calendar"
+        case .messages: "Messages"
+        case .jobSearch: "Job Search"
+        case .family: "Family"
+        case .admin: "Admin"
+        case .personal: "Personal"
+        case .finance: "Finance"
+        case .health: "Health"
+        case .project: "Project"
+        case .waitingOn: "Waiting On"
+        case .approval: "Approval"
+        }
+    }
+}
+
+public enum LifeTaskStatus: String, Codable, CaseIterable, Identifiable, Sendable {
+    case inbox
+    case needsBlake
+    case assignedToDaneel
+    case waitingOnExternal
+    case scheduled
+    case snoozed
+    case done
+    case blocked
+    case cancelled
+
+    public var id: String {
+        rawValue
+    }
+
+    public var title: String {
+        switch self {
+        case .inbox: "Inbox"
+        case .needsBlake: "Needs Blake"
+        case .assignedToDaneel: "Assigned to Daneel"
+        case .waitingOnExternal: "Waiting On"
+        case .scheduled: "Scheduled"
+        case .snoozed: "Snoozed"
+        case .done: "Done"
+        case .blocked: "Blocked"
+        case .cancelled: "Cancelled"
+        }
+    }
+
+    public var isTerminal: Bool {
+        switch self {
+        case .done, .cancelled: true
+        case .inbox, .needsBlake, .assignedToDaneel, .waitingOnExternal, .scheduled, .snoozed, .blocked: false
+        }
+    }
+}
+
+public enum LifeActor: String, Codable, CaseIterable, Identifiable, Sendable {
+    case blake
+    case sarah
+    case family
+    case daneel
+    case external
+
+    public var id: String {
+        rawValue
+    }
+
+    public var displayName: String {
+        switch self {
+        case .blake: "Blake"
+        case .sarah: "Sarah"
+        case .family: "Family"
+        case .daneel: "Daneel"
+        case .external: "External"
+        }
+    }
+}
+
+public enum LifeSourceType: String, Codable, CaseIterable, Identifiable, Sendable {
+    case email
+    case calendar
+    case message
+    case manual
+    case chat
+    case jobSearch
+    case family
+
+    public var id: String {
+        rawValue
+    }
+
+    public var title: String {
+        switch self {
+        case .email: "Email"
+        case .calendar: "Calendar"
+        case .message: "Message"
+        case .manual: "Manual"
+        case .chat: "Chat"
+        case .jobSearch: "Job Search"
+        case .family: "Family"
+        }
+    }
+}
+
+public enum ApprovalActionType: String, Codable, CaseIterable, Identifiable, Sendable {
+    case sendEmail
+    case sendMessage
+    case createCalendarEvent
+    case applyToJob
+    case archiveEmail
+    case delegateTask
+    case other
+
+    public var id: String {
+        rawValue
+    }
+
+    public var title: String {
+        switch self {
+        case .sendEmail: "Send Email"
+        case .sendMessage: "Send Message"
+        case .createCalendarEvent: "Create Calendar Event"
+        case .applyToJob: "Apply to Job"
+        case .archiveEmail: "Archive Email"
+        case .delegateTask: "Delegate Task"
+        case .other: "Other"
+        }
+    }
+}
+
+public enum ApprovalRiskLevel: String, Codable, CaseIterable, Identifiable, Sendable {
+    case low
+    case medium
+    case high
+
+    public var id: String {
+        rawValue
+    }
+
+    public var title: String {
+        switch self {
+        case .low: "Low"
+        case .medium: "Medium"
+        case .high: "High"
+        }
+    }
+}
+
+public enum ApprovalStatus: String, Codable, CaseIterable, Identifiable, Sendable {
+    case pending
+    case approved
+    case rejected
+    case completed
+    case failed
+
+    public var id: String {
+        rawValue
+    }
+}
+
+public enum JobOpportunityStage: String, Codable, CaseIterable, Identifiable, Sendable {
+    case target
+    case saved
+    case applied
+    case recruiterContact
+    case screenScheduled
+    case interviewing
+    case followUpDue
+    case offer
+    case rejected
+    case closed
+
+    public var id: String {
+        rawValue
+    }
+
+    public var title: String {
+        switch self {
+        case .target: "Target"
+        case .saved: "Saved"
+        case .applied: "Applied"
+        case .recruiterContact: "Recruiter Contact"
+        case .screenScheduled: "Screen Scheduled"
+        case .interviewing: "Interviewing"
+        case .followUpDue: "Follow Up Due"
+        case .offer: "Offer"
+        case .rejected: "Rejected"
+        case .closed: "Closed"
+        }
+    }
+}
+
+public enum FamilyRequestAction: String, Codable, CaseIterable, Identifiable, Sendable {
+    case createTask
+    case createCalendarEvent
+    case askQuestion
+    case needsClarification
+
+    public var id: String {
+        rawValue
+    }
+
+    public var title: String {
+        switch self {
+        case .createTask: "Create Task"
+        case .createCalendarEvent: "Create Calendar Event"
+        case .askQuestion: "Ask Question"
+        case .needsClarification: "Needs Clarification"
+        }
+    }
+}
+
+public enum FamilyRequestStatus: String, Codable, CaseIterable, Identifiable, Sendable {
+    case received
+    case convertedToTask
+    case awaitingApproval
+    case completed
+    case blocked
+    case dismissed
+
+    public var id: String {
+        rawValue
+    }
+}
+
+public struct LifeTaskSource: Codable, Hashable, Sendable {
+    public var sourceType: LifeSourceType
+    public var sourceID: String?
+    public var sourceURL: URL?
+    public var displayName: String
+    public var originActor: LifeActor?
+
+    public init(
+        sourceType: LifeSourceType,
+        sourceID: String? = nil,
+        sourceURL: URL? = nil,
+        displayName: String,
+        originActor: LifeActor? = nil
+    ) {
+        self.sourceType = sourceType
+        self.sourceID = sourceID
+        self.sourceURL = sourceURL
+        self.displayName = displayName
+        self.originActor = originActor
+    }
+}
+
+public struct LifeTask: Identifiable, Codable, Hashable, Sendable {
+    public let id: UUID
+    public var title: String
+    public var summary: String
+    public var category: LifeTaskCategory
+    public var status: LifeTaskStatus
+    public var priority: LifePriority
+    public var urgencyScore: Int
+    public var importanceScore: Int
+    public var dueAt: Date?
+    public var snoozedUntil: Date?
+    public var estimatedMinutes: Int?
+    public var nextAction: String
+    public var owner: LifeActor
+    public var assignee: LifeActor
+    public var source: LifeTaskSource?
+    public var confidence: Double
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        title: String,
+        summary: String = "",
+        category: LifeTaskCategory,
+        status: LifeTaskStatus = .inbox,
+        priority: LifePriority = .p2,
+        urgencyScore: Int = 50,
+        importanceScore: Int = 50,
+        dueAt: Date? = nil,
+        snoozedUntil: Date? = nil,
+        estimatedMinutes: Int? = nil,
+        nextAction: String,
+        owner: LifeActor = .blake,
+        assignee: LifeActor = .blake,
+        source: LifeTaskSource? = nil,
+        confidence: Double = 1.0,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.title = title
+        self.summary = summary
+        self.category = category
+        self.status = status
+        self.priority = priority
+        self.urgencyScore = urgencyScore
+        self.importanceScore = importanceScore
+        self.dueAt = dueAt
+        self.snoozedUntil = snoozedUntil
+        self.estimatedMinutes = estimatedMinutes
+        self.nextAction = nextAction
+        self.owner = owner
+        self.assignee = assignee
+        self.source = source
+        self.confidence = confidence
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    public var isSarahOriginated: Bool {
+        owner == .sarah || source?.originActor == .sarah
+    }
+}
+
+public struct ApprovalAction: Identifiable, Codable, Hashable, Sendable {
+    public let id: UUID
+    public var taskID: UUID?
+    public var title: String
+    public var summary: String
+    public var actionType: ApprovalActionType
+    public var proposedPayloadPreview: String
+    public var riskLevel: ApprovalRiskLevel
+    public var status: ApprovalStatus
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        taskID: UUID? = nil,
+        title: String,
+        summary: String,
+        actionType: ApprovalActionType,
+        proposedPayloadPreview: String,
+        riskLevel: ApprovalRiskLevel,
+        status: ApprovalStatus = .pending,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.taskID = taskID
+        self.title = title
+        self.summary = summary
+        self.actionType = actionType
+        self.proposedPayloadPreview = proposedPayloadPreview
+        self.riskLevel = riskLevel
+        self.status = status
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+public struct JobOpportunity: Identifiable, Codable, Hashable, Sendable {
+    public let id: UUID
+    public var company: String
+    public var role: String
+    public var url: URL?
+    public var contactName: String?
+    public var contactChannel: String?
+    public var stage: JobOpportunityStage
+    public var lastTouchAt: Date?
+    public var nextFollowUpAt: Date?
+    public var notes: String
+    public var associatedTaskIDs: [UUID]
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        company: String,
+        role: String,
+        url: URL? = nil,
+        contactName: String? = nil,
+        contactChannel: String? = nil,
+        stage: JobOpportunityStage,
+        lastTouchAt: Date? = nil,
+        nextFollowUpAt: Date? = nil,
+        notes: String = "",
+        associatedTaskIDs: [UUID] = [],
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.company = company
+        self.role = role
+        self.url = url
+        self.contactName = contactName
+        self.contactChannel = contactChannel
+        self.stage = stage
+        self.lastTouchAt = lastTouchAt
+        self.nextFollowUpAt = nextFollowUpAt
+        self.notes = notes
+        self.associatedTaskIDs = associatedTaskIDs
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+public struct FamilyRequest: Identifiable, Codable, Hashable, Sendable {
+    public let id: UUID
+    public var requester: LifeActor
+    public var source: LifeTaskSource
+    public var rawText: String
+    public var interpretedAction: FamilyRequestAction
+    public var linkedTaskID: UUID?
+    public var linkedApprovalID: UUID?
+    public var status: FamilyRequestStatus
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        requester: LifeActor,
+        source: LifeTaskSource,
+        rawText: String,
+        interpretedAction: FamilyRequestAction,
+        linkedTaskID: UUID? = nil,
+        linkedApprovalID: UUID? = nil,
+        status: FamilyRequestStatus,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.requester = requester
+        self.source = source
+        self.rawText = rawText
+        self.interpretedAction = interpretedAction
+        self.linkedTaskID = linkedTaskID
+        self.linkedApprovalID = linkedApprovalID
+        self.status = status
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}

--- a/AgentBoardCore/Services/LifeOpsFixtures.swift
+++ b/AgentBoardCore/Services/LifeOpsFixtures.swift
@@ -1,0 +1,341 @@
+import Foundation
+
+public struct LifeOpsSeedData: Sendable {
+    public var tasks: [LifeTask]
+    public var approvalActions: [ApprovalAction]
+    public var jobOpportunities: [JobOpportunity]
+    public var familyRequests: [FamilyRequest]
+
+    public init(
+        tasks: [LifeTask],
+        approvalActions: [ApprovalAction],
+        jobOpportunities: [JobOpportunity],
+        familyRequests: [FamilyRequest]
+    ) {
+        self.tasks = tasks
+        self.approvalActions = approvalActions
+        self.jobOpportunities = jobOpportunities
+        self.familyRequests = familyRequests
+    }
+}
+
+public enum LifeOpsFixtures {
+    public enum IDs {
+        public static let emailReplyTask = uuid("5A5F6558-7BB8-465E-A55F-7F75C11FA001")
+        public static let calendarPrepTask = uuid("5A5F6558-7BB8-465E-A55F-7F75C11FA002")
+        public static let jobFollowUpTask = uuid("5A5F6558-7BB8-465E-A55F-7F75C11FA003")
+        public static let familyMessageTask = uuid("5A5F6558-7BB8-465E-A55F-7F75C11FA004")
+        public static let waitingOnTask = uuid("5A5F6558-7BB8-465E-A55F-7F75C11FA005")
+        public static let snoozedTask = uuid("5A5F6558-7BB8-465E-A55F-7F75C11FA006")
+        public static let inboxAdminTask = uuid("5A5F6558-7BB8-465E-A55F-7F75C11FA007")
+        public static let approval = uuid("A61B2CE2-08A4-45E0-903A-7F75C11FA001")
+        public static let completedApproval = uuid("A61B2CE2-08A4-45E0-903A-7F75C11FA002")
+        public static let jobOpportunity = uuid("CF06A8BC-BFA0-4C9E-8E1E-7F75C11FA001")
+        public static let familyRequest = uuid("AD6A4965-EBE6-442B-B006-7F75C11FA001")
+    }
+
+    public static func makeSeedData(now: Date = Date()) -> LifeOpsSeedData {
+        let tasks = makeTasks(now: now)
+        let approvals = makeApprovalActions(now: now)
+        let jobs = makeJobOpportunities(now: now)
+        let familyRequests = makeFamilyRequests(now: now)
+
+        return LifeOpsSeedData(
+            tasks: tasks,
+            approvalActions: approvals,
+            jobOpportunities: jobs,
+            familyRequests: familyRequests
+        )
+    }
+
+    public static func makeTasks(now: Date = Date()) -> [LifeTask] {
+        [
+            emailReplyTask(now: now),
+            calendarPrepTask(now: now),
+            jobFollowUpTask(now: now),
+            familyMessageTask(now: now),
+            waitingOnTask(now: now),
+            snoozedTask(now: now),
+            inboxAdminTask(now: now)
+        ]
+    }
+
+    public static func makeApprovalActions(now: Date = Date()) -> [ApprovalAction] {
+        [
+            ApprovalAction(
+                id: IDs.approval,
+                taskID: IDs.emailReplyTask,
+                title: "Approve recruiter reply",
+                summary: "Daneel drafted a short availability response.",
+                actionType: .sendEmail,
+                proposedPayloadPreview: "Thanks for reaching out. I can do Thursday afternoon or Friday morning.",
+                riskLevel: .medium,
+                status: .pending,
+                createdAt: offset(now, minutes: -25),
+                updatedAt: offset(now, minutes: -25)
+            ),
+            ApprovalAction(
+                id: IDs.completedApproval,
+                taskID: IDs.jobFollowUpTask,
+                title: "Archive old job alert",
+                summary: "The alert was already captured into the pipeline.",
+                actionType: .archiveEmail,
+                proposedPayloadPreview: "Archive the duplicate alert email.",
+                riskLevel: .low,
+                status: .completed,
+                createdAt: offset(now, days: -1),
+                updatedAt: offset(now, hours: -20)
+            )
+        ]
+    }
+
+    public static func makeJobOpportunities(now: Date = Date()) -> [JobOpportunity] {
+        [
+            JobOpportunity(
+                id: IDs.jobOpportunity,
+                company: "Northstar Labs",
+                role: "Agent Platform Lead",
+                url: URL(string: "https://example.com/jobs/northstar-platform"),
+                contactName: "Jordan Lee",
+                contactChannel: "Email",
+                stage: .followUpDue,
+                lastTouchAt: offset(now, days: -5),
+                nextFollowUpAt: offset(now, hours: -1),
+                notes: "Strong fit for agent orchestration and QA workflow experience.",
+                associatedTaskIDs: [IDs.jobFollowUpTask],
+                createdAt: offset(now, days: -8),
+                updatedAt: offset(now, hours: -1)
+            )
+        ]
+    }
+
+    public static func makeFamilyRequests(now: Date = Date()) -> [FamilyRequest] {
+        [
+            FamilyRequest(
+                id: IDs.familyRequest,
+                requester: .sarah,
+                source: LifeTaskSource(
+                    sourceType: .message,
+                    sourceID: "imessage-sarah-vet",
+                    displayName: "Sarah via iMessage",
+                    originActor: .sarah
+                ),
+                rawText: "Can you remind Blake to call the vet tomorrow?",
+                interpretedAction: .createTask,
+                linkedTaskID: IDs.familyMessageTask,
+                status: .convertedToTask,
+                createdAt: offset(now, minutes: -35),
+                updatedAt: offset(now, minutes: -35)
+            )
+        ]
+    }
+
+    private static func emailReplyTask(now: Date) -> LifeTask {
+        LifeTask(
+            id: IDs.emailReplyTask,
+            title: "Reply to recruiter about availability",
+            summary: "A recruiter asked for two interview windows this week.",
+            category: .email,
+            status: .needsBlake,
+            priority: .p1,
+            urgencyScore: 82,
+            importanceScore: 76,
+            dueAt: offset(now, hours: 4),
+            estimatedMinutes: 12,
+            nextAction: "Pick two realistic windows and approve Daneel's draft.",
+            owner: .blake,
+            assignee: .blake,
+            source: LifeTaskSource(
+                sourceType: .email,
+                sourceID: "email-recruiter-availability",
+                sourceURL: URL(string: "message://lifeops/recruiter-availability"),
+                displayName: "Recruiter email"
+            ),
+            confidence: 0.93,
+            createdAt: offset(now, hours: -2),
+            updatedAt: offset(now, hours: -1)
+        )
+    }
+
+    private static func calendarPrepTask(now: Date) -> LifeTask {
+        LifeTask(
+            id: IDs.calendarPrepTask,
+            title: "Prep notes for benefits call",
+            summary: "Calendar event has no agenda and needs a short checklist.",
+            category: .calendar,
+            status: .scheduled,
+            priority: .p1,
+            urgencyScore: 74,
+            importanceScore: 68,
+            dueAt: offset(now, hours: 6),
+            estimatedMinutes: 20,
+            nextAction: "List questions about enrollment deadlines and coverage.",
+            owner: .blake,
+            assignee: .blake,
+            source: LifeTaskSource(
+                sourceType: .calendar,
+                sourceID: "calendar-benefits-call",
+                displayName: "Today's calendar"
+            ),
+            confidence: 0.88,
+            createdAt: offset(now, hours: -3),
+            updatedAt: offset(now, minutes: -45)
+        )
+    }
+
+    private static func jobFollowUpTask(now: Date) -> LifeTask {
+        LifeTask(
+            id: IDs.jobFollowUpTask,
+            title: "Follow up with Northstar Labs",
+            summary: "Application has been quiet for five business days.",
+            category: .jobSearch,
+            status: .needsBlake,
+            priority: .p1,
+            urgencyScore: 70,
+            importanceScore: 84,
+            dueAt: endOfDay(for: now),
+            estimatedMinutes: 15,
+            nextAction: "Send a concise follow-up note referencing the platform role.",
+            owner: .blake,
+            assignee: .daneel,
+            source: LifeTaskSource(
+                sourceType: .jobSearch,
+                sourceID: "northstar-platform-role",
+                sourceURL: URL(string: "https://example.com/jobs/northstar-platform"),
+                displayName: "Job pipeline"
+            ),
+            confidence: 0.9,
+            createdAt: offset(now, days: -5),
+            updatedAt: offset(now, hours: -2)
+        )
+    }
+
+    private static func familyMessageTask(now: Date) -> LifeTask {
+        LifeTask(
+            id: IDs.familyMessageTask,
+            title: "Call the vet tomorrow",
+            summary: "Sarah asked for a reminder to schedule the follow-up appointment.",
+            category: .family,
+            status: .needsBlake,
+            priority: .p1,
+            urgencyScore: 78,
+            importanceScore: 72,
+            dueAt: offset(now, days: 1),
+            estimatedMinutes: 10,
+            nextAction: "Call the vet and confirm the appointment window with Sarah.",
+            owner: .family,
+            assignee: .blake,
+            source: LifeTaskSource(
+                sourceType: .message,
+                sourceID: "imessage-sarah-vet",
+                displayName: "Sarah via iMessage",
+                originActor: .sarah
+            ),
+            confidence: 0.95,
+            createdAt: offset(now, minutes: -35),
+            updatedAt: offset(now, minutes: -35)
+        )
+    }
+
+    private static func waitingOnTask(now: Date) -> LifeTask {
+        LifeTask(
+            id: IDs.waitingOnTask,
+            title: "Waiting on childcare schedule",
+            summary: "Need confirmation before planning Friday afternoon.",
+            category: .waitingOn,
+            status: .waitingOnExternal,
+            priority: .p2,
+            urgencyScore: 52,
+            importanceScore: 66,
+            dueAt: offset(now, days: 2),
+            estimatedMinutes: 5,
+            nextAction: "Check whether the schedule arrived by tomorrow afternoon.",
+            owner: .family,
+            assignee: .external,
+            source: LifeTaskSource(
+                sourceType: .message,
+                sourceID: "childcare-schedule-thread",
+                displayName: "Family thread"
+            ),
+            confidence: 0.86,
+            createdAt: offset(now, days: -1),
+            updatedAt: offset(now, hours: -4)
+        )
+    }
+
+    private static func snoozedTask(now: Date) -> LifeTask {
+        LifeTask(
+            id: IDs.snoozedTask,
+            title: "Compare dental plan options",
+            summary: "Useful but not needed until enrollment details are in.",
+            category: .admin,
+            status: .snoozed,
+            priority: .p2,
+            urgencyScore: 36,
+            importanceScore: 58,
+            dueAt: offset(now, days: 7),
+            snoozedUntil: offset(now, days: 3),
+            estimatedMinutes: 30,
+            nextAction: "Review plan comparison after benefits documents arrive.",
+            owner: .blake,
+            assignee: .blake,
+            source: LifeTaskSource(
+                sourceType: .manual,
+                sourceID: "manual-dental-plan",
+                displayName: "Manual capture"
+            ),
+            confidence: 1.0,
+            createdAt: offset(now, days: -2),
+            updatedAt: offset(now, hours: -8)
+        )
+    }
+
+    private static func inboxAdminTask(now: Date) -> LifeTask {
+        LifeTask(
+            id: IDs.inboxAdminTask,
+            title: "Renew library card",
+            summary: "Captured from a reminder note and needs triage.",
+            category: .admin,
+            status: .inbox,
+            priority: .p3,
+            urgencyScore: 24,
+            importanceScore: 30,
+            estimatedMinutes: 8,
+            nextAction: "Decide whether this belongs this week.",
+            owner: .blake,
+            assignee: .blake,
+            source: LifeTaskSource(
+                sourceType: .manual,
+                sourceID: "manual-library-card",
+                displayName: "Manual capture"
+            ),
+            confidence: 1.0,
+            createdAt: offset(now, minutes: -10),
+            updatedAt: offset(now, minutes: -10)
+        )
+    }
+
+    private static func uuid(_ value: String) -> UUID {
+        guard let uuid = UUID(uuidString: value) else {
+            preconditionFailure("Invalid LifeOps fixture UUID: \(value)")
+        }
+        return uuid
+    }
+
+    private static func offset(_ date: Date, days: Int) -> Date {
+        Calendar.current.date(byAdding: .day, value: days, to: date) ?? date
+    }
+
+    private static func offset(_ date: Date, hours: Int) -> Date {
+        Calendar.current.date(byAdding: .hour, value: hours, to: date) ?? date
+    }
+
+    private static func offset(_ date: Date, minutes: Int) -> Date {
+        Calendar.current.date(byAdding: .minute, value: minutes, to: date) ?? date
+    }
+
+    private static func endOfDay(for date: Date) -> Date {
+        let calendar = Calendar.current
+        return calendar.dateInterval(of: .day, for: date)?.end.addingTimeInterval(-1) ?? date
+    }
+}

--- a/AgentBoardCore/Stores/AgentBoardAppModel.swift
+++ b/AgentBoardCore/Stores/AgentBoardAppModel.swift
@@ -14,6 +14,7 @@ public final class AgentBoardAppModel {
     public let workStore: WorkStore
     public let agentsStore: AgentsStore
     public let sessionsStore: SessionsStore
+    public let lifeOpsStore: LifeOpsStore
     public let sessionLauncher: SessionLauncher
 
     public var selectedDestination: AppDestination = .chat
@@ -31,6 +32,7 @@ public final class AgentBoardAppModel {
         workStore: WorkStore,
         agentsStore: AgentsStore,
         sessionsStore: SessionsStore,
+        lifeOpsStore: LifeOpsStore = LifeOpsStore(),
         sessionLauncher: SessionLauncher,
         companionClient: CompanionClient
     ) {
@@ -40,6 +42,7 @@ public final class AgentBoardAppModel {
         self.workStore = workStore
         self.agentsStore = agentsStore
         self.sessionsStore = sessionsStore
+        self.lifeOpsStore = lifeOpsStore
         self.sessionLauncher = sessionLauncher
         self.companionClient = companionClient
     }
@@ -200,6 +203,7 @@ public enum AgentBoardBootstrap {
             cache: cache,
             settingsStore: settingsStore
         )
+        let lifeOpsStore = LifeOpsStore()
         let sessionLauncher = SessionLauncher()
 
         // Pre-warm the shell-environment probe in the background so it's ready
@@ -216,6 +220,7 @@ public enum AgentBoardBootstrap {
             workStore: workStore,
             agentsStore: agentsStore,
             sessionsStore: sessionsStore,
+            lifeOpsStore: lifeOpsStore,
             sessionLauncher: sessionLauncher,
             companionClient: companionClient
         )

--- a/AgentBoardCore/Stores/LifeOpsStore.swift
+++ b/AgentBoardCore/Stores/LifeOpsStore.swift
@@ -1,0 +1,272 @@
+import Foundation
+import Observation
+
+public protocol LifeOpsIngestionService: Sendable {
+    func fetchNewInboxItems() async throws -> [LifeTask]
+    func fetchCalendarPrepItems() async throws -> [LifeTask]
+    func fetchFamilyRequests() async throws -> [FamilyRequest]
+}
+
+public protocol LifeOpsActionService: Sendable {
+    func submitQuickCapture(_ text: String) async throws -> LifeTask
+    func approveAction(_ action: ApprovalAction) async throws
+    func rejectAction(_ action: ApprovalAction) async throws
+    func askDaneel(task: LifeTask, message: String) async throws -> ApprovalAction?
+}
+
+public struct FixtureLifeOpsIngestionService: LifeOpsIngestionService {
+    public init() {}
+
+    public func fetchNewInboxItems() async throws -> [LifeTask] {
+        LifeOpsFixtures.makeTasks().filter { $0.status == .inbox }
+    }
+
+    public func fetchCalendarPrepItems() async throws -> [LifeTask] {
+        LifeOpsFixtures.makeTasks().filter { $0.category == .calendar }
+    }
+
+    public func fetchFamilyRequests() async throws -> [FamilyRequest] {
+        LifeOpsFixtures.makeFamilyRequests()
+    }
+}
+
+public struct FixtureLifeOpsActionService: LifeOpsActionService {
+    public init() {}
+
+    public func submitQuickCapture(_ text: String) async throws -> LifeTask {
+        LifeTask(
+            title: text,
+            category: .personal,
+            status: .inbox,
+            priority: .p2,
+            nextAction: "Clarify the next action.",
+            source: LifeTaskSource(
+                sourceType: .manual,
+                sourceID: "quick-capture",
+                displayName: "Quick capture"
+            )
+        )
+    }
+
+    public func approveAction(_: ApprovalAction) async throws {}
+
+    public func rejectAction(_: ApprovalAction) async throws {}
+
+    public func askDaneel(task _: LifeTask, message _: String) async throws -> ApprovalAction? {
+        nil
+    }
+}
+
+@MainActor
+@Observable
+public final class LifeOpsStore {
+    public private(set) var tasks: [LifeTask]
+    public private(set) var approvalActions: [ApprovalAction]
+    public private(set) var jobOpportunities: [JobOpportunity]
+    public private(set) var familyRequests: [FamilyRequest]
+    public private(set) var lastRefreshAt: Date
+    public var statusMessage: String?
+
+    @ObservationIgnored private let calendar: Calendar
+    @ObservationIgnored private let nowProvider: () -> Date
+
+    public init(
+        seedData: LifeOpsSeedData? = nil,
+        calendar: Calendar = .current,
+        now: @escaping () -> Date = { Date() }
+    ) {
+        let initialData = seedData ?? LifeOpsFixtures.makeSeedData(now: now())
+        self.tasks = initialData.tasks
+        self.approvalActions = initialData.approvalActions
+        self.jobOpportunities = initialData.jobOpportunities
+        self.familyRequests = initialData.familyRequests
+        self.lastRefreshAt = now()
+        self.calendar = calendar
+        self.nowProvider = now
+    }
+
+    public var nowTasks: [LifeTask] {
+        Array(visibleTasks
+            .filter { $0.priority == .p0 || $0.priority == .p1 }
+            .sorted(by: priorityDueUrgencySort)
+            .prefix(3))
+    }
+
+    public var todayTasks: [LifeTask] {
+        visibleTasks
+            .filter { task in
+                task.priority == .p1 || task.dueAt.map(isTodayOrOverdue) == true
+            }
+            .sorted(by: priorityDueUrgencySort)
+    }
+
+    public var inboxTasks: [LifeTask] {
+        tasks
+            .filter { $0.status == .inbox }
+            .sorted { $0.createdAt > $1.createdAt }
+    }
+
+    public var waitingTasks: [LifeTask] {
+        tasks
+            .filter { $0.status == .waitingOnExternal }
+            .sorted(by: priorityDueUrgencySort)
+    }
+
+    public var familyTasks: [LifeTask] {
+        tasks
+            .filter { task in
+                task.owner == .family ||
+                    task.owner == .sarah ||
+                    task.category == .family ||
+                    task.source?.originActor == .sarah
+            }
+            .sorted(by: priorityDueUrgencySort)
+    }
+
+    public var pendingApprovals: [ApprovalAction] {
+        approvalActions
+            .filter { $0.status == .pending }
+            .sorted { $0.createdAt < $1.createdAt }
+    }
+
+    public var jobFollowUpsDue: [JobOpportunity] {
+        let endOfToday = endOfDay(for: nowProvider())
+
+        return jobOpportunities
+            .filter { opportunity in
+                guard opportunity.stage != .closed,
+                      opportunity.stage != .rejected,
+                      let nextFollowUpAt = opportunity.nextFollowUpAt else {
+                    return false
+                }
+                return nextFollowUpAt <= endOfToday
+            }
+            .sorted { first, second in
+                (first.nextFollowUpAt ?? .distantFuture) < (second.nextFollowUpAt ?? .distantFuture)
+            }
+    }
+
+    @discardableResult
+    public func createQuickTask(title: String) -> LifeTask? {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let now = nowProvider()
+        let task = LifeTask(
+            title: trimmed,
+            summary: "Captured quickly for later triage.",
+            category: .personal,
+            status: .inbox,
+            priority: .p2,
+            urgencyScore: 45,
+            importanceScore: 45,
+            estimatedMinutes: 10,
+            nextAction: "Clarify the next action.",
+            owner: .blake,
+            assignee: .blake,
+            source: LifeTaskSource(
+                sourceType: .manual,
+                sourceID: "quick-capture-\(UUID().uuidString)",
+                displayName: "Quick capture"
+            ),
+            confidence: 1.0,
+            createdAt: now,
+            updatedAt: now
+        )
+
+        tasks.insert(task, at: 0)
+        lastRefreshAt = now
+        statusMessage = "Captured \"\(trimmed)\"."
+        return task
+    }
+
+    public func markDone(id: UUID) {
+        updateTask(id: id) { task, now in
+            task.status = .done
+            task.updatedAt = now
+        }
+    }
+
+    public func snooze(id: UUID, until date: Date) {
+        updateTask(id: id) { task, now in
+            task.status = .snoozed
+            task.snoozedUntil = date
+            task.updatedAt = now
+        }
+    }
+
+    public func assignToDaneel(id: UUID) {
+        updateTask(id: id) { task, now in
+            task.status = .assignedToDaneel
+            task.assignee = .daneel
+            task.updatedAt = now
+        }
+    }
+
+    public func updateJobOpportunityStage(id: UUID, stage: JobOpportunityStage) {
+        guard let index = jobOpportunities.firstIndex(where: { $0.id == id }) else { return }
+        jobOpportunities[index].stage = stage
+        jobOpportunities[index].updatedAt = nowProvider()
+    }
+
+    private var visibleTasks: [LifeTask] {
+        let now = nowProvider()
+        return tasks.filter { task in
+            !task.status.isTerminal && !isSnoozed(task, now: now)
+        }
+    }
+
+    private func isSnoozed(_ task: LifeTask, now: Date) -> Bool {
+        guard task.status == .snoozed || task.snoozedUntil != nil else {
+            return false
+        }
+
+        guard let snoozedUntil = task.snoozedUntil else {
+            return true
+        }
+
+        return snoozedUntil > now
+    }
+
+    private func priorityDueUrgencySort(_ lhs: LifeTask, _ rhs: LifeTask) -> Bool {
+        if lhs.priority.sortRank != rhs.priority.sortRank {
+            return lhs.priority.sortRank < rhs.priority.sortRank
+        }
+
+        switch (lhs.dueAt, rhs.dueAt) {
+        case let (lhsDate?, rhsDate?) where lhsDate != rhsDate:
+            return lhsDate < rhsDate
+        case (.some, nil):
+            return true
+        case (nil, .some):
+            return false
+        default:
+            break
+        }
+
+        if lhs.urgencyScore != rhs.urgencyScore {
+            return lhs.urgencyScore > rhs.urgencyScore
+        }
+
+        if lhs.importanceScore != rhs.importanceScore {
+            return lhs.importanceScore > rhs.importanceScore
+        }
+
+        return lhs.updatedAt > rhs.updatedAt
+    }
+
+    private func isTodayOrOverdue(_ date: Date) -> Bool {
+        date <= endOfDay(for: nowProvider())
+    }
+
+    private func endOfDay(for date: Date) -> Date {
+        calendar.dateInterval(of: .day, for: date)?.end.addingTimeInterval(-1) ?? date
+    }
+
+    private func updateTask(id: UUID, mutation: (inout LifeTask, Date) -> Void) {
+        guard let index = tasks.firstIndex(where: { $0.id == id }) else { return }
+        let now = nowProvider()
+        mutation(&tasks[index], now)
+        lastRefreshAt = now
+    }
+}

--- a/AgentBoardMobile/MobileRootView.swift
+++ b/AgentBoardMobile/MobileRootView.swift
@@ -2,6 +2,7 @@ import AgentBoardCore
 import SwiftUI
 
 struct MobileRootView: View {
+    @Environment(AgentBoardAppModel.self) private var appModel
     @State private var selectedDestination: AppDestination = .chat
 
     var body: some View {
@@ -14,6 +15,16 @@ struct MobileRootView: View {
                 .accessibilityIdentifier("mobile_tab_chat")
             } label: {
                 Label(AppDestination.chat.title, systemImage: AppDestination.chat.systemImage)
+            }
+
+            Tab(value: AppDestination.lifeOps) {
+                NavigationStack {
+                    LifeOpsScreen(store: appModel.lifeOpsStore, mode: .compact)
+                        .navigationTitle(AppDestination.lifeOps.title)
+                }
+                .accessibilityIdentifier("mobile_tab_lifeOps")
+            } label: {
+                Label(AppDestination.lifeOps.title, systemImage: AppDestination.lifeOps.systemImage)
             }
 
             Tab(value: AppDestination.work) {

--- a/AgentBoardTests/AppDestinationTests.swift
+++ b/AgentBoardTests/AppDestinationTests.swift
@@ -5,7 +5,7 @@ import Testing
 struct AppDestinationTests {
     @Test func appDestinationAllCasesAreStable() {
         // Ordering matters because navigation rails iterate `.allCases` directly.
-        #expect(AppDestination.allCases == [.chat, .work, .agents, .sessions, .settings])
+        #expect(AppDestination.allCases == [.chat, .lifeOps, .work, .agents, .sessions, .settings])
     }
 
     @Test func appDestinationIDMatchesRawValue() {
@@ -16,6 +16,7 @@ struct AppDestinationTests {
 
     @Test func appDestinationTitleIsUserFacing() {
         #expect(AppDestination.chat.title == "Chat")
+        #expect(AppDestination.lifeOps.title == "LifeOps")
         #expect(AppDestination.work.title == "Work")
         #expect(AppDestination.agents.title == "Agents")
         #expect(AppDestination.sessions.title == "Sessions")

--- a/AgentBoardTests/LifeOpsInterfaceTests.swift
+++ b/AgentBoardTests/LifeOpsInterfaceTests.swift
@@ -1,0 +1,88 @@
+import AgentBoardCore
+import Foundation
+import Testing
+
+struct LifeOpsInterfaceTests {
+    @Test func appDestinationExposesLifeOpsInDesktopTabs() {
+        #expect(AppDestination.allCases.contains(.lifeOps))
+        #expect(AppDestination.desktopTabs.contains(.lifeOps))
+        #expect(AppDestination.lifeOps.title == "LifeOps")
+        #expect(!AppDestination.lifeOps.systemImage.isEmpty)
+    }
+
+    @Test func appModelOwnsFixtureBackedLifeOpsStore() throws {
+        let source = try Self.source("AgentBoardCore/Stores/AgentBoardAppModel.swift")
+
+        #expect(source.contains("public let lifeOpsStore: LifeOpsStore"))
+        #expect(source.contains("let lifeOpsStore = LifeOpsStore()"))
+        #expect(source.contains("lifeOpsStore: lifeOpsStore"))
+    }
+
+    @Test func macShellRoutesLifeOpsToSharedScreen() throws {
+        let source = try Self.source("AgentBoard/DesktopRootView.swift")
+
+        #expect(source.contains("case .lifeOps:"))
+        #expect(source.contains("LifeOpsScreen(store: appModel.lifeOpsStore, mode: .dashboard)"))
+    }
+
+    @Test func mobileShellIncludesLifeOpsTab() throws {
+        let source = try Self.source("AgentBoardMobile/MobileRootView.swift")
+
+        #expect(source.contains("Tab(value: AppDestination.lifeOps)"))
+        #expect(source.contains("LifeOpsScreen(store: appModel.lifeOpsStore, mode: .compact)"))
+        #expect(source.contains(#".accessibilityIdentifier("mobile_tab_lifeOps")"#))
+    }
+
+    @Test func lifeOpsScreenExposesSectionAccessibilityContracts() throws {
+        let source = try Self.source("AgentBoardUI/Screens/LifeOpsScreen.swift")
+
+        #expect(source.contains(#".accessibilityIdentifier("screen_lifeops")"#))
+        #expect(source.contains(#""lifeops.section.now""#))
+        #expect(source.contains(#""lifeops.section.today""#))
+        #expect(source.contains(#""lifeops.section.approvals""#))
+        #expect(source.contains(#""lifeops.section.family""#))
+        #expect(source.contains(#""lifeops.section.jobSearch""#))
+        #expect(source.contains("Array(store.nowTasks.prefix(3))"))
+    }
+
+    @Test func lifeOpsComponentsExposeInteractiveAccessibilityIdentifiers() throws {
+        let priority = try Self.source("AgentBoardUI/Components/LifeOpsPriorityBadge.swift")
+        let row = try Self.source("AgentBoardUI/Components/LifeOpsTaskRow.swift")
+        let capture = try Self.source("AgentBoardUI/Components/LifeOpsQuickCaptureView.swift")
+
+        #expect(priority.contains(#".accessibilityIdentifier("lifeops.priority.badge")"#))
+        #expect(row.contains(#".accessibilityIdentifier("lifeops.task.row")"#))
+        #expect(capture.contains(#".accessibilityIdentifier("lifeops.quickCapture.field")"#))
+        #expect(capture.contains(#".accessibilityIdentifier("lifeops.quickCapture.submit")"#))
+    }
+
+    @MainActor
+    @Test func lifeOpsScreenIsStoreBackedAndFixtureRenderable() throws {
+        let source = try Self.source("AgentBoardUI/Screens/LifeOpsScreen.swift")
+        let fixtures = LifeOpsFixtures.makeSeedData()
+        let store = LifeOpsStore(seedData: fixtures)
+
+        #expect(source.contains("let store: LifeOpsStore"))
+        #expect(!store.nowTasks.isEmpty)
+        #expect(!store.pendingApprovals.isEmpty)
+        #expect(!store.familyTasks.isEmpty)
+    }
+
+    private static func source(_ relativePath: String) throws -> String {
+        try String(contentsOf: repositoryRoot.appending(path: relativePath), encoding: .utf8)
+    }
+
+    private static var repositoryRoot: URL {
+        var directory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+
+        while directory.path != "/" {
+            if FileManager.default.fileExists(atPath: directory.appending(path: "project.yml").path) {
+                return directory
+            }
+            directory.deleteLastPathComponent()
+        }
+
+        Issue.record("Unable to locate repository root from \(#filePath)")
+        return URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+    }
+}

--- a/AgentBoardTests/LifeOpsModelsTests.swift
+++ b/AgentBoardTests/LifeOpsModelsTests.swift
@@ -1,0 +1,160 @@
+import AgentBoardCore
+import Foundation
+import Testing
+
+@Suite("LifeOps models")
+struct LifeOpsModelsTests {
+    @Test func lifePriorityDisplayOrderMapsUrgentFirst() {
+        #expect(LifePriority.displayOrder == [.p0, .p1, .p2, .p3])
+        #expect(LifePriority.displayOrder.map(\.displayName) == ["P0", "P1", "P2", "P3"])
+        #expect(LifePriority.p0.sortRank < LifePriority.p1.sortRank)
+        #expect(LifePriority.p1.sortRank < LifePriority.p2.sortRank)
+        #expect(LifePriority.p2.sortRank < LifePriority.p3.sortRank)
+    }
+
+    @Test func lifeTaskCodableRoundTripPreservesAllFields() throws {
+        let source = LifeTaskSource(
+            sourceType: .email,
+            sourceID: "message-1",
+            sourceURL: URL(string: "message://lifeops/message-1"),
+            displayName: "Recruiter email",
+            originActor: .external
+        )
+        let task = LifeTask(
+            id: UUID(),
+            title: "Reply to recruiter",
+            summary: "Pick times and reply.",
+            category: .email,
+            status: .needsBlake,
+            priority: .p1,
+            urgencyScore: 80,
+            importanceScore: 75,
+            dueAt: fixedNow,
+            snoozedUntil: fixedNow.addingTimeInterval(3600),
+            estimatedMinutes: 12,
+            nextAction: "Pick two windows.",
+            owner: .blake,
+            assignee: .daneel,
+            source: source,
+            confidence: 0.91,
+            createdAt: fixedNow.addingTimeInterval(-600),
+            updatedAt: fixedNow
+        )
+
+        #expect(try roundTrip(task) == task)
+    }
+
+    @Test func approvalActionCodableRoundTripPreservesAllFields() throws {
+        let approval = ApprovalAction(
+            id: UUID(),
+            taskID: UUID(),
+            title: "Approve reply",
+            summary: "Daneel drafted a reply.",
+            actionType: .sendEmail,
+            proposedPayloadPreview: "Thanks, Thursday works.",
+            riskLevel: .medium,
+            status: .pending,
+            createdAt: fixedNow.addingTimeInterval(-120),
+            updatedAt: fixedNow
+        )
+
+        #expect(try roundTrip(approval) == approval)
+    }
+
+    @Test func jobOpportunityCodableRoundTripPreservesAllFields() throws {
+        let taskID = UUID()
+        let opportunity = JobOpportunity(
+            id: UUID(),
+            company: "Northstar Labs",
+            role: "Agent Platform Lead",
+            url: URL(string: "https://example.com/job"),
+            contactName: "Jordan",
+            contactChannel: "Email",
+            stage: .followUpDue,
+            lastTouchAt: fixedNow.addingTimeInterval(-86400),
+            nextFollowUpAt: fixedNow,
+            notes: "Good fit.",
+            associatedTaskIDs: [taskID],
+            createdAt: fixedNow.addingTimeInterval(-172_800),
+            updatedAt: fixedNow
+        )
+
+        #expect(try roundTrip(opportunity) == opportunity)
+    }
+
+    @Test func familyRequestCodableRoundTripPreservesAllFields() throws {
+        let taskID = UUID()
+        let approvalID = UUID()
+        let request = FamilyRequest(
+            id: UUID(),
+            requester: .sarah,
+            source: LifeTaskSource(
+                sourceType: .message,
+                sourceID: "imessage-1",
+                displayName: "Sarah via iMessage",
+                originActor: .sarah
+            ),
+            rawText: "Can you remind Blake to call the vet tomorrow?",
+            interpretedAction: .createTask,
+            linkedTaskID: taskID,
+            linkedApprovalID: approvalID,
+            status: .convertedToTask,
+            createdAt: fixedNow.addingTimeInterval(-300),
+            updatedAt: fixedNow
+        )
+
+        #expect(try roundTrip(request) == request)
+    }
+
+    @Test func fixturesConstructValidRelatedData() {
+        let seed = LifeOpsFixtures.makeSeedData(now: fixedNow)
+        let taskIDs = Set(seed.tasks.map(\.id))
+        let approvalIDs = Set(seed.approvalActions.map(\.id))
+
+        #expect(!seed.tasks.isEmpty)
+        #expect(!seed.approvalActions.isEmpty)
+        #expect(!seed.jobOpportunities.isEmpty)
+        #expect(!seed.familyRequests.isEmpty)
+
+        for approval in seed.approvalActions {
+            if let taskID = approval.taskID {
+                #expect(taskIDs.contains(taskID))
+            }
+        }
+
+        for opportunity in seed.jobOpportunities {
+            #expect(!opportunity.associatedTaskIDs.isEmpty)
+            for taskID in opportunity.associatedTaskIDs {
+                #expect(taskIDs.contains(taskID))
+            }
+        }
+
+        for request in seed.familyRequests {
+            if let taskID = request.linkedTaskID {
+                #expect(taskIDs.contains(taskID))
+            }
+            if let approvalID = request.linkedApprovalID {
+                #expect(approvalIDs.contains(approvalID))
+            }
+        }
+    }
+
+    @Test func fixturesIncludeRequiredMVPExamples() {
+        let seed = LifeOpsFixtures.makeSeedData(now: fixedNow)
+
+        #expect(seed.tasks.contains { $0.id == LifeOpsFixtures.IDs.emailReplyTask && $0.category == .email })
+        #expect(seed.tasks.contains { $0.id == LifeOpsFixtures.IDs.calendarPrepTask && $0.category == .calendar })
+        #expect(seed.tasks.contains { $0.id == LifeOpsFixtures.IDs.jobFollowUpTask && $0.category == .jobSearch })
+        #expect(seed.tasks.contains { $0.id == LifeOpsFixtures.IDs.familyMessageTask && $0.isSarahOriginated })
+        #expect(seed.tasks.contains { $0.id == LifeOpsFixtures.IDs.waitingOnTask && $0.status == .waitingOnExternal })
+        #expect(seed.tasks.contains { $0.id == LifeOpsFixtures.IDs.snoozedTask && $0.status == .snoozed })
+        #expect(seed.approvalActions.contains { $0.id == LifeOpsFixtures.IDs.approval && $0.status == .pending })
+    }
+
+    private let fixedNow = Date(timeIntervalSince1970: 1_779_907_600)
+
+    private func roundTrip<T: Codable & Equatable>(_ value: T) throws -> T {
+        let data = try JSONEncoder().encode(value)
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+}

--- a/AgentBoardTests/LifeOpsStoreTests.swift
+++ b/AgentBoardTests/LifeOpsStoreTests.swift
@@ -1,0 +1,195 @@
+import AgentBoardCore
+import Foundation
+import Testing
+
+@Suite("LifeOpsStore", .serialized)
+@MainActor
+struct LifeOpsStoreTests {
+    @Test func nowTasksReturnsAtMostThreeSortedP0P1Tasks() {
+        let store = makeStore(
+            tasks: [
+                makeTask(title: "P1 third", priority: .p1, urgency: 70, dueOffset: 3600),
+                makeTask(title: "P0 first", priority: .p0, urgency: 30, dueOffset: 7200),
+                makeTask(title: "P1 second", priority: .p1, urgency: 90, dueOffset: 1800),
+                makeTask(title: "P1 fourth", priority: .p1, urgency: 60, dueOffset: 10800),
+                makeTask(title: "P2 excluded", priority: .p2, urgency: 99, dueOffset: 600)
+            ]
+        )
+
+        #expect(store.nowTasks.count == 3)
+        #expect(store.nowTasks.map(\.title) == ["P0 first", "P1 second", "P1 third"])
+    }
+
+    @Test func doneAndSnoozedTasksDisappearFromToday() {
+        let active = makeTask(title: "Active today", priority: .p1, dueOffset: 600)
+        let done = makeTask(title: "Done today", status: .done, priority: .p1, dueOffset: 600)
+        let snoozed = makeTask(
+            title: "Snoozed today",
+            status: .snoozed,
+            priority: .p1,
+            dueOffset: 600,
+            snoozedUntil: fixedNow.addingTimeInterval(86400)
+        )
+        let store = makeStore(tasks: [active, done, snoozed])
+
+        #expect(store.todayTasks.map(\.title) == ["Active today"])
+    }
+
+    @Test func familyTasksIncludeSarahOriginatedAndFamilyOwnedItems() {
+        let sarahSource = makeTask(
+            title: "Sarah source",
+            category: .messages,
+            source: LifeTaskSource(
+                sourceType: .message,
+                sourceID: "sarah-1",
+                displayName: "Sarah via iMessage",
+                originActor: .sarah
+            )
+        )
+        let familyOwned = makeTask(title: "Family owner", category: .admin, owner: .family)
+        let unrelated = makeTask(title: "Unrelated", category: .admin, owner: .blake)
+        let store = makeStore(tasks: [sarahSource, familyOwned, unrelated])
+
+        #expect(Set(store.familyTasks.map(\.title)) == ["Sarah source", "Family owner"])
+    }
+
+    @Test func pendingApprovalsFilterCorrectly() {
+        let pending = ApprovalAction(
+            title: "Pending",
+            summary: "Needs approval.",
+            actionType: .sendEmail,
+            proposedPayloadPreview: "Draft",
+            riskLevel: .medium,
+            status: .pending,
+            createdAt: fixedNow,
+            updatedAt: fixedNow
+        )
+        let completed = ApprovalAction(
+            title: "Completed",
+            summary: "Already done.",
+            actionType: .archiveEmail,
+            proposedPayloadPreview: "Archive",
+            riskLevel: .low,
+            status: .completed,
+            createdAt: fixedNow,
+            updatedAt: fixedNow
+        )
+        let store = makeStore(approvalActions: [completed, pending])
+
+        #expect(store.pendingApprovals == [pending])
+    }
+
+    @Test func quickCaptureCreatesInboxTask() throws {
+        let store = makeStore(tasks: [])
+        let created = try #require(store.createQuickTask(title: "  Pay registration fee  "))
+
+        #expect(created.title == "Pay registration fee")
+        #expect(created.status == .inbox)
+        #expect(created.source?.sourceType == .manual)
+        #expect(store.inboxTasks.contains(created))
+    }
+
+    @Test func markDoneSnoozeAndAssignMutateTaskState() throws {
+        let task = makeTask(title: "Mutable", priority: .p1)
+        let store = makeStore(tasks: [task])
+
+        store.assignToDaneel(id: task.id)
+        var updated = try #require(store.tasks.first)
+        #expect(updated.status == .assignedToDaneel)
+        #expect(updated.assignee == .daneel)
+
+        store.snooze(id: task.id, until: fixedNow.addingTimeInterval(3600))
+        updated = try #require(store.tasks.first)
+        #expect(updated.status == .snoozed)
+        #expect(updated.snoozedUntil == fixedNow.addingTimeInterval(3600))
+
+        store.markDone(id: task.id)
+        updated = try #require(store.tasks.first)
+        #expect(updated.status == .done)
+    }
+
+    @Test func jobFollowUpsDueIncludesOpenOpportunitiesThroughToday() {
+        let due = JobOpportunity(
+            company: "Due Co",
+            role: "Lead",
+            stage: .followUpDue,
+            nextFollowUpAt: fixedNow.addingTimeInterval(-600),
+            associatedTaskIDs: [],
+            createdAt: fixedNow,
+            updatedAt: fixedNow
+        )
+        let later = JobOpportunity(
+            company: "Later Co",
+            role: "Lead",
+            stage: .saved,
+            nextFollowUpAt: fixedNow.addingTimeInterval(172_800),
+            associatedTaskIDs: [],
+            createdAt: fixedNow,
+            updatedAt: fixedNow
+        )
+        let closed = JobOpportunity(
+            company: "Closed Co",
+            role: "Lead",
+            stage: .closed,
+            nextFollowUpAt: fixedNow.addingTimeInterval(-600),
+            associatedTaskIDs: [],
+            createdAt: fixedNow,
+            updatedAt: fixedNow
+        )
+        let store = makeStore(jobOpportunities: [later, closed, due])
+
+        #expect(store.jobFollowUpsDue == [due])
+    }
+
+    private let fixedNow = Date(timeIntervalSince1970: 1_779_907_600)
+
+    private func makeStore(
+        tasks: [LifeTask] = [],
+        approvalActions: [ApprovalAction] = [],
+        jobOpportunities: [JobOpportunity] = [],
+        familyRequests: [FamilyRequest] = []
+    ) -> LifeOpsStore {
+        LifeOpsStore(
+            seedData: LifeOpsSeedData(
+                tasks: tasks,
+                approvalActions: approvalActions,
+                jobOpportunities: jobOpportunities,
+                familyRequests: familyRequests
+            ),
+            now: { fixedNow }
+        )
+    }
+
+    private func makeTask(
+        title: String,
+        category: LifeTaskCategory = .personal,
+        status: LifeTaskStatus = .needsBlake,
+        priority: LifePriority = .p2,
+        urgency: Int = 50,
+        dueOffset: TimeInterval? = nil,
+        snoozedUntil: Date? = nil,
+        owner: LifeActor = .blake,
+        source: LifeTaskSource? = nil
+    ) -> LifeTask {
+        LifeTask(
+            id: UUID(),
+            title: title,
+            summary: "Summary",
+            category: category,
+            status: status,
+            priority: priority,
+            urgencyScore: urgency,
+            importanceScore: 50,
+            dueAt: dueOffset.map { fixedNow.addingTimeInterval($0) },
+            snoozedUntil: snoozedUntil,
+            estimatedMinutes: 10,
+            nextAction: "Next action",
+            owner: owner,
+            assignee: .blake,
+            source: source,
+            confidence: 1.0,
+            createdAt: fixedNow,
+            updatedAt: fixedNow
+        )
+    }
+}

--- a/AgentBoardUI/Components/DesktopSidebar.swift
+++ b/AgentBoardUI/Components/DesktopSidebar.swift
@@ -159,6 +159,7 @@ struct DesktopSidebar: View {
 
     private func tabCount(_ tab: AppDestination) -> Int? {
         switch tab {
+        case .lifeOps: appModel.lifeOpsStore.nowTasks.count
         case .work: appModel.workStore.items.count
         case .agents: appModel.agentsStore.summaries.count
         case .sessions: appModel.sessionsStore.sessions.count

--- a/AgentBoardUI/Components/LifeOpsPriorityBadge.swift
+++ b/AgentBoardUI/Components/LifeOpsPriorityBadge.swift
@@ -1,0 +1,37 @@
+import AgentBoardCore
+import SwiftUI
+
+struct LifeOpsPriorityBadge: View {
+    let priority: LifePriority
+
+    var body: some View {
+        Text(priority.displayName)
+            .font(.system(.caption2, design: .rounded, weight: .bold))
+            .foregroundStyle(foregroundColor)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(backgroundColor.opacity(0.18))
+            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .stroke(backgroundColor.opacity(0.6), lineWidth: 1)
+            }
+            .accessibilityIdentifier("lifeops.priority.badge")
+    }
+
+    private var backgroundColor: Color {
+        switch priority {
+        case .p0: NeuPalette.accentCoral
+        case .p1: NeuPalette.accentOrange
+        case .p2: NeuPalette.accentCyan
+        case .p3: NeuPalette.textTertiary
+        }
+    }
+
+    private var foregroundColor: Color {
+        switch priority {
+        case .p3: NeuPalette.textSecondary
+        case .p0, .p1, .p2: backgroundColor
+        }
+    }
+}

--- a/AgentBoardUI/Components/LifeOpsQuickCaptureView.swift
+++ b/AgentBoardUI/Components/LifeOpsQuickCaptureView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct LifeOpsQuickCaptureView: View {
+    @State private var text = ""
+    let onSubmit: (String) -> Void
+
+    private var canSubmit: Bool {
+        !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "square.and.pencil")
+                .foregroundStyle(NeuPalette.textSecondary)
+
+            TextField("Quick capture", text: $text)
+                .textFieldStyle(.plain)
+                .submitLabel(.done)
+                .onSubmit(submit)
+                .accessibilityIdentifier("lifeops.quickCapture.field")
+
+            Button(action: submit) {
+                Image(systemName: "plus")
+                    .font(.system(size: 13, weight: .bold))
+                    .frame(width: 28, height: 28)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(canSubmit ? NeuPalette.accentForeground : NeuPalette.textDisabled)
+            .background(canSubmit ? NeuPalette.accentCyan : NeuPalette.inset)
+            .clipShape(Circle())
+            .disabled(!canSubmit)
+            .accessibilityLabel("Add LifeOps task")
+            .accessibilityIdentifier("lifeops.quickCapture.submit")
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(NeuPalette.inset)
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private func submit() {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        onSubmit(trimmed)
+        text = ""
+    }
+}

--- a/AgentBoardUI/Components/LifeOpsTaskRow.swift
+++ b/AgentBoardUI/Components/LifeOpsTaskRow.swift
@@ -1,0 +1,82 @@
+import AgentBoardCore
+import SwiftUI
+
+struct LifeOpsTaskRow: View {
+    let task: LifeTask
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            LifeOpsPriorityBadge(priority: task.priority)
+                .padding(.top, 2)
+
+            VStack(alignment: .leading, spacing: 7) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(task.title)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(NeuPalette.textPrimary)
+                        .lineLimit(2)
+
+                    if task.isSarahOriginated {
+                        Label("Sarah", systemImage: "message.fill")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(NeuPalette.accentOrange)
+                            .labelStyle(.titleAndIcon)
+                            .lineLimit(1)
+                    }
+                }
+
+                Text(task.nextAction)
+                    .font(.caption)
+                    .foregroundStyle(NeuPalette.textSecondary)
+                    .lineLimit(2)
+
+                HStack(spacing: 8) {
+                    metadataPill(task.category.title, systemImage: "tag")
+
+                    if let source = task.source {
+                        metadataPill(source.displayName, systemImage: sourceIcon(for: source.sourceType))
+                    }
+
+                    if let dueAt = task.dueAt {
+                        metadataPill(dueAt.formatted(date: .abbreviated, time: .shortened), systemImage: "clock")
+                    }
+
+                    if task.owner != .blake || task.assignee != .blake {
+                        metadataPill("\(task.owner.displayName) -> \(task.assignee.displayName)", systemImage: "person.2")
+                    }
+                }
+                .lineLimit(1)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(14)
+        .background(NeuPalette.surface.opacity(0.78))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(NeuPalette.borderSoft, lineWidth: 1)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("lifeops.task.row")
+    }
+
+    private func metadataPill(_ text: String, systemImage: String) -> some View {
+        Label(text, systemImage: systemImage)
+            .font(.caption2)
+            .foregroundStyle(NeuPalette.textTertiary)
+            .labelStyle(.titleAndIcon)
+    }
+
+    private func sourceIcon(for type: LifeSourceType) -> String {
+        switch type {
+        case .email: "envelope"
+        case .calendar: "calendar"
+        case .message: "message"
+        case .manual: "square.and.pencil"
+        case .chat: "bubble.left.and.bubble.right"
+        case .jobSearch: "briefcase"
+        case .family: "person.2"
+        }
+    }
+}

--- a/AgentBoardUI/Screens/LifeOpsScreen.swift
+++ b/AgentBoardUI/Screens/LifeOpsScreen.swift
@@ -1,0 +1,385 @@
+import AgentBoardCore
+import SwiftUI
+
+enum LifeOpsScreenMode {
+    case dashboard
+    case compact
+}
+
+struct LifeOpsScreen: View {
+    let store: LifeOpsStore
+    let mode: LifeOpsScreenMode
+
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    private var usesCompactLayout: Bool {
+        mode == .compact || horizontalSizeClass == .compact
+    }
+
+    var body: some View {
+        ZStack {
+            NeuBackground()
+
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 24) {
+                    header
+
+                    if usesCompactLayout {
+                        compactContent
+                    } else {
+                        dashboardContent
+                    }
+                }
+                .padding(usesCompactLayout ? 16 : 24)
+                .padding(.bottom, 32)
+            }
+        }
+        .agentBoardNavigationBarHidden(true)
+        .accessibilityIdentifier("screen_lifeops")
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .bottom) {
+                VStack(alignment: .leading, spacing: 6) {
+                    AgentBoardEyebrow(text: "LIFEOPS")
+                    Text("LifeOps")
+                        .font(.system(size: usesCompactLayout ? 34 : 32, weight: .bold))
+                        .foregroundStyle(NeuPalette.textPrimary)
+                    Text("Updated \(store.lastRefreshAt.formatted(date: .abbreviated, time: .shortened))")
+                        .font(.caption)
+                        .foregroundStyle(NeuPalette.textSecondary)
+                }
+
+                Spacer()
+
+                if !usesCompactLayout {
+                    summaryStrip
+                }
+            }
+
+            LifeOpsQuickCaptureView { title in
+                store.createQuickTask(title: title)
+            }
+        }
+        .accessibilityIdentifier("lifeops.header")
+    }
+
+    private var summaryStrip: some View {
+        HStack(spacing: 12) {
+            metric("Now", count: store.nowTasks.count, color: NeuPalette.accentOrange)
+            metric("Approvals", count: store.pendingApprovals.count, color: NeuPalette.accentCyan)
+            metric("Family", count: store.familyTasks.count, color: NeuPalette.accentGreen)
+        }
+    }
+
+    private var compactContent: some View {
+        VStack(alignment: .leading, spacing: 26) {
+            taskSection(
+                title: "Now",
+                accessibilityID: "lifeops.section.now",
+                tasks: Array(store.nowTasks.prefix(3)),
+                emptyText: "Clear for now."
+            )
+            taskSection(
+                title: "Today",
+                accessibilityID: "lifeops.section.today",
+                tasks: store.todayTasks,
+                emptyText: "No timed items today."
+            )
+            approvalSection
+            familySection
+            jobSearchSection
+            taskSection(
+                title: "Inbox",
+                accessibilityID: "lifeops.section.inbox",
+                tasks: store.inboxTasks,
+                emptyText: "Inbox is empty."
+            )
+            taskSection(
+                title: "Waiting On",
+                accessibilityID: "lifeops.section.waiting",
+                tasks: store.waitingTasks,
+                emptyText: "No blockers tracked."
+            )
+        }
+    }
+
+    private var dashboardContent: some View {
+        HStack(alignment: .top, spacing: 24) {
+            VStack(alignment: .leading, spacing: 26) {
+                taskSection(
+                    title: "Now",
+                    accessibilityID: "lifeops.section.now",
+                    tasks: Array(store.nowTasks.prefix(3)),
+                    emptyText: "Clear for now."
+                )
+                taskSection(
+                    title: "Today",
+                    accessibilityID: "lifeops.section.today",
+                    tasks: store.todayTasks,
+                    emptyText: "No timed items today."
+                )
+            }
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+
+            VStack(alignment: .leading, spacing: 26) {
+                taskSection(
+                    title: "Inbox",
+                    accessibilityID: "lifeops.section.inbox",
+                    tasks: store.inboxTasks,
+                    emptyText: "Inbox is empty."
+                )
+                approvalSection
+                taskSection(
+                    title: "Waiting On",
+                    accessibilityID: "lifeops.section.waiting",
+                    tasks: store.waitingTasks,
+                    emptyText: "No blockers tracked."
+                )
+            }
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+
+            VStack(alignment: .leading, spacing: 26) {
+                jobSearchSection
+                familySection
+            }
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+    }
+
+    private func taskSection(
+        title: String,
+        accessibilityID: String,
+        tasks: [LifeTask],
+        emptyText: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionHeader(title, count: tasks.count)
+
+            if tasks.isEmpty {
+                emptyState(emptyText)
+            } else {
+                LazyVStack(spacing: 10) {
+                    ForEach(tasks) { task in
+                        LifeOpsTaskRow(task: task)
+                    }
+                }
+            }
+        }
+        .accessibilityIdentifier(accessibilityID)
+    }
+
+    private var approvalSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionHeader("Needs Approval", count: store.pendingApprovals.count)
+
+            if store.pendingApprovals.isEmpty {
+                emptyState("No pending approvals.")
+            } else {
+                LazyVStack(spacing: 10) {
+                    ForEach(store.pendingApprovals) { approval in
+                        approvalRow(approval)
+                    }
+                }
+            }
+        }
+        .accessibilityIdentifier("lifeops.section.approvals")
+    }
+
+    private var jobSearchSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionHeader("Job Search", count: store.jobFollowUpsDue.count)
+
+            if store.jobFollowUpsDue.isEmpty {
+                emptyState("No follow-ups due.")
+            } else {
+                LazyVStack(spacing: 10) {
+                    ForEach(store.jobFollowUpsDue) { opportunity in
+                        jobRow(opportunity)
+                    }
+                }
+            }
+        }
+        .accessibilityIdentifier("lifeops.section.jobSearch")
+    }
+
+    private var familySection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionHeader("Family", count: store.familyTasks.count)
+
+            if store.familyTasks.isEmpty && store.familyRequests.isEmpty {
+                emptyState("No family items.")
+            } else {
+                LazyVStack(spacing: 10) {
+                    ForEach(store.familyTasks) { task in
+                        LifeOpsTaskRow(task: task)
+                    }
+
+                    ForEach(store.familyRequests) { request in
+                        familyRequestRow(request)
+                    }
+                }
+            }
+        }
+        .accessibilityIdentifier("lifeops.section.family")
+    }
+
+    private func sectionHeader(_ title: String, count: Int) -> some View {
+        HStack(spacing: 8) {
+            Text(title.uppercased())
+                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                .foregroundStyle(NeuPalette.textSecondary)
+            Text("\(count)")
+                .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                .foregroundStyle(NeuPalette.textTertiary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(NeuPalette.inset)
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+            Spacer()
+        }
+    }
+
+    private func metric(_ label: String, count: Int, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text("\(count)")
+                .font(.title3.weight(.bold))
+                .foregroundStyle(color)
+                .monospacedDigit()
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(NeuPalette.textSecondary)
+        }
+        .frame(width: 78, alignment: .leading)
+    }
+
+    private func emptyState(_ text: String) -> some View {
+        Text(text)
+            .font(.subheadline)
+            .foregroundStyle(NeuPalette.textTertiary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 14)
+            .padding(.horizontal, 12)
+            .background(NeuPalette.surface.opacity(0.42))
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private func approvalRow(_ approval: ApprovalAction) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: approvalIcon(for: approval.actionType))
+                .font(.body.weight(.semibold))
+                .foregroundStyle(NeuPalette.accentCyan)
+                .frame(width: 28, height: 28)
+                .background(NeuPalette.accentCyan.opacity(0.16))
+                .clipShape(Circle())
+
+            VStack(alignment: .leading, spacing: 7) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text(approval.title)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(NeuPalette.textPrimary)
+                    Spacer()
+                    Text(approval.riskLevel.title)
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(approvalRiskColor(approval.riskLevel))
+                }
+
+                Text(approval.summary)
+                    .font(.caption)
+                    .foregroundStyle(NeuPalette.textSecondary)
+                    .lineLimit(2)
+
+                Text(approval.proposedPayloadPreview)
+                    .font(.caption2)
+                    .foregroundStyle(NeuPalette.textTertiary)
+                    .lineLimit(2)
+            }
+        }
+        .padding(14)
+        .background(NeuPalette.accentCyan.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(NeuPalette.accentCyan.opacity(0.28), lineWidth: 1)
+        }
+        .accessibilityIdentifier("lifeops.approval.row")
+    }
+
+    private func jobRow(_ opportunity: JobOpportunity) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(opportunity.company)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(NeuPalette.textPrimary)
+                Spacer()
+                Text(opportunity.stage.title)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(NeuPalette.accentOrange)
+            }
+
+            Text(opportunity.role)
+                .font(.caption)
+                .foregroundStyle(NeuPalette.textSecondary)
+
+            if let nextFollowUpAt = opportunity.nextFollowUpAt {
+                Label(nextFollowUpAt.formatted(date: .abbreviated, time: .shortened), systemImage: "clock")
+                    .font(.caption2)
+                    .foregroundStyle(NeuPalette.textTertiary)
+            }
+        }
+        .padding(14)
+        .background(NeuPalette.surface.opacity(0.78))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(NeuPalette.borderSoft, lineWidth: 1)
+        }
+        .accessibilityIdentifier("lifeops.job.row")
+    }
+
+    private func familyRequestRow(_ request: FamilyRequest) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("\(request.requester.displayName) request", systemImage: "message.fill")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(NeuPalette.accentOrange)
+
+            Text(request.rawText)
+                .font(.subheadline)
+                .foregroundStyle(NeuPalette.textPrimary)
+                .lineLimit(2)
+
+            Text(request.interpretedAction.title)
+                .font(.caption2)
+                .foregroundStyle(NeuPalette.textTertiary)
+        }
+        .padding(14)
+        .background(NeuPalette.surface.opacity(0.78))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(NeuPalette.accentOrange.opacity(0.28), lineWidth: 1)
+        }
+        .accessibilityIdentifier("lifeops.familyRequest.row")
+    }
+
+    private func approvalIcon(for type: ApprovalActionType) -> String {
+        switch type {
+        case .sendEmail: "envelope.badge"
+        case .sendMessage: "message.badge"
+        case .createCalendarEvent: "calendar.badge.plus"
+        case .applyToJob: "briefcase"
+        case .archiveEmail: "archivebox"
+        case .delegateTask: "person.crop.circle.badge.checkmark"
+        case .other: "checkmark.seal"
+        }
+    }
+
+    private func approvalRiskColor(_ riskLevel: ApprovalRiskLevel) -> Color {
+        switch riskLevel {
+        case .low: NeuPalette.accentGreen
+        case .medium: NeuPalette.accentOrange
+        case .high: NeuPalette.accentCoral
+        }
+    }
+}

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -194,4 +194,21 @@ Agents → CompanionServer → FSEvents + ps
 
 ---
 
+## ADR-014: LifeOps executive assistant module
+**Date:** 2026-05-27
+**Status:** Planned
+**Decision:** Add a LifeOps module inside AgentBoard rather than starting a separate app for Blake's ADHD-oriented executive-function assistant workflow.
+
+**Context:** Blake wants Daneel to help outside coding: triaging email, calendar, messages, job-search follow-ups, family logistics, and delegated personal/admin tasks. The system needs both a macOS dashboard and iOS companion app, plus chat with Daneel and a shared family coordination path for Sarah through iMessage. AgentBoard already has macOS/iOS shells, Hermes chat integration, shared SwiftUI/Core targets, task-board concepts, and companion-service patterns, making it the fastest place to start.
+
+**Consequences:**
+- LifeOps will be a separate product area from coding Work/Sessions/Agents so personal/family tasks do not pollute development workflows.
+- V1 starts with shared models, fixture-backed `LifeOpsStore`, protocol seams, macOS/iOS UI, and tests.
+- Real email/calendar/iMessage automation is deferred until the task model and UI are usable.
+- Sarah/family support is a first-class requirement: Sarah can request family tasks/calendar items through iMessage, but cannot see Blake's private tasks or approve actions as Blake by default.
+- External side effects such as sending messages, sending email, applying to jobs, or modifying non-family calendar events require explicit approval.
+- See `docs/PRD-lifeops-executive-assistant.md`, `docs/superpowers/specs/2026-05-27-lifeops-executive-assistant-design.md`, and `docs/superpowers/plans/2026-05-27-lifeops-mvp-implementation.md`.
+
+---
+
 *To add a new ADR: append with the next number, include date, status, decision, context, and consequences.*

--- a/docs/PRD-lifeops-executive-assistant.md
+++ b/docs/PRD-lifeops-executive-assistant.md
@@ -1,0 +1,394 @@
+# PRD: LifeOps Executive Assistant
+
+**Date:** 2026-05-27
+**Owner:** Blake Crane
+**Agent partner:** Daneel
+**Product surface:** AgentBoard macOS + AgentBoardMobile iOS
+**Status:** Draft for implementation handoff
+
+## 1. Summary
+
+Build a LifeOps layer inside AgentBoard that lets Daneel act as Blake's executive-function assistant outside coding. The system captures obligations from email, calendar, messaging, manual chat, and job-search activity; converts them into structured tasks; assigns urgency; displays them in a macOS dashboard and iOS companion; and lets Blake delegate work back to Daneel.
+
+This is primarily Blake's personal operating system, but it must also support family coordination with Sarah. Daneel should be able to add shared family calendar items and accept task requests from Sarah through iMessage, while keeping ownership, consent, and visibility clear.
+
+## 2. Problem
+
+Blake has ADHD and needs external executive-function support for:
+
+- Email triage and follow-up
+- Calendar awareness and prep
+- Job-search structure
+- Family logistics
+- Message follow-through
+- Remembering loose obligations
+- Delegating small admin actions to Daneel
+
+The current setup is fragmented across email, calendar, messaging apps, Apple Reminders, GitHub/project systems, and memory. This causes dropped balls, stale job leads, appointment prep gaps, and mental overhead.
+
+## 3. Goals
+
+### Product goals
+
+1. Create one trusted task surface for non-coding life/admin/job-search work.
+2. Keep Blake oriented with short, realistic daily views instead of giant backlogs.
+3. Give Daneel structured objects to act on: tasks, approvals, calendar items, job leads, waiting-on items.
+4. Support family coordination with Sarah via shared family calendar/task intake.
+5. Ship useful app scaffolding quickly in the existing macOS and iOS AgentBoard apps.
+
+### ADHD-support goals
+
+1. Externalize working memory.
+2. Minimize capture friction.
+3. Prioritize by time/consequence, not vague productivity vibes.
+4. Provide gentle recovery from drift instead of shame.
+5. Make the next action obvious.
+6. Keep notification volume low and meaningful.
+
+## 4. Non-goals for v1
+
+- No autonomous sending of email/iMessage without explicit approval.
+- No full replacement for Apple Calendar/Reminders on day one.
+- No medical/therapeutic claims.
+- No ML-heavy priority optimizer before we have real usage data.
+- No multi-user family task platform beyond Sarah intake/shared calendar support.
+- No app-store-polished UI before core workflow is proven.
+
+## 5. Users and roles
+
+### Blake
+
+Primary user. Owns the task system, approval queue, job-search pipeline, and daily planning views.
+
+### Daneel
+
+Agent operator. Reads authorized sources, creates tasks, drafts replies/actions, prioritizes, nudges, and performs delegated work after approval.
+
+### Sarah
+
+Family collaborator. Can request family tasks through iMessage and can receive shared calendar items. Sarah does not need full access to Blake's private task system unless explicitly enabled later.
+
+## 6. Core concepts
+
+### Life task
+
+A structured obligation/opportunity with source, priority, status, next action, owner, and assignee.
+
+Required fields:
+
+- `id`
+- `title`
+- `summary`
+- `category`
+- `status`
+- `priority` (`P0`, `P1`, `P2`, `P3`)
+- `urgencyScore` 0-100
+- `importanceScore` 0-100
+- `dueAt`
+- `snoozedUntil`
+- `estimatedMinutes`
+- `nextAction`
+- `owner` (`blake`, `sarah`, `family`, `daneel`)
+- `assignee` (`blake`, `daneel`, `sarah`, `external`)
+- `sourceType`
+- `sourceID`
+- `sourceURL`
+- `confidence`
+- `createdAt`
+- `updatedAt`
+
+### Task categories
+
+- `email`
+- `calendar`
+- `messages`
+- `jobSearch`
+- `family`
+- `admin`
+- `personal`
+- `finance`
+- `health`
+- `project`
+- `waitingOn`
+- `approval`
+
+### Statuses
+
+- `inbox` — captured but not reviewed
+- `needsBlake` — Blake must act/decide
+- `assignedToDaneel` — Daneel has work to do
+- `waitingOnExternal` — blocked by someone else
+- `scheduled` — tied to calendar/time block
+- `snoozed` — intentionally hidden until later
+- `done`
+- `blocked`
+- `cancelled`
+
+### Priority
+
+- `P0` — urgent, time-sensitive, high consequence, interrupt-worthy
+- `P1` — should be handled today
+- `P2` — this week / important but not burning
+- `P3` — backlog / someday / low pressure
+
+## 7. Main workflows
+
+### 7.1 Daily briefing
+
+Every morning, Daneel reviews authorized sources and produces a concise LifeOps briefing:
+
+- P0/P1 tasks
+- Today's calendar
+- Meeting prep gaps
+- Job-search follow-ups due
+- Waiting-on items
+- Suggested first action
+- Items Daneel can handle if approved
+
+The app should show the same briefing in the dashboard.
+
+### 7.2 Email-to-task triage
+
+Daneel scans new email and classifies each item:
+
+- No action
+- Reply needed
+- Waiting on someone
+- Scheduling/calendar
+- Bill/admin
+- Job-search lead
+- Family/personal
+- FYI/archive
+
+For actionable items, Daneel creates LifeTasks with a source link and next action. If a reply is needed, Daneel can create a draft action that Blake approves before sending.
+
+### 7.3 Calendar defense
+
+Calendar items create prep and logistics tasks:
+
+- Meeting without agenda: create prep task
+- Interview: create prep checklist
+- Travel/logistics: flag timing
+- Back-to-back meetings: warn
+- Family event: optionally add/share with Sarah
+
+### 7.4 Job-search pipeline
+
+Track opportunities as structured records:
+
+- Company
+- Role
+- URL
+- Contact
+- Stage
+- Last touch
+- Next follow-up
+- Resume/cover letter version
+- Notes
+- Associated tasks
+
+Pipeline stages:
+
+- `target`
+- `saved`
+- `applied`
+- `recruiterContact`
+- `screenScheduled`
+- `interviewing`
+- `followUpDue`
+- `offer`
+- `rejected`
+- `closed`
+
+### 7.5 Sarah / family task intake
+
+Sarah can send an iMessage request to Daneel, such as:
+
+- "Can you remind Blake to call the vet tomorrow?"
+- "Please add soccer pickup Friday at 4."
+- "Can you put dinner with my parents on the family calendar?"
+
+Daneel should:
+
+1. Parse the request.
+2. Decide whether it is a task, calendar item, or question.
+3. Create a LifeTask with owner `family` or `sarah` as appropriate.
+4. Add shared family calendar events when the request is unambiguous and permitted.
+5. Confirm back to Sarah over iMessage.
+6. Surface the item to Blake in the family section or daily briefing.
+
+Approval rule: Sarah can add family tasks/calendar events, but cannot send messages as Blake, access private job-search/email details, or approve actions on Blake's behalf unless Blake explicitly grants that later.
+
+### 7.6 Delegation to Daneel
+
+Blake can assign tasks to Daneel from chat, desktop, or iOS:
+
+- Draft a reply
+- Summarize a thread
+- Find job leads
+- Prepare interview notes
+- Schedule options
+- Research a purchase/admin decision
+
+The task moves to `assignedToDaneel`; output appears in an approval queue if it has external side effects.
+
+## 8. App surfaces
+
+### macOS dashboard
+
+Primary orientation surface.
+
+Sections:
+
+1. Now — 1 to 3 recommended actions
+2. Today — realistic daily list
+3. Inbox — captured but untriaged items
+4. Needs approval — drafts/actions waiting for Blake
+5. Waiting on — people/systems Blake is waiting for
+6. Job search — pipeline and follow-ups
+7. Family — Sarah/family calendar/tasks
+8. Calendar — today/tomorrow agenda and prep gaps
+9. Chat — talk to Daneel in context
+
+### iOS companion
+
+Mobile should be action-oriented, not a dense dashboard.
+
+Tabs/sections:
+
+1. Today
+2. Capture
+3. Approvals
+4. Job Search
+5. Family
+6. Chat
+
+Required v1 mobile actions:
+
+- Mark done
+- Snooze
+- Add quick task
+- Ask Daneel
+- Approve/reject draft action
+- View today's calendar/prep tasks
+
+## 9. Notification rules
+
+Default notifications must be conservative.
+
+Interrupt immediately only for:
+
+- P0 tasks
+- Appointment starting soon
+- Hard deadline today
+- Interview/call prep missing
+- Approved family-critical reminders
+
+Daily briefing handles P1/P2.
+P3 stays quiet unless requested.
+
+## 10. Safety and permissions
+
+### Daneel can do without approval
+
+- Read authorized sources
+- Summarize
+- Create local tasks
+- Draft replies/actions
+- Suggest priorities
+- Move/snooze tasks
+- Add non-sensitive family tasks from Sarah
+
+### Daneel needs approval before
+
+- Sending email/messages as Blake
+- Applying to jobs
+- Sharing files
+- Creating/modifying non-family calendar events
+- Deleting/archiving email
+- Spending money
+- Contacting third parties
+
+### Sarah can do in v1
+
+- Send iMessage task requests
+- Request shared family calendar events
+- Ask Daneel to add a family task to Blake's system
+
+### Sarah cannot do in v1
+
+- See Blake's private tasks by default
+- Approve external actions as Blake
+- Access Blake's private email/job-search details
+- Send messages as Blake
+
+## 11. MVP acceptance criteria
+
+### Data/model layer
+
+- LifeTask model exists in AgentBoardCore.
+- JobOpportunity model exists in AgentBoardCore.
+- ApprovalAction model exists in AgentBoardCore.
+- FamilyRequest model exists in AgentBoardCore.
+- LifeOpsStore can load seeded/demo data and perform create/update/status/snooze/done actions.
+
+### macOS UI
+
+- AgentBoard has a LifeOps section/screen.
+- Screen shows Now, Today, Inbox, Approvals, Job Search, Family, Waiting On.
+- User can create a quick task.
+- User can mark tasks done/snoozed.
+- User can open chat with Daneel from the LifeOps context.
+
+### iOS UI
+
+- AgentBoardMobile exposes LifeOps tab/section.
+- Today list, quick capture, approvals, and family tasks are visible.
+- User can mark done/snooze/create quick task.
+
+### Agent integration scaffold
+
+- App has clear service protocols for future ingestion:
+  - Email triage service
+  - Calendar service
+  - Message intake service
+  - Job pipeline service
+  - Daneel action service
+- v1 may use mock/local implementations, but protocols and models must make real integration straightforward.
+
+### Tests
+
+- Model tests cover priority/status/category encoding.
+- Store tests cover create/update/snooze/done/filtering.
+- UI/semantics tests cover key LifeOps views and accessibility identifiers.
+
+## 12. Metrics for success
+
+- Blake checks the Today/Now view daily.
+- Fewer forgotten replies/follow-ups.
+- Job-search follow-ups are visible and dated.
+- Sarah can add family tasks without turning Blake into a relay server.
+- P0/P1 list stays small enough to trust.
+- Daneel can answer: "what should I do next?" from structured state.
+
+## 13. Implementation strategy
+
+Build this as a LifeOps module inside AgentBoard first rather than a separate app. AgentBoard already has:
+
+- macOS and iOS targets
+- shared SwiftUI architecture
+- Hermes chat integration
+- task-board concepts
+- companion service patterns
+- local persistence patterns
+
+Do not block on real email/calendar/iMessage integrations. Start with models, store, dashboard UI, iOS UI, and mock ingestion/service protocols. Then connect real sources incrementally.
+
+## 14. Open questions
+
+1. Which calendar is canonical for shared family events: Apple Calendar, Google Calendar, or both?
+2. Should LifeOps tasks sync to Apple Reminders, and if so, only P0/P1 or all tasks?
+3. Should Sarah get a lightweight view later, or remain iMessage-only in v1?
+4. Should personal LifeOps data live in `~/.hermes/kanban.db`, SwiftData, or a new LifeOps SQLite store?
+
+Recommendation for v1: use app-local store/protocols with seeded data, then decide canonical persistence after Blake uses the UI for a few days.

--- a/docs/superpowers/plans/2026-05-27-lifeops-mvp-implementation.md
+++ b/docs/superpowers/plans/2026-05-27-lifeops-mvp-implementation.md
@@ -1,0 +1,290 @@
+# LifeOps MVP Implementation Plan
+
+> **For Hermes:** Use Codex or subagent-driven-development to implement this plan task-by-task. Keep real external integrations out of the first pass.
+
+**Goal:** Add a LifeOps executive-function dashboard to AgentBoard macOS and AgentBoardMobile iOS, backed by shared models, fixture data, and store logic.
+
+**Architecture:** Add LifeOps as a separate module inside AgentBoardCore/AgentBoardUI. Use in-memory fixture services for v1. Integrate a LifeOps destination into the existing native macOS sidebar and iOS shell without disrupting coding-agent workflows.
+
+**Tech Stack:** Swift 6, SwiftUI, Observation, Swift Testing, XcodeGen project.yml.
+
+---
+
+## Guardrails
+
+- Do not implement live email/calendar/iMessage automation in this pass.
+- Do not send any real messages or create real calendar events.
+- Do not edit `AgentBoard.xcodeproj/project.pbxproj` directly; edit `project.yml` and run `xcodegen generate` if needed.
+- Preserve existing Work/Sessions/Agents/Chat behavior.
+- Keep UI native SwiftUI per ADR-013.
+- Run quality gates before handoff:
+  - `swiftlint lint --strict`
+  - `xcodebuild test -scheme AgentBoard -destination 'platform=macOS'`
+  - `xcodebuild -scheme AgentBoardMobile -destination 'generic/platform=iOS Simulator' build`
+
+## Task 1: Add LifeOps models
+
+**Objective:** Create shared Codable/Sendable data structures for LifeOps.
+
+**Files:**
+- Create: `AgentBoardCore/Models/LifeOpsModels.swift`
+- Test: `AgentBoardTests/LifeOpsModelsTests.swift`
+- Modify if needed: `project.yml`
+
+**Implementation details:**
+
+Add enums:
+
+- `LifePriority: String, Codable, CaseIterable, Sendable` with `p0`, `p1`, `p2`, `p3`
+- `LifeTaskCategory`
+- `LifeTaskStatus`
+- `LifeActor`
+- `LifeSourceType`
+- `ApprovalActionType`
+- `ApprovalRiskLevel`
+- `ApprovalStatus`
+- `JobOpportunityStage`
+- `FamilyRequestAction`
+- `FamilyRequestStatus`
+
+Add structs:
+
+- `LifeTask`
+- `LifeTaskSource`
+- `ApprovalAction`
+- `JobOpportunity`
+- `FamilyRequest`
+
+**Tests:**
+
+- Codable round trip for each primary struct.
+- `LifePriority` display ordering maps P0 before P1 before P2 before P3.
+- Defaults/fixtures can construct valid values.
+
+**Verify:**
+
+```bash
+xcodebuild test -scheme AgentBoard -destination 'platform=macOS' -only-testing:AgentBoardTests/LifeOpsModelsTests
+```
+
+## Task 2: Add LifeOps fixtures
+
+**Objective:** Provide realistic local data for UI and store testing.
+
+**Files:**
+- Create: `AgentBoardCore/Services/LifeOpsFixtures.swift`
+- Test: update `AgentBoardTests/LifeOpsModelsTests.swift` or create `LifeOpsFixturesTests.swift`
+
+**Fixture requirements:**
+
+Include examples for:
+
+- P1 email reply task
+- Calendar prep task
+- Job-search follow-up
+- Sarah/family iMessage-originated task
+- Pending approval action
+- Waiting-on item
+- Snoozed P2 task
+
+**Verify:**
+
+- Fixture arrays are non-empty.
+- Fixture IDs referenced by associated objects exist.
+
+## Task 3: Add LifeOpsStore
+
+**Objective:** Implement observable store logic for dashboard sections.
+
+**Files:**
+- Create: `AgentBoardCore/Stores/LifeOpsStore.swift`
+- Test: `AgentBoardTests/LifeOpsStoreTests.swift`
+
+**Store responsibilities:**
+
+- Load fixture data initially.
+- `nowTasks`: unsnoozed/non-done P0/P1 tasks, max 3, sorted by priority/due/urgency.
+- `todayTasks`: due today or P1, excluding done/cancelled/snoozed.
+- `inboxTasks`: status `inbox`.
+- `waitingTasks`: status `waitingOnExternal`.
+- `familyTasks`: owner/category family or Sarah-originated source.
+- `pendingApprovals`: pending approval actions.
+- `jobFollowUpsDue`: opportunities with `nextFollowUpAt <= now/end of today`.
+- `createQuickTask(title:)`.
+- `markDone(id:)`.
+- `snooze(id:until:)`.
+- `assignToDaneel(id:)`.
+
+**Tests:**
+
+- Now returns at most 3 tasks.
+- Done/snoozed tasks disappear from Today.
+- Sarah/family tasks appear in Family.
+- Pending approvals filter correctly.
+- Quick capture creates an Inbox task.
+
+## Task 4: Add shared LifeOps UI components
+
+**Objective:** Build reusable row/badge/capture components.
+
+**Files:**
+- Create: `AgentBoardUI/Components/LifeOpsPriorityBadge.swift`
+- Create: `AgentBoardUI/Components/LifeOpsTaskRow.swift`
+- Create: `AgentBoardUI/Components/LifeOpsQuickCaptureView.swift`
+
+**UI requirements:**
+
+- `LifeOpsPriorityBadge` shows P0/P1/P2/P3 text and visually distinct severity.
+- `LifeOpsTaskRow` shows title, next action, source/category, due date if present, assignee/owner if relevant.
+- `LifeOpsQuickCaptureView` accepts text and calls a closure.
+- Add accessibility identifiers:
+  - `lifeops.priority.badge`
+  - `lifeops.task.row`
+  - `lifeops.quickCapture.field`
+  - `lifeops.quickCapture.submit`
+
+## Task 5: Add LifeOpsScreen
+
+**Objective:** Create shared dashboard sections for macOS/iOS reuse.
+
+**Files:**
+- Create: `AgentBoardUI/Screens/LifeOpsScreen.swift`
+- Optionally create section subviews if the file grows too large:
+  - `LifeOpsTodayView.swift`
+  - `LifeOpsApprovalsView.swift`
+  - `LifeOpsJobSearchView.swift`
+  - `LifeOpsFamilyView.swift`
+
+**UI sections:**
+
+- Now
+- Today
+- Inbox
+- Needs Approval
+- Waiting On
+- Job Search
+- Family
+
+**Requirements:**
+
+- Top Now section never renders more than 3 tasks.
+- Family section clearly labels Sarah-originated tasks.
+- Approval section uses a distinct visual treatment.
+- Quick capture is visible near the top.
+- Empty states are friendly and short.
+
+## Task 6: Add macOS navigation entry
+
+**Objective:** Add LifeOps to the AgentBoard macOS sidebar.
+
+**Files:**
+- Modify likely files after inspection:
+  - `AgentBoard/DesktopRootView.swift`
+  - `AgentBoardCore/Models/AppDestination.swift`
+  - any sidebar enum/list helpers
+
+**Requirements:**
+
+- Add a `lifeOps` destination.
+- Sidebar label: `LifeOps`.
+- Icon suggestion: `checklist` or `brain.head.profile` if available.
+- Selecting it shows `LifeOpsScreen(store: appModel.lifeOpsStore)` or equivalent.
+- Preserve existing destinations.
+
+## Task 7: Add iOS/mobile navigation entry
+
+**Objective:** Expose LifeOps in AgentBoardMobile.
+
+**Files:**
+- Modify likely files after inspection:
+  - `AgentBoardMobile/MobileRootView.swift`
+  - `AgentBoardCore/Models/AppDestination.swift`
+  - app model if needed
+
+**Requirements:**
+
+- Add LifeOps tab/section.
+- Mobile defaults to Now/Today and Quick Capture.
+- Do not overcrowd the tab bar if current structure has limited tabs; use an existing More/NavigationStack pattern if present.
+
+## Task 8: Wire LifeOpsStore into app model
+
+**Objective:** Make the store available to both app shells.
+
+**Files:**
+- Modify: `AgentBoardCore/Stores/AgentBoardAppModel.swift`
+
+**Requirements:**
+
+- Add `public let lifeOpsStore: LifeOpsStore` or equivalent.
+- Initialize with fixtures/local service.
+- Do not trigger external network calls on startup.
+
+## Task 9: Add UI/semantics tests
+
+**Objective:** Guard the new navigation and accessibility contracts.
+
+**Files:**
+- Create: `AgentBoardTests/LifeOpsInterfaceTests.swift`
+- Or extend existing native interface tests if appropriate.
+
+**Tests:**
+
+- `AppDestination` includes LifeOps.
+- LifeOps screen exposes accessibility IDs for Now, Today, Approvals, Family, Quick Capture.
+- Store-backed screen can render fixture data.
+
+## Task 10: Documentation and ADR
+
+**Objective:** Keep architecture docs current.
+
+**Files:**
+- Modify: `docs/ADR.md`
+- Modify: `AGENTS.md` if the implementation changes active architecture.
+
+**ADR content:**
+
+- Add ADR-014: LifeOps module inside AgentBoard.
+- Record decision to start with fixtures/protocol seams and defer real integrations.
+- Record family/Sarah iMessage intake as explicit design requirement.
+
+## Final verification
+
+Run:
+
+```bash
+swiftlint lint --strict
+xcodebuild test -scheme AgentBoard -destination 'platform=macOS'
+xcodebuild -scheme AgentBoardMobile -destination 'generic/platform=iOS Simulator' build
+git status --short
+git log --oneline -5
+```
+
+Expected:
+
+- SwiftLint passes.
+- macOS tests pass.
+- iOS build passes.
+- Changes are committed on a feature branch.
+
+## Suggested branch and PR
+
+Branch:
+
+```text
+feat/lifeops-mvp-scaffold
+```
+
+PR title:
+
+```text
+feat: add LifeOps executive assistant scaffold
+```
+
+PR body summary:
+
+- Adds LifeOps models/store/fixtures.
+- Adds macOS and iOS LifeOps dashboard surfaces.
+- Adds fixture-backed family/job-search/approval sections.
+- Adds tests for models/store/UI contracts.
+- Defers real email/calendar/iMessage integrations to follow-up PRs.

--- a/docs/superpowers/specs/2026-05-27-lifeops-executive-assistant-design.md
+++ b/docs/superpowers/specs/2026-05-27-lifeops-executive-assistant-design.md
@@ -1,0 +1,333 @@
+# LifeOps Executive Assistant Design
+
+**Date:** 2026-05-27
+**Related PRD:** `docs/PRD-lifeops-executive-assistant.md`
+**Product:** AgentBoard macOS + AgentBoardMobile iOS
+
+## Design thesis
+
+LifeOps turns AgentBoard from a coding-agent command center into a broader executive-function command center, while preserving the existing developer workflow. The LifeOps module should be clearly separated from Work/Sessions/Agents so personal/family/job-search tasks do not pollute coding workflows.
+
+The first implementation should prioritize structure and visibility over full automation. Build the task models, stores, dashboard screens, and agent handoff seams first. Email/calendar/iMessage integrations can then plug into the same model without forcing UI rewrites.
+
+## Architecture overview
+
+```text
+Authorized sources
+  ├─ Email
+  ├─ Calendar
+  ├─ iMessage / Telegram / Discord
+  ├─ Manual quick capture
+  └─ Daneel chat
+        ↓
+LifeOps ingestion protocols
+        ↓
+LifeOpsStore
+        ↓
+Shared models in AgentBoardCore
+        ↓
+macOS LifeOps dashboard + iOS LifeOps companion
+        ↓
+Daneel action / approval queue
+```
+
+## Module boundaries
+
+### AgentBoardCore
+
+Owns shared models, store logic, protocols, and fake/local service implementations.
+
+Proposed files:
+
+- `AgentBoardCore/Models/LifeOpsModels.swift`
+- `AgentBoardCore/Stores/LifeOpsStore.swift`
+- `AgentBoardCore/Services/LifeOpsIngestionService.swift`
+- `AgentBoardCore/Services/LifeOpsActionService.swift`
+- `AgentBoardCore/Services/LifeOpsFixtures.swift`
+
+### AgentBoardUI
+
+Owns shared SwiftUI components/screens used by both macOS and iOS.
+
+Proposed files:
+
+- `AgentBoardUI/Screens/LifeOpsScreen.swift`
+- `AgentBoardUI/Screens/LifeOpsTodayView.swift`
+- `AgentBoardUI/Screens/LifeOpsInboxView.swift`
+- `AgentBoardUI/Screens/LifeOpsApprovalsView.swift`
+- `AgentBoardUI/Screens/LifeOpsJobSearchView.swift`
+- `AgentBoardUI/Screens/LifeOpsFamilyView.swift`
+- `AgentBoardUI/Components/LifeOpsTaskRow.swift`
+- `AgentBoardUI/Components/LifeOpsPriorityBadge.swift`
+- `AgentBoardUI/Components/LifeOpsQuickCaptureView.swift`
+
+### AgentBoard macOS
+
+Adds a LifeOps destination to the native sidebar.
+
+### AgentBoardMobile iOS
+
+Adds a LifeOps tab or destination to the mobile shell. The mobile version should default to Today and Quick Capture.
+
+## Data model
+
+### LifeTask
+
+Represents a task, obligation, reminder, or next action.
+
+Key design choice: LifeTask should not reuse `KanbanTask` directly. KanbanTask is optimized for agent/development work. LifeOps tasks need richer personal metadata: source link, due date, snooze, owner, assignee, confidence, urgency, family/job-search categories, and approval state.
+
+Fields:
+
+```swift
+public struct LifeTask: Identifiable, Codable, Hashable, Sendable {
+    public let id: UUID
+    public var title: String
+    public var summary: String
+    public var category: LifeTaskCategory
+    public var status: LifeTaskStatus
+    public var priority: LifePriority
+    public var urgencyScore: Int
+    public var importanceScore: Int
+    public var dueAt: Date?
+    public var snoozedUntil: Date?
+    public var estimatedMinutes: Int?
+    public var nextAction: String
+    public var owner: LifeActor
+    public var assignee: LifeActor
+    public var source: LifeTaskSource?
+    public var confidence: Double
+    public var createdAt: Date
+    public var updatedAt: Date
+}
+```
+
+### ApprovalAction
+
+Represents something Daneel prepared but needs permission to execute.
+
+Examples:
+
+- Send email reply
+- Send iMessage
+- Create calendar event
+- Apply to job
+- Archive email
+
+Fields:
+
+```swift
+public struct ApprovalAction: Identifiable, Codable, Hashable, Sendable {
+    public let id: UUID
+    public var taskID: UUID?
+    public var title: String
+    public var summary: String
+    public var actionType: ApprovalActionType
+    public var proposedPayloadPreview: String
+    public var riskLevel: ApprovalRiskLevel
+    public var status: ApprovalStatus
+    public var createdAt: Date
+    public var updatedAt: Date
+}
+```
+
+### JobOpportunity
+
+Represents one job-search opportunity and its follow-up state.
+
+Fields:
+
+```swift
+public struct JobOpportunity: Identifiable, Codable, Hashable, Sendable {
+    public let id: UUID
+    public var company: String
+    public var role: String
+    public var url: URL?
+    public var contactName: String?
+    public var contactChannel: String?
+    public var stage: JobOpportunityStage
+    public var lastTouchAt: Date?
+    public var nextFollowUpAt: Date?
+    public var notes: String
+    public var associatedTaskIDs: [UUID]
+    public var createdAt: Date
+    public var updatedAt: Date
+}
+```
+
+### FamilyRequest
+
+Represents a request from Sarah or another approved family channel.
+
+Fields:
+
+```swift
+public struct FamilyRequest: Identifiable, Codable, Hashable, Sendable {
+    public let id: UUID
+    public var requester: LifeActor
+    public var source: LifeTaskSource
+    public var rawText: String
+    public var interpretedAction: FamilyRequestAction
+    public var linkedTaskID: UUID?
+    public var linkedApprovalID: UUID?
+    public var status: FamilyRequestStatus
+    public var createdAt: Date
+    public var updatedAt: Date
+}
+```
+
+## Store design
+
+`LifeOpsStore` should be `@Observable` and `@MainActor`, following the existing AgentBoard store pattern.
+
+Responsibilities:
+
+- Hold task collections
+- Compute Now/Today/Inbox/Waiting/Family/Approvals views
+- Create quick-capture tasks
+- Mark done
+- Snooze
+- Assign to Daneel
+- Update job opportunity stage
+- Expose seeded fixtures for v1
+
+It should not directly read email/calendar/iMessage. Those come through protocols.
+
+Proposed protocols:
+
+```swift
+public protocol LifeOpsIngestionService: Sendable {
+    func fetchNewInboxItems() async throws -> [LifeTask]
+    func fetchCalendarPrepItems() async throws -> [LifeTask]
+    func fetchFamilyRequests() async throws -> [FamilyRequest]
+}
+
+public protocol LifeOpsActionService: Sendable {
+    func submitQuickCapture(_ text: String) async throws -> LifeTask
+    func approveAction(_ action: ApprovalAction) async throws
+    func rejectAction(_ action: ApprovalAction) async throws
+    func askDaneel(task: LifeTask, message: String) async throws -> ApprovalAction?
+}
+```
+
+V1 can implement fixture/local versions. Real integrations can be added behind these protocols.
+
+## UI design
+
+### macOS LifeOpsScreen
+
+Use a native SwiftUI layout consistent with ADR-013.
+
+Structure:
+
+- Header: "LifeOps" + last refresh + quick capture field
+- Left/main content: Now and Today
+- Secondary sections: Inbox, Approvals, Waiting On
+- Right/detail pane or lower sections: Job Search and Family
+
+Must avoid overwhelming the user. The top of the screen should never show more than three Now items.
+
+### iOS LifeOps screen
+
+Use mobile-first sections:
+
+1. Now
+2. Today
+3. Quick Capture
+4. Approvals
+5. Family
+6. Job Search follow-ups
+
+Do not attempt to show every dashboard column on iPhone.
+
+## Family collaboration design
+
+Sarah interacts primarily through iMessage. The app stores the results as FamilyRequests and LifeTasks.
+
+Rules:
+
+- Sarah can request family tasks and shared calendar events.
+- Sarah-originated items should be visibly labeled.
+- Shared family tasks appear in Blake's LifeOps Family section and daily briefing.
+- Calendar writes from Sarah should go to the configured shared family calendar once integration exists.
+- Anything that sends a message as Blake still requires Blake approval.
+
+V1 UI should include Sarah/family fixture examples even before live iMessage integration exists, so the interaction model is testable.
+
+## Agent chat integration
+
+LifeOps should reuse existing Hermes chat transport rather than inventing a second chat system.
+
+Add contextual prompts/buttons later:
+
+- "Ask Daneel what to do next"
+- "Ask Daneel to draft reply"
+- "Assign to Daneel"
+- "Summarize this source"
+
+V1 can deep-link or prefill existing chat context if full contextual chat wiring is too large.
+
+## Persistence decision
+
+Do not prematurely commit to final persistence in the first UI scaffold.
+
+Recommended order:
+
+1. In-memory fixture store for first UI implementation.
+2. Local JSON or SwiftData-backed store once interactions settle.
+3. Evaluate whether canonical LifeOps state belongs in a new Hermes LifeOps SQLite DB, `kanban.db`, or app SwiftData synced through companion/CloudKit.
+
+Rationale: LifeOps has more privacy and sync implications than coding tasks. The first implementation should prove data shape and UX before locking the backend.
+
+## Accessibility and ADHD design constraints
+
+- Keep Now list to 1-3 items.
+- Use clear P0/P1/P2/P3 labels.
+- Show next action on every task row.
+- Support snooze without guilt language.
+- Avoid red-heavy UI except true P0.
+- Always show source/origin when available.
+- Make family-originated items obvious.
+- Make approval actions visually distinct from normal tasks.
+
+## Error handling
+
+- Failed ingestion should not clear existing tasks.
+- Failed Daneel action should create a visible blocked/error state.
+- Failed calendar/message integration should produce an approval/action error rather than silently disappearing.
+- Low-confidence task extraction should go to Inbox, not Today.
+
+## Testing strategy
+
+### Model tests
+
+- Codable round trips for LifeTask, ApprovalAction, JobOpportunity, FamilyRequest.
+- Priority/status/category display metadata.
+
+### Store tests
+
+- Now limits to top 3 unsnoozed P0/P1 items.
+- Today excludes snoozed/done/cancelled tasks.
+- Family section includes Sarah-originated family tasks.
+- Approvals filters pending approval actions.
+- Job follow-ups due today surface in Today.
+
+### UI/semantics tests
+
+- macOS LifeOps destination exists.
+- iOS LifeOps tab/section exists.
+- Quick capture field/button exists.
+- Now/Today/Approvals/Family sections expose accessibility identifiers.
+
+## Codex implementation guidance
+
+First Codex task should build the LifeOps scaffold only:
+
+- Models
+- Fixture store
+- Shared UI screens/components
+- macOS sidebar destination
+- iOS tab/section
+- Tests
+
+Do not implement real email/calendar/iMessage automation in the first pass. Real integrations should follow after the UI/data model is visible and Blake can react to it.


### PR DESCRIPTION
## Summary
- Adds LifeOps executive-assistant planning docs, ADR-014, and AgentBoard implementation scaffold.
- Adds shared LifeOps models, fixtures, and `LifeOpsStore` for ADHD-oriented task views, approvals, job-search follow-ups, and Sarah/family request support.
- Adds shared SwiftUI LifeOps UI plus macOS sidebar and iOS tab integration.
- Adds model/store/interface tests.

## Scope boundaries
- Fixture-backed scaffold only.
- No live email/calendar/iMessage automation yet.
- No external side effects or real message/calendar writes.

## Quality gates
- ✅ `swiftlint lint --strict`
- ✅ `swiftformat --lint --config .swiftformat AgentBoard AgentBoardTests`
- ✅ `xcodebuild test -scheme AgentBoard -destination 'platform=macOS'`
- ✅ `xcodebuild -scheme AgentBoardMobile -destination 'generic/platform=iOS Simulator' build`

Closes #136.
