### PR TITLE
fix: Phase 0 stabilization (gh path, crash-free bootstrap, doc drift)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ The active product is the Hermes-first SwiftUI rebuild.
 
 ### Source of truth split
 
-- **Hermes gateway** powers chat (WebSocket JSON-RPC protocol)
+- **Hermes gateway** powers chat (HTTP + SSE, OpenAI-compatible `/v1/chat/completions`)
 - **`~/.hermes/kanban.db`** is the task/work-tracking backend — all Kanban data lives here
 - **AgentBoard companion** monitors live tmux sessions and agent health (process discovery + tmux pane capture)
 - **GitHub Issues** are the external work-tracking source, consumed by Hermes agents

--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		AC9718464408D550B64EFB4E /* ConfigBackupServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15329720160FF009D5B1535 /* ConfigBackupServiceTests.swift */; };
 		B01C8989FACCB9D76DD46CDF /* ChatStoreSlashCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0551DF2CA889DD84A9EFF3B7 /* ChatStoreSlashCommandTests.swift */; };
 		B05AB72D9955BEF4CD1E3B7A /* KanbanModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A55930915B4E8B29ECFC5DD /* KanbanModels.swift */; };
+		B13E9A7DA4903C65AE1FEEC6 /* NoopAgentBoardCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B023A92D06AE2F3272FC200 /* NoopAgentBoardCacheTests.swift */; };
 		B32E7225FAA8967B580A58A1 /* CreateIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 702A0D71A27F07711AF96C4A /* CreateIssueSheet.swift */; };
 		B51F9A6B9302EDD7F2EB1437 /* BoardChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D736CF52ACD4E2BD9D3ADC /* BoardChrome.swift */; };
 		B87AB9550FF94448824BFFB2 /* ChatHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82BF95164B1DFE66D15CB770 /* ChatHeader.swift */; };
@@ -138,6 +139,7 @@
 		DC38BD815D6E073F6D62E1D7 /* NeumorphicTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4BD1071B801A6A1C9E1CEF /* NeumorphicTheme.swift */; };
 		DD6C36042860EA2D423261EE /* SessionDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05A145F7A1A70B53DF066DBD /* SessionDetailSheet.swift */; };
 		DE5629641FE81BB20A7186A9 /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A2BE598EEDA7A998AEA8DE /* MarkdownText.swift */; };
+		DF0EA5DC994F51BF546BA378 /* NoopAgentBoardCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6350F1AD876CFC0042771A6F /* NoopAgentBoardCache.swift */; };
 		E069DEDCB71500BCB3DA43A4 /* FoundationExtrasTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B9B576059ADDC3B5D219868 /* FoundationExtrasTests.swift */; };
 		E1025BED622BADB001F95D4D /* CompanionSQLiteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06C0FE6A5C6D69E553E904D0 /* CompanionSQLiteStore.swift */; };
 		E1F05B25E20BE9959941A7A9 /* AttachmentViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2941E5B6C18CF76C4621BB /* AttachmentViews.swift */; };
@@ -255,6 +257,7 @@
 		08C9688956A467F60F3B9B34 /* KanbanDataReading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanDataReading.swift; sourceTree = "<group>"; };
 		08FC87E1E7EE82E2FE4C749F /* ChatEndpointValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatEndpointValidatorTests.swift; sourceTree = "<group>"; };
 		0A55930915B4E8B29ECFC5DD /* KanbanModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanModels.swift; sourceTree = "<group>"; };
+		0B023A92D06AE2F3272FC200 /* NoopAgentBoardCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoopAgentBoardCacheTests.swift; sourceTree = "<group>"; };
 		0B7442B7AA1CFE33776582C1 /* AgentBoardMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBoardMobileApp.swift; sourceTree = "<group>"; };
 		0D0FBEDFA7766F71A98B48E3 /* SlashCommandHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandHandler.swift; sourceTree = "<group>"; };
 		132785F0427381E3DB05BD8E /* ChatEndpointValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatEndpointValidator.swift; sourceTree = "<group>"; };
@@ -289,6 +292,7 @@
 		54CA712A46E969ED79300E4F /* LinkPreviewService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkPreviewService.swift; sourceTree = "<group>"; };
 		5F60733BA5BCAD5BD388E855 /* AgentBoardMobile.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AgentBoardMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		63376B7513D3E5CFE45372D6 /* BoardPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardPalette.swift; sourceTree = "<group>"; };
+		6350F1AD876CFC0042771A6F /* NoopAgentBoardCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoopAgentBoardCache.swift; sourceTree = "<group>"; };
 		651B64AF0921713BAE550D2D /* TaskDetailSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailSheet.swift; sourceTree = "<group>"; };
 		6A0D9C21BA312AB952D0E48B /* KanbanAssigneePickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanAssigneePickerTests.swift; sourceTree = "<group>"; };
 		6C0ED2A504BC7E3CA18E4094 /* GitHubWorkServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubWorkServiceTests.swift; sourceTree = "<group>"; };
@@ -435,6 +439,7 @@
 				8562113DB3BC11316C4B4A50 /* LabelSchemaTests.swift */,
 				957114148477B05585A13D7C /* MockURLProtocol.swift */,
 				BB5CC5206E88A59FBD80A856 /* NativeSwiftUIInterfaceTests.swift */,
+				0B023A92D06AE2F3272FC200 /* NoopAgentBoardCacheTests.swift */,
 				9503F3F8C1E54BE6D35A3641 /* PRDComposerTests.swift */,
 				CE1B1DC901AD1D60B3855D38 /* SessionLauncherTests.swift */,
 				92E0CE9F3A8E9CA87A6C3B95 /* SessionsStoreTests.swift */,
@@ -585,6 +590,7 @@
 			children = (
 				3024AF0B4A66DE64BDB27E15 /* AgentBoardCache.swift */,
 				D3A2A89ABC8C35C2FB32C909 /* AgentBoardCacheProtocol.swift */,
+				6350F1AD876CFC0042771A6F /* NoopAgentBoardCache.swift */,
 				A55C723CBBB22E568A7E3D63 /* SettingsRepository.swift */,
 			);
 			path = Persistence;
@@ -967,6 +973,7 @@
 				E9D09CAC0D952EE1295DFA60 /* LabelSchemaTests.swift in Sources */,
 				38E1089316EEC57E444A6FB1 /* MockURLProtocol.swift in Sources */,
 				9781E0240F8A4C6FC3DC30B7 /* NativeSwiftUIInterfaceTests.swift in Sources */,
+				B13E9A7DA4903C65AE1FEEC6 /* NoopAgentBoardCacheTests.swift in Sources */,
 				DAB3EA4A5AF33E4165CD6551 /* PRDComposerTests.swift in Sources */,
 				9A90C5EF45CA6630C7EA64CD /* SessionLauncherTests.swift in Sources */,
 				F18232EF1BD587C14FCCD06F /* SessionsStoreTests.swift in Sources */,
@@ -1009,6 +1016,7 @@
 				B05AB72D9955BEF4CD1E3B7A /* KanbanModels.swift in Sources */,
 				CB10A2005C3CAEE8253B7324 /* LabelSchema.swift in Sources */,
 				BCE6371A2B658B37FE0C3124 /* LinkPreviewService.swift in Sources */,
+				DF0EA5DC994F51BF546BA378 /* NoopAgentBoardCache.swift in Sources */,
 				A86A0A76B46CE6265194C0A6 /* PRDComposer.swift in Sources */,
 				D806724D20A2D1EC0A81416B /* ProcessAsync.swift in Sources */,
 				9EAAAF4FFBF10F8A576AF5BD /* SessionLauncher.swift in Sources */,

--- a/AgentBoardCore/Persistence/AgentBoardCacheProtocol.swift
+++ b/AgentBoardCore/Persistence/AgentBoardCacheProtocol.swift
@@ -5,7 +5,7 @@ import Foundation
 /// in without a real `ModelContainer`. The concrete `AgentBoardCache` conforms
 /// to it via an extension in AgentBoardCache.swift.
 @MainActor
-public protocol AgentBoardCacheProtocol: Sendable {
+public protocol AgentBoardCacheProtocol: SessionsCacheStoring, Sendable {
     // MARK: - Conversations (ChatStore)
 
     func loadConversations() throws -> [ChatConversation]
@@ -23,8 +23,7 @@ public protocol AgentBoardCacheProtocol: Sendable {
 
     // MARK: - Sessions + agent summaries (SessionsStore / AgentsStore)
 
-    func loadSessions() throws -> [AgentSession]
-    func replaceSessions(_ sessions: [AgentSession]) throws
+    // loadSessions/replaceSessions are inherited from SessionsCacheStoring.
     func loadAgentSummaries() throws -> [AgentSummary]
     func replaceAgentSummaries(_ agents: [AgentSummary]) throws
 }

--- a/AgentBoardCore/Persistence/NoopAgentBoardCache.swift
+++ b/AgentBoardCore/Persistence/NoopAgentBoardCache.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Cache-less fallback used when SwiftData container creation fails even
+/// in-memory. Reads return nothing; writes are dropped. Keeps the app
+/// launchable instead of crashing in AgentBoardBootstrap.
+@MainActor
+public final class NoopAgentBoardCache: AgentBoardCacheProtocol {
+    public init() {}
+
+    public func loadConversations() throws -> [ChatConversation] {
+        []
+    }
+
+    public func loadMessages(conversationID _: UUID) throws -> [ConversationMessage] {
+        []
+    }
+
+    public func saveConversationSnapshot(
+        conversation _: ChatConversation,
+        messages _: [ConversationMessage]
+    ) throws {}
+    public func deleteConversation(id _: UUID) throws {}
+
+    public func loadWorkItems() throws -> [WorkItem] {
+        []
+    }
+
+    public func replaceWorkItems(_: [WorkItem]) throws {}
+
+    public func loadSessions() throws -> [AgentSession] {
+        []
+    }
+
+    public func replaceSessions(_: [AgentSession]) throws {}
+    public func loadAgentSummaries() throws -> [AgentSummary] {
+        []
+    }
+
+    public func replaceAgentSummaries(_: [AgentSummary]) throws {}
+}

--- a/AgentBoardCore/Services/GitHubWorkService.swift
+++ b/AgentBoardCore/Services/GitHubWorkService.swift
@@ -293,13 +293,21 @@ public actor GitHubWorkService: GitHubWorkServicing {
     }
 
     #if os(macOS)
+        /// Probe known Homebrew locations for `gh`; mirrors KanbanCLIWriter.resolveHermes().
+        public static func resolvedGHPath(
+            isExecutable: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) }
+        ) -> String {
+            let candidates = ["/opt/homebrew/bin/gh", "/usr/local/bin/gh"]
+            return candidates.first(where: isExecutable) ?? "gh"
+        }
+
         private func fetchIssuesViaCLI(
             for repository: ConfiguredRepository
         ) async throws -> [WorkItem] {
             let result: ProcessResult
             do {
                 result = try await Process.runAsync(
-                    executablePath: "/usr/local/bin/gh",
+                    executablePath: Self.resolvedGHPath(),
                     arguments: [
                         "api", "repos/\(repository.owner)/\(repository.name)/issues",
                         "-f", "state=all",

--- a/AgentBoardCore/Stores/AgentBoardAppModel.swift
+++ b/AgentBoardCore/Stores/AgentBoardAppModel.swift
@@ -164,7 +164,7 @@ public final class AgentBoardAppModel {
 @MainActor
 public enum AgentBoardBootstrap {
     public static func makeLiveAppModel() -> AgentBoardAppModel {
-        let cache: AgentBoardCache
+        let cache: AgentBoardCacheProtocol
 
         do {
             cache = try AgentBoardCache()
@@ -172,7 +172,9 @@ public enum AgentBoardBootstrap {
             do {
                 cache = try AgentBoardCache(inMemory: true)
             } catch {
-                fatalError("Unable to create AgentBoard cache: \(error.localizedDescription)")
+                Logger(subsystem: "com.agentboard.modern", category: "AgentBoardBootstrap")
+                    .fault("Cache unavailable, running cache-less: \(error.localizedDescription)")
+                cache = NoopAgentBoardCache()
             }
         }
 

--- a/AgentBoardCore/Stores/AgentBoardAppModel.swift
+++ b/AgentBoardCore/Stores/AgentBoardAppModel.swift
@@ -164,7 +164,7 @@ public final class AgentBoardAppModel {
 @MainActor
 public enum AgentBoardBootstrap {
     public static func makeLiveAppModel() -> AgentBoardAppModel {
-        let cache: AgentBoardCacheProtocol
+        let cache: any AgentBoardCacheProtocol
 
         do {
             cache = try AgentBoardCache()

--- a/AgentBoardTests/GitHubWorkServiceTests.swift
+++ b/AgentBoardTests/GitHubWorkServiceTests.swift
@@ -143,6 +143,26 @@ struct GitHubWorkServiceTests {
         #expect(item.issueNumber == 22)
     }
 
+    #if os(macOS)
+        @Test
+        func resolvedGHPathPrefersHomebrewARM() {
+            let path = GitHubWorkService.resolvedGHPath { $0 == "/opt/homebrew/bin/gh" }
+            #expect(path == "/opt/homebrew/bin/gh")
+        }
+
+        @Test
+        func resolvedGHPathFallsBackToIntelHomebrew() {
+            let path = GitHubWorkService.resolvedGHPath { $0 == "/usr/local/bin/gh" }
+            #expect(path == "/usr/local/bin/gh")
+        }
+
+        @Test
+        func resolvedGHPathFallsBackToBareNameWhenAbsent() {
+            let path = GitHubWorkService.resolvedGHPath { _ in false }
+            #expect(path == "gh")
+        }
+    #endif
+
     private func issueJSON(number: Int) -> String {
         """
         {

--- a/AgentBoardTests/NoopAgentBoardCacheTests.swift
+++ b/AgentBoardTests/NoopAgentBoardCacheTests.swift
@@ -1,0 +1,22 @@
+@testable import AgentBoardCore
+import Foundation
+import Testing
+
+@MainActor
+struct NoopAgentBoardCacheTests {
+    @Test
+    func allReadsReturnEmptyAndWritesDoNotThrow() throws {
+        let cache = NoopAgentBoardCache()
+
+        #expect(try cache.loadConversations().isEmpty)
+        #expect(try cache.loadMessages(conversationID: UUID()).isEmpty)
+        #expect(try cache.loadWorkItems().isEmpty)
+        #expect(try cache.loadSessions().isEmpty)
+        #expect(try cache.loadAgentSummaries().isEmpty)
+
+        try cache.replaceWorkItems([])
+        try cache.replaceSessions([])
+        try cache.replaceAgentSummaries([])
+        try cache.deleteConversation(id: UUID())
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The old OpenClaw/beads/macOS-only prototype has been retired from the codebase. 
 
 ## Product shape
 
-- **Hermes gateway** powers chat (WebSocket JSON-RPC) and is the write authority for kanban tasks via the `hermes kanban` CLI.
+- **Hermes gateway** powers chat (HTTP + SSE streaming via an OpenAI-compatible `/v1/chat/completions` endpoint) and is the write authority for kanban tasks via the `hermes kanban` CLI.
 - **`~/.hermes/kanban.db`** is the source of truth for the Kanban board — tasks, comments, and runs all live here.
 - **GitHub Issues** are tracked as work items for issue triage and reference.
 - **AgentBoardCompanion** owns agent session monitoring (tmux/process discovery) and live execution state.
@@ -106,7 +106,7 @@ flowchart TD
     Mac --> UI
     Mobile --> UI
     UI --> Core
-    Core -->|chat WebSocket| Hermes
+    Core -->|chat HTTP/SSE| Hermes
     Core -->|read SQLite| KanbanDB
     Core -->|write via CLI| Hermes
     Core -->|work items| GitHub

--- a/docs/superpowers/plans/2026-07-16-phase0-stabilization.md
+++ b/docs/superpowers/plans/2026-07-16-phase0-stabilization.md
@@ -1,0 +1,301 @@
+# Phase 0 — Stabilization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove AgentBoard's known instability — Apple-silicon-broken `gh` fallback, bootstrap crash path, and stale transport docs — before feature work begins.
+
+**Architecture:** Three surgical fixes with no new subsystems: an executable-path probe for the `gh` CLI (mirroring the existing `resolveHermes()` pattern in `KanbanCLIWriter`), a no-op `AgentBoardCacheProtocol` conformance that replaces the bootstrap `fatalError`, and doc corrections. Spec: `docs/superpowers/specs/2026-07-16-feature-complete-stability-design.md` (Phase 0).
+
+**Tech Stack:** Swift 6, SwiftUI, SwiftData, XCTest/Swift Testing, xcodegen, SwiftLint.
+
+## Global Constraints
+
+- Swift 6 strict concurrency; all stores are `@MainActor @Observable`.
+- No `ObservableObject`/`@Published`/`CoreData`/`@StateObject`/`DispatchQueue` (repo standard).
+- TDD: write the failing test before the implementation.
+- Every PR must build all three schemes (AgentBoard, AgentBoardMobile, AgentBoardCompanion) and pass SwiftLint strict.
+- Unit tests run on the mac-mini node: `ssh mac-mini "cd ~/Projects/AgentBoard && xcodebuild test -scheme AgentBoard -configuration Debug -destination 'platform=macOS' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -parallel-testing-enabled NO -only-testing:AgentBoardTests"` (pull the branch on mac-mini first).
+- New files must be picked up by xcodegen: run `xcodegen generate` after adding files.
+
+---
+
+### Task 1: `gh` executable resolution in GitHubWorkService
+
+The CLI fallback hard-codes `/usr/local/bin/gh` (`GitHubWorkService.swift:302`), which does not exist on Apple-silicon Homebrew installs (`/opt/homebrew/bin/gh`).
+
+**Files:**
+- Modify: `AgentBoardCore/Services/GitHubWorkService.swift` (around line 295–320, `fetchIssuesViaCLI`)
+- Test: `AgentBoardTests/GitHubWorkServiceTests.swift` (existing file — append)
+
+**Interfaces:**
+- Produces: `static func GitHubWorkService.resolvedGHPath(isExecutable: (String) -> Bool) -> String` — probes `/opt/homebrew/bin/gh` then `/usr/local/bin/gh`, returns `"gh"` if neither exists (matches `KanbanCLIWriter.resolveHermes()` fallback convention).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `AgentBoardTests/GitHubWorkServiceTests.swift` (match the file's existing XCTest or Swift Testing style — shown here as XCTest; convert to `@Test` if the file uses Swift Testing):
+
+```swift
+func testResolvedGHPathPrefersHomebrewARM() {
+    let path = GitHubWorkService.resolvedGHPath { $0 == "/opt/homebrew/bin/gh" }
+    XCTAssertEqual(path, "/opt/homebrew/bin/gh")
+}
+
+func testResolvedGHPathFallsBackToIntelHomebrew() {
+    let path = GitHubWorkService.resolvedGHPath { $0 == "/usr/local/bin/gh" }
+    XCTAssertEqual(path, "/usr/local/bin/gh")
+}
+
+func testResolvedGHPathFallsBackToBareNameWhenAbsent() {
+    let path = GitHubWorkService.resolvedGHPath { _ in false }
+    XCTAssertEqual(path, "gh")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run (on mac-mini or locally as fallback): the Global Constraints test command with `-only-testing:AgentBoardTests/GitHubWorkServiceTests`.
+Expected: FAIL — `type 'GitHubWorkService' has no member 'resolvedGHPath'` (compile error counts as the failing state).
+
+- [ ] **Step 3: Implement the resolver and use it**
+
+In `AgentBoardCore/Services/GitHubWorkService.swift`, inside the `#if os(macOS)` block (near `fetchIssuesViaCLI`) add:
+
+```swift
+/// Probe known Homebrew locations for `gh`; mirror KanbanCLIWriter.resolveHermes().
+static func resolvedGHPath(
+    isExecutable: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) }
+) -> String {
+    let candidates = ["/opt/homebrew/bin/gh", "/usr/local/bin/gh"]
+    return candidates.first(where: isExecutable) ?? "gh"
+}
+```
+
+Then in `fetchIssuesViaCLI`, replace:
+
+```swift
+result = try await Process.runAsync(
+    executablePath: "/usr/local/bin/gh",
+```
+
+with:
+
+```swift
+result = try await Process.runAsync(
+    executablePath: Self.resolvedGHPath(),
+```
+
+(If other call sites in the file use the hard-coded path — check with `grep -n '/usr/local/bin/gh' AgentBoardCore/Services/GitHubWorkService.swift` — replace them the same way.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Same command as Step 2. Expected: PASS (3 new tests green, no regressions in the class).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add AgentBoardCore/Services/GitHubWorkService.swift AgentBoardTests/GitHubWorkServiceTests.swift
+git commit -m "fix: resolve gh CLI path for Apple-silicon Homebrew"
+```
+
+---
+
+### Task 2: Replace bootstrap `fatalError` with a no-op cache
+
+`AgentBoardBootstrap.makeLiveAppModel()` crashes if both on-disk and in-memory SwiftData containers fail (`AgentBoardAppModel.swift:175`). Degrade to cache-less mode instead.
+
+**Files:**
+- Create: `AgentBoardCore/Persistence/NoopAgentBoardCache.swift`
+- Modify: `AgentBoardCore/Stores/AgentBoardAppModel.swift` (the `AgentBoardBootstrap.makeLiveAppModel()` `do/catch`, ~lines 166–178)
+- Test: `AgentBoardTests/NoopAgentBoardCacheTests.swift` (new)
+
+**Interfaces:**
+- Consumes: `AgentBoardCacheProtocol` (`AgentBoardCore/Persistence/AgentBoardCacheProtocol.swift:8`) — all four stores already accept this protocol.
+- Produces: `@MainActor final class NoopAgentBoardCache: AgentBoardCacheProtocol` — every `load*` returns `[]`, every write is a silent no-op, nothing throws.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `AgentBoardTests/NoopAgentBoardCacheTests.swift`:
+
+```swift
+import XCTest
+@testable import AgentBoardCore
+
+@MainActor
+final class NoopAgentBoardCacheTests: XCTestCase {
+    func testAllReadsReturnEmptyAndWritesDoNotThrow() throws {
+        let cache = NoopAgentBoardCache()
+
+        XCTAssertTrue(try cache.loadConversations().isEmpty)
+        XCTAssertTrue(try cache.loadMessages(conversationID: UUID()).isEmpty)
+        XCTAssertTrue(try cache.loadWorkItems().isEmpty)
+        XCTAssertTrue(try cache.loadSessions().isEmpty)
+        XCTAssertTrue(try cache.loadAgentSummaries().isEmpty)
+
+        XCTAssertNoThrow(try cache.replaceWorkItems([]))
+        XCTAssertNoThrow(try cache.replaceSessions([]))
+        XCTAssertNoThrow(try cache.replaceAgentSummaries([]))
+        XCTAssertNoThrow(try cache.deleteConversation(id: UUID()))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Global Constraints test command with `-only-testing:AgentBoardTests/NoopAgentBoardCacheTests`.
+Expected: FAIL — `cannot find 'NoopAgentBoardCache' in scope`.
+
+- [ ] **Step 3: Implement NoopAgentBoardCache**
+
+Create `AgentBoardCore/Persistence/NoopAgentBoardCache.swift`:
+
+```swift
+import Foundation
+
+/// Cache-less fallback used when SwiftData container creation fails even
+/// in-memory. Reads return nothing; writes are dropped. Keeps the app
+/// launchable instead of crashing in AgentBoardBootstrap.
+@MainActor
+public final class NoopAgentBoardCache: AgentBoardCacheProtocol {
+    public init() {}
+
+    public func loadConversations() throws -> [ChatConversation] { [] }
+    public func loadMessages(conversationID: UUID) throws -> [ConversationMessage] { [] }
+    public func saveConversationSnapshot(
+        conversation: ChatConversation,
+        messages: [ConversationMessage]
+    ) throws {}
+    public func deleteConversation(id: UUID) throws {}
+
+    public func loadWorkItems() throws -> [WorkItem] { [] }
+    public func replaceWorkItems(_ items: [WorkItem]) throws {}
+
+    public func loadSessions() throws -> [AgentSession] { [] }
+    public func replaceSessions(_ sessions: [AgentSession]) throws {}
+    public func loadAgentSummaries() throws -> [AgentSummary] { [] }
+    public func replaceAgentSummaries(_ agents: [AgentSummary]) throws {}
+}
+```
+
+Run `xcodegen generate` so the new file joins the targets.
+
+- [ ] **Step 4: Wire it into the bootstrap**
+
+In `AgentBoardCore/Stores/AgentBoardAppModel.swift`, `AgentBoardBootstrap.makeLiveAppModel()`, replace:
+
+```swift
+let cache: AgentBoardCache
+
+do {
+    cache = try AgentBoardCache()
+} catch {
+    do {
+        cache = try AgentBoardCache(inMemory: true)
+    } catch {
+        fatalError("Unable to create AgentBoard cache: \(error.localizedDescription)")
+    }
+}
+```
+
+with:
+
+```swift
+let cache: AgentBoardCacheProtocol
+
+do {
+    cache = try AgentBoardCache()
+} catch {
+    do {
+        cache = try AgentBoardCache(inMemory: true)
+    } catch {
+        Logger(subsystem: "com.agentboard", category: "bootstrap")
+            .fault("Cache unavailable, running cache-less: \(error.localizedDescription)")
+        cache = NoopAgentBoardCache()
+    }
+}
+```
+
+Add `import OSLog` at the top of the file if not present. If any downstream `makeLiveAppModel` code requires the concrete `AgentBoardCache` type, the compiler will flag it — those sites should accept the protocol (they already do per the issue #108 DI cleanup).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Global Constraints test command (full `AgentBoardTests`). Expected: PASS, including the new NoopAgentBoardCacheTests and no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add AgentBoardCore/Persistence/NoopAgentBoardCache.swift AgentBoardCore/Stores/AgentBoardAppModel.swift AgentBoardTests/NoopAgentBoardCacheTests.swift AgentBoard.xcodeproj/project.pbxproj
+git commit -m "fix: degrade to cache-less mode instead of fatalError in bootstrap"
+```
+
+---
+
+### Task 3: Fix transport doc drift
+
+Docs claim chat uses "WebSocket JSON-RPC"; the client is HTTP POST `/v1/chat/completions` + SSE streaming (`HermesGatewayClient.swift`).
+
+**Files:**
+- Modify: `README.md:16` and `README.md:109`
+- Modify: `AGENTS.md:67`
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: Edit the three lines**
+
+`README.md:16` — replace:
+> **Hermes gateway** powers chat (WebSocket JSON-RPC) and is the write authority for kanban tasks via the `hermes kanban` CLI.
+
+with:
+> **Hermes gateway** powers chat (HTTP + SSE streaming via an OpenAI-compatible `/v1/chat/completions` endpoint) and is the write authority for kanban tasks via the `hermes kanban` CLI.
+
+`README.md:109` — replace `Core -->|chat WebSocket| Hermes` with `Core -->|chat HTTP/SSE| Hermes`.
+
+`AGENTS.md:67` — replace `- **Hermes gateway** powers chat (WebSocket JSON-RPC protocol)` with `- **Hermes gateway** powers chat (HTTP + SSE, OpenAI-compatible /v1/chat/completions)`.
+
+- [ ] **Step 2: Verify no stale references remain**
+
+Run: `grep -rn "WebSocket\|JSON-RPC" README.md AGENTS.md docs/architecture.md`
+Expected: no chat-transport hits (Companion event-stream mentions, if any, are fine — only Hermes chat claims must change).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md AGENTS.md
+git commit -m "docs: correct Hermes chat transport to HTTP + SSE"
+```
+
+---
+
+### Task 4: Verification gate + PR
+
+**Files:** none new.
+
+- [ ] **Step 1: Build all three schemes**
+
+```bash
+xcodebuild build -scheme AgentBoard -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
+xcodebuild build -scheme AgentBoardMobile -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO
+xcodebuild build -scheme AgentBoardCompanion -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
+```
+Expected: `** BUILD SUCCEEDED **` × 3.
+
+- [ ] **Step 2: SwiftLint strict**
+
+Run: `swiftlint --strict`
+Expected: no output (zero violations).
+
+- [ ] **Step 3: Full unit suite on mac-mini**
+
+Push the branch, then run the Global Constraints test command on mac-mini after `git pull` there. Expected: all ~390 tests pass.
+
+- [ ] **Step 4: Open PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --repo jbcrane13/AgentBoard --title "fix: Phase 0 stabilization (gh path, crash-free bootstrap, doc drift)" --body "Implements Phase 0 of docs/superpowers/specs/2026-07-16-feature-complete-stability-design.md. Closes the Phase 0 tracking issue."
+```
+
+---
+
+## Later Phases
+
+Phases 1–4 (chat completion, agent-kanban parity, 3-column issues board, dashboard) are specced in `docs/superpowers/specs/2026-07-16-feature-complete-stability-design.md` and tracked as GitHub issues. Each gets its own plan document in `docs/superpowers/plans/` when picked up — Phase 1 must start with the two gateway spikes (capability parameters, history endpoint) because their outcomes shape the plan's tasks.

--- a/docs/superpowers/specs/2026-07-16-feature-complete-stability-design.md
+++ b/docs/superpowers/specs/2026-07-16-feature-complete-stability-design.md
@@ -1,0 +1,98 @@
+# AgentBoard Feature-Complete & Stability Design
+
+- **Date:** 2026-07-16
+- **Status:** Approved
+- **Author:** Blake Crane + Claude
+- **Scope:** Bring the four core surfaces (Hermes chat, agent task kanban, GitHub issues board, dashboard) to feature-complete and stabilize the app. The LifeOps executive-assistant module (docs/PRD-lifeops-executive-assistant.md) is explicitly **out of scope** for this effort.
+
+## Goals
+
+1. Rich, feature-complete Hermes chat: block-level markdown, tool-use display, functional slash-command toggles, resolved history story, voice playback.
+2. Agent task kanban at parity with the Work board: drag-and-drop and offline cache.
+3. GitHub issues board simplified to three columns: To Do / In Progress / Resolved.
+4. A new Dashboard home screen summarizing app state, fed by existing stores.
+5. Known instability removed: crash path, hard-coded `gh` path, doc drift.
+
+## Non-Goals
+
+- LifeOps executive-assistant module (dashboard here is app-status only).
+- Changes to the Hermes gateway or Companion service beyond what the app consumes.
+- Reworking the `status:*` GitHub label schema (presentation remap only).
+
+## Current State (verified 2026-07-15)
+
+- **Chat** (`AgentBoardUI/Screens/ChatScreen.swift`, `ChatStore`, `HermesGatewayClient`): SSE streaming works; ~24 slash commands with autocomplete (`SlashCommandHandler`); conversation CRUD works; sync via Companion. Gaps: `MarkdownText` is inline-only + fenced code; no tool-call rendering; toggle commands (`/think`, `/web`, `/code`, `/image`, `/speak`, `/memory`, `/tools`) post a system message but change nothing; `/skills` always passes an empty list; `HermesGatewayClient.loadConversationHistory` is a stub returning `[]`; voice attachments record but don't play back (`VoiceViews.swift:142` TODO).
+- **Agent kanban** (`AgentsScreen`, `AgentsStore`, `KanbanDataService` reading `~/.hermes/kanban.db`, writes via `KanbanCLIWriter`): 6 columns, create/complete/block/comment/reassign work. Gaps: no drag-and-drop; no SwiftData cache (DB reopened every refresh); agent summaries hard-code `activeSessionCount = 0` (`AgentsStore.swift:238`).
+- **GitHub issues board** (`WorkScreen`, `WorkStore`, `GitHubWorkService`): most complete surface — REST API + `gh` CLI fallback, drag-and-drop, create/edit/close. Gaps: 4-column layout (Ready/In Progress/Review/Done) vs. desired 3; `gh` fallback path hard-coded to `/usr/local/bin/gh` (`GitHubWorkService.swift:302`).
+- **Dashboard:** absent.
+- **Stability:** `fatalError` in `AgentBoardBootstrap.makeLiveAppModel()` if SwiftData cache creation fails twice (`AgentBoardAppModel.swift:175`); README/AGENTS claim chat is "WebSocket JSON-RPC" but the client is HTTP POST `/v1/chat/completions` + SSE.
+- **Tests:** ~388 unit tests in `AgentBoardTests`, healthy; no E2E UI smoke coverage.
+
+## Design
+
+Approach: **stabilize first, then vertical slices.** Each phase is an independent, PR-sized slice; every slice is filed as a GitHub issue (`type:` / `priority:` / `status:` labels) before work starts.
+
+### Phase 0 — Stabilization
+
+1. **`gh` path resolution** — replace the hard-coded `/usr/local/bin/gh` with resolution via `/usr/bin/env gh` (inherits PATH), falling back to probing `/opt/homebrew/bin/gh` and `/usr/local/bin/gh`. Unit-test the resolver.
+2. **Remove crash path** — introduce a no-op cache conforming to `AgentBoardCacheProtocol`; `makeLiveAppModel()` degrades to cache-less mode instead of `fatalError` when both on-disk and in-memory SwiftData containers fail. Log the degradation.
+3. **Doc drift** — update `README.md` and `AGENTS.md` transport description to HTTP + SSE (OpenAI-compatible `/v1/chat/completions`).
+4. **Gate** — all three targets build, SwiftLint strict clean, full unit suite green on mac-mini.
+
+### Phase 1 — Chat feature-complete
+
+1. **Block-level markdown.** Add Apple's `swift-markdown` package; new renderer walks the AST and emits SwiftUI blocks: headings, ordered/unordered lists (nested), blockquotes, tables (horizontally scrollable), thematic breaks, paragraphs via `AttributedString` inline styling. Existing fenced-code-block presentation (language label, monospaced, horizontal scroll) is preserved. `MarkdownText` keeps its public interface so `ChatBubble` call sites don't change.
+2. **Tool-use display.** Extend the SSE decoder in `HermesGatewayClient` to decode `delta.tool_calls` (and non-streaming `message.tool_calls`). Add a tool-call part to the chat message model (name, arguments JSON, optional result). `ChatBubble` renders tool calls as collapsible chips: collapsed shows the tool name + status; expanded shows pretty-printed arguments and result. Unknown/partial payloads render degraded, never crash the stream.
+3. **Functional capability toggles.** `ChatStore` holds per-conversation capability flags (think/web/code/image/speak/memory/tools). Toggle commands flip flags and reflect state in `/status`. Flags map to request-body parameters on the gateway call. **Spike first**: probe the running Hermes gateway to confirm which parameters it honors; any unsupported capability falls back to system-prompt injection, clearly labeled in `/status`. Wire `/skills` to real skill discovery if the gateway exposes an endpoint; otherwise keep it listing the local slash-command skill category.
+4. **Remote history resolution.** Spike: does Hermes expose a conversations/history endpoint? If yes, implement `loadConversationHistory` against it and reconcile with Companion sync. If no, formally designate the Companion as the history authority, delete the stub, and document the decision (ADR).
+5. **Voice playback.** Implement the `VoiceViews.swift` TODO with `AVAudioPlayer`: play/pause button and progress indicator on voice attachments, one active playback at a time.
+
+### Phase 2 — Agent task kanban parity
+
+1. **Drag-and-drop.** Mirror the WorkScreen pattern: cards `.draggable(taskID)`, columns `.dropDestination`. Drop triggers optimistic status move → `KanbanCLIWriter` write → revert + error surface on failure. Valid transitions follow the existing `KanbanStatus` semantics (e.g., anything can move to `blocked`/`done`; `archived` stays out of the board).
+2. **SwiftData cache.** Cache kanban tasks through the existing `AgentBoardCacheProtocol` so the board hydrates instantly on launch and renders the last snapshot when `~/.hermes/kanban.db` is unavailable. Refresh replaces the snapshot.
+3. **Real agent activity.** Replace the hard-coded `activeSessionCount = 0` in `AgentsStore.buildAgentSummaries` with live session counts from the Companion sessions feed.
+
+### Phase 3 — GitHub issues board: three columns
+
+1. **Column mapping** (presentation only; `status:*` labels preserved):
+   - **To Do** — open, `status:ready` or no `status:*` label.
+   - **In Progress** — open, `status:in-progress` or `status:review` (`status:blocked` also lands here with a blocked badge on the card).
+   - **Resolved** — closed issues.
+2. **Transitions.** Drag to Resolved → close the issue. Drag out of Resolved → reopen + set the target `status:*` label. Drag between To Do and In Progress → swap labels as today.
+3. **Update** `WorkState` mapping, `WorkStore.updateStatus`, board rendering, and all affected tests.
+
+### Phase 4 — Dashboard home screen
+
+1. **Navigation.** New `.dashboard` case in `AppDestination`; first tab on both macOS (sidebar) and iOS (tab bar).
+2. **Content** — tiles fed entirely by existing stores via a lightweight view model derived from `AgentBoardAppModel` (no new services):
+   - Agent tasks by status + currently running tasks (AgentsStore).
+   - GitHub issue counts per column + recent activity (WorkStore).
+   - Active sessions and companion/gateway health (SessionsStore + health checks).
+   - Recent conversations with jump-to-chat (ChatStore).
+3. **Interaction.** Tapping a tile navigates to its screen. Pull-to-refresh / refresh button triggers the shared refresh loop.
+4. **Implementation notes.** Built with the frontend-design skill; every interactive element gets an `accessibilityIdentifier` per the `{screen}_{element}_{description}` convention (`dashboard_*`).
+
+### Cross-cutting
+
+- **TDD** per repo convention; tests run on mac-mini via SSH; SwiftLint strict; all three targets must build per PR.
+- **Tracking:** one GitHub issue per slice with `type:` / `priority:` / `status:` labels; issues filed before implementation starts.
+- **Rough shape:** ~8 PRs (Phase 0: 1, Phase 1: 3, Phase 2: 1–2, Phase 3: 1, Phase 4: 1–2).
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Hermes gateway may not support capability parameters or a history endpoint | Phase 1 opens with time-boxed spikes; defined fallbacks (system-prompt injection; Companion as history authority) so the phase cannot stall |
+| `swift-markdown` AST rendering edge cases (nested lists, tables) | Snapshot-style unit tests over a corpus of representative markdown; degraded-but-safe rendering for unsupported nodes |
+| Optimistic kanban DnD vs. CLI write failures | Revert-on-failure with visible error toast; unit tests for the revert path |
+| 3-column remap breaks existing label-driven workflows | Labels are never removed/renamed — mapping is read-side + transition-side only |
+
+## Success Criteria
+
+- Chat renders headings, lists, tables, blockquotes, and tool calls; toggles change actual request behavior (or clearly-labeled fallback); voice notes play back; the history stub is gone (implemented or ADR'd away).
+- Agent kanban supports drag-between-columns and renders from cache when the DB is unavailable.
+- Issues board shows exactly To Do / In Progress / Resolved with working drag transitions including close/reopen.
+- Dashboard is the first tab on both platforms and every tile navigates correctly.
+- No `fatalError` in the bootstrap path; `gh` fallback works on Apple-silicon; docs match the code.
+- Full unit suite green on mac-mini; SwiftLint strict clean; all three targets build.


### PR DESCRIPTION
Implements Phase 0 of `docs/superpowers/specs/2026-07-16-feature-complete-stability-design.md` (plan: `docs/superpowers/plans/2026-07-16-phase0-stabilization.md`).

- Resolve `gh` CLI path for Apple-silicon Homebrew (probes /opt/homebrew then /usr/local, mirrors `resolveHermes()`)
- Replace bootstrap `fatalError` with `NoopAgentBoardCache` cache-less fallback; `AgentBoardCacheProtocol` now refines `SessionsCacheStoring`
- Correct README/AGENTS chat transport claims (WebSocket JSON-RPC → HTTP + SSE)

Verification: 392/392 unit tests pass, SwiftLint strict clean, all three schemes build. Tests ran locally (gateway host fallback) because mac-mini was unreachable.

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)