### PR TITLE
feat: block-level markdown rendering in chat (#139)

### DIFF
--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		00D4FD7D1E850E381301E79B /* BoardPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63376B7513D3E5CFE45372D6 /* BoardPalette.swift */; };
 		011B0517E71FDF2B9BB75A97 /* ChatBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFBB71134457F46E6F2B247 /* ChatBubble.swift */; };
 		02A1ED4D473E2364438AEF82 /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = AD7CA2BAC6FD5DFD28FC0BCD /* Nuke */; };
+		03601128965EFC35A0097F79 /* MarkdownBlockParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E8BA0A7421FAF69CBF5AD4F /* MarkdownBlockParser.swift */; };
 		06B09775C2F43ADB9D2A7DDB /* CreateIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 702A0D71A27F07711AF96C4A /* CreateIssueSheet.swift */; };
 		0B3C6DC24A36FE8A19357506 /* KanbanAssigneePickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0D9C21BA312AB952D0E48B /* KanbanAssigneePickerTests.swift */; };
 		0C635EBBEF9AD782093F5594 /* BoardPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63376B7513D3E5CFE45372D6 /* BoardPalette.swift */; };
@@ -88,6 +89,7 @@
 		81CAC6C9E0241A2ADE971ADC /* CompanionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035DCBF4EE40EE6A14CFE890 /* CompanionClient.swift */; };
 		82B58AACCD18C3D73506C751 /* AgentBoardCompanionKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB3E71CE348AC298EB4048DE /* AgentBoardCompanionKit.framework */; };
 		8304F715858D01DEFB812754 /* DesktopSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7D59DE18AF7B3E0D84EF9A /* DesktopSidebar.swift */; };
+		8423C4D50605F7D24E794BE9 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = 7DB9FBE46328DC9BBD5989DF /* Markdown */; };
 		8497E073979589F788921999 /* ChatConversationSyncCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80BC8F409E30E995C8CEA744 /* ChatConversationSyncCoordinator.swift */; };
 		86474D9EDB4C400C89B3F5FF /* QuickLaunchSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FFDF3222AEE5530E6C58DFC /* QuickLaunchSheet.swift */; };
 		87A19AEDBCBE0206D4D71EFE /* DemoFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20006E3DE0937110157F9D1 /* DemoFixtures.swift */; };
@@ -157,6 +159,7 @@
 		F78742DD742A458919E091C0 /* AgentBoardCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		FD03671AAB65C52CE827D3DA /* AgentBoardCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; };
 		FD05A98C162D7CC536D93096 /* AgentBoardApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC92FF930020DC82D470A002 /* AgentBoardApp.swift */; };
+		FD12EEBFD3C62E6F30A61E92 /* MarkdownBlockParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4637D9675B1C126E65C54970 /* MarkdownBlockParserTests.swift */; };
 		FE8D645DBA85A27F0139427B /* AttachmentInteractions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31C11E46072F7E4A9FFADDB /* AttachmentInteractions.swift */; };
 		FF4D3F1289548330CC170576 /* ChatStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F925ACBB136730BD7852D8B /* ChatStoreTests.swift */; };
 /* End PBXBuildFile section */
@@ -286,7 +289,9 @@
 		3E3C09A95E37674D30B6072F /* AttachmentPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentPicker.swift; sourceTree = "<group>"; };
 		3FEBA7BFDBBBF6316B340FAA /* VoiceViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceViews.swift; sourceTree = "<group>"; };
 		4542E208AACDF95595A0B0D4 /* AgentBoardDesignTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBoardDesignTheme.swift; sourceTree = "<group>"; };
+		4637D9675B1C126E65C54970 /* MarkdownBlockParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownBlockParserTests.swift; sourceTree = "<group>"; };
 		4A978B41E9572538A1E74E5C /* EmbeddedTerminalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedTerminalView.swift; sourceTree = "<group>"; };
+		4E8BA0A7421FAF69CBF5AD4F /* MarkdownBlockParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownBlockParser.swift; sourceTree = "<group>"; };
 		4F7D59DE18AF7B3E0D84EF9A /* DesktopSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopSidebar.swift; sourceTree = "<group>"; };
 		52959B32060C120BA1BB1AB7 /* ShellEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvironment.swift; sourceTree = "<group>"; };
 		54CA712A46E969ED79300E4F /* LinkPreviewService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkPreviewService.swift; sourceTree = "<group>"; };
@@ -363,6 +368,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		068A8FD26CED9743FC6E56C7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8423C4D50605F7D24E794BE9 /* Markdown in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		0D326533098B690337045128 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -437,6 +450,7 @@
 				6A0D9C21BA312AB952D0E48B /* KanbanAssigneePickerTests.swift */,
 				AE3F349D2B17FA90738CCDD5 /* KanbanModelsTests.swift */,
 				8562113DB3BC11316C4B4A50 /* LabelSchemaTests.swift */,
+				4637D9675B1C126E65C54970 /* MarkdownBlockParserTests.swift */,
 				957114148477B05585A13D7C /* MockURLProtocol.swift */,
 				BB5CC5206E88A59FBD80A856 /* NativeSwiftUIInterfaceTests.swift */,
 				0B023A92D06AE2F3272FC200 /* NoopAgentBoardCacheTests.swift */,
@@ -537,6 +551,7 @@
 			isa = PBXGroup;
 			children = (
 				7ABBA014D0943EA3DA8EEB96 /* FoundationExtras.swift */,
+				4E8BA0A7421FAF69CBF5AD4F /* MarkdownBlockParser.swift */,
 				D10B0893112C597A1F745A53 /* ProcessAsync.swift */,
 			);
 			path = Support;
@@ -686,6 +701,7 @@
 			buildConfigurationList = 10C8E641A539E5705C444269 /* Build configuration list for PBXNativeTarget "AgentBoardCore" */;
 			buildPhases = (
 				7E5BFA54826936011F573208 /* Sources */,
+				068A8FD26CED9743FC6E56C7 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -693,6 +709,7 @@
 			);
 			name = AgentBoardCore;
 			packageProductDependencies = (
+				7DB9FBE46328DC9BBD5989DF /* Markdown */,
 			);
 			productName = AgentBoardCore;
 			productReference = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */;
@@ -833,6 +850,7 @@
 			packageReferences = (
 				D04429BB4AFEDD9352E7C3BF /* XCRemoteSwiftPackageReference "Nuke" */,
 				8A42E6F6CCF27450821E497E /* XCRemoteSwiftPackageReference "SwiftTerm" */,
+				DD9EEC3698937F6E0D7CDC3B /* XCRemoteSwiftPackageReference "swift-markdown" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 81E8705C0A4C85BE52A078CB /* Products */;
@@ -971,6 +989,7 @@
 				0B3C6DC24A36FE8A19357506 /* KanbanAssigneePickerTests.swift in Sources */,
 				DAAA6677EBC51F4C7796E505 /* KanbanModelsTests.swift in Sources */,
 				E9D09CAC0D952EE1295DFA60 /* LabelSchemaTests.swift in Sources */,
+				FD12EEBFD3C62E6F30A61E92 /* MarkdownBlockParserTests.swift in Sources */,
 				38E1089316EEC57E444A6FB1 /* MockURLProtocol.swift in Sources */,
 				9781E0240F8A4C6FC3DC30B7 /* NativeSwiftUIInterfaceTests.swift in Sources */,
 				B13E9A7DA4903C65AE1FEEC6 /* NoopAgentBoardCacheTests.swift in Sources */,
@@ -1016,6 +1035,7 @@
 				B05AB72D9955BEF4CD1E3B7A /* KanbanModels.swift in Sources */,
 				CB10A2005C3CAEE8253B7324 /* LabelSchema.swift in Sources */,
 				BCE6371A2B658B37FE0C3124 /* LinkPreviewService.swift in Sources */,
+				03601128965EFC35A0097F79 /* MarkdownBlockParser.swift in Sources */,
 				DF0EA5DC994F51BF546BA378 /* NoopAgentBoardCache.swift in Sources */,
 				A86A0A76B46CE6265194C0A6 /* PRDComposer.swift in Sources */,
 				D806724D20A2D1EC0A81416B /* ProcessAsync.swift in Sources */,
@@ -1590,6 +1610,14 @@
 				minimumVersion = 12.0.0;
 			};
 		};
+		DD9EEC3698937F6E0D7CDC3B /* XCRemoteSwiftPackageReference "swift-markdown" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/swiftlang/swift-markdown";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.5.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1597,6 +1625,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D04429BB4AFEDD9352E7C3BF /* XCRemoteSwiftPackageReference "Nuke" */;
 			productName = NukeUI;
+		};
+		7DB9FBE46328DC9BBD5989DF /* Markdown */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DD9EEC3698937F6E0D7CDC3B /* XCRemoteSwiftPackageReference "swift-markdown" */;
+			productName = Markdown;
 		};
 		8E67F37D82C33338077E4371 /* Nuke */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/AgentBoardCore/Support/MarkdownBlockParser.swift
+++ b/AgentBoardCore/Support/MarkdownBlockParser.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Markdown
+
+/// A block-level chunk of a rendered chat message. `MarkdownText` (UI) maps
+/// each case to a SwiftUI view; parsing lives here in Core so it is unit
+/// testable.
+public enum MarkdownBlock: Equatable, Sendable {
+    public struct ListItem: Equatable, Sendable {
+        public let text: AttributedString
+        public let depth: Int
+
+        public init(text: AttributedString, depth: Int) {
+            self.text = text
+            self.depth = depth
+        }
+    }
+
+    case paragraph(AttributedString)
+    case heading(level: Int, text: AttributedString)
+    case code(String, language: String?)
+    case list(items: [ListItem], ordered: Bool)
+    case blockquote([MarkdownBlock])
+    case table(headers: [AttributedString], rows: [[AttributedString]])
+    case thematicBreak
+}
+
+public enum MarkdownBlockParser {
+    public static func parse(_ content: String) -> [MarkdownBlock] {
+        let document = Document(parsing: content)
+        return document.children.flatMap { block(from: $0) }
+    }
+
+    // MARK: - Block mapping
+
+    private static func block(from markup: Markup) -> [MarkdownBlock] {
+        switch markup {
+        case let heading as Heading:
+            return [.heading(level: min(max(heading.level, 1), 6), text: inlineText(of: heading))]
+        case let code as CodeBlock:
+            return [.code(
+                code.code.trimmingCharacters(in: .newlines),
+                language: code.language?.trimmedOrNil
+            )]
+        case let list as UnorderedList:
+            return [.list(items: listItems(of: list, depth: 0), ordered: false)]
+        case let list as OrderedList:
+            return [.list(items: listItems(of: list, depth: 0), ordered: true)]
+        case let quote as BlockQuote:
+            return [.blockquote(quote.children.flatMap { block(from: $0) })]
+        case let table as Markdown.Table:
+            return [tableBlock(from: table)]
+        case is ThematicBreak:
+            return [.thematicBreak]
+        default:
+            // Paragraphs and any unhandled block type degrade to styled prose.
+            let text = inlineText(of: markup)
+            return text.characters.isEmpty ? [] : [.paragraph(text)]
+        }
+    }
+
+    private static func listItems(of list: Markup, depth: Int) -> [MarkdownBlock.ListItem] {
+        list.children.compactMap { $0 as? Markdown.ListItem }.flatMap { item -> [MarkdownBlock.ListItem] in
+            var rows: [MarkdownBlock.ListItem] = []
+            var nested: [MarkdownBlock.ListItem] = []
+            var ownText = AttributedString()
+
+            for child in item.children {
+                switch child {
+                case let sublist as UnorderedList:
+                    nested.append(contentsOf: listItems(of: sublist, depth: depth + 1))
+                case let sublist as OrderedList:
+                    nested.append(contentsOf: listItems(of: sublist, depth: depth + 1))
+                default:
+                    if !ownText.characters.isEmpty {
+                        ownText += AttributedString(" ")
+                    }
+                    ownText += inlineText(of: child)
+                }
+            }
+
+            if !ownText.characters.isEmpty {
+                rows.append(MarkdownBlock.ListItem(text: ownText, depth: depth))
+            }
+            rows.append(contentsOf: nested)
+            return rows
+        }
+    }
+
+    private static func tableBlock(from table: Markdown.Table) -> MarkdownBlock {
+        let headers = table.head.cells.map { inlineText(of: $0) } as [AttributedString]
+        let rows = table.body.rows.map { row in
+            row.cells.map { inlineText(of: $0) } as [AttributedString]
+        } as [[AttributedString]]
+        return .table(headers: headers, rows: rows)
+    }
+
+    // MARK: - Inline styling
+
+    /// Re-serialize a block's inline content to markdown and let Foundation
+    /// apply inline styling (bold/italic/links/inline code). Falls back to
+    /// plain text when Foundation rejects the fragment.
+    private static func inlineText(of markup: Markup) -> AttributedString {
+        let source = inlineMarkdownSource(of: markup)
+        if let attributed = try? AttributedString(
+            markdown: source,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        ) {
+            return attributed
+        }
+        return AttributedString(markup.format().trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    private static func inlineMarkdownSource(of markup: Markup) -> String {
+        // Detach before formatting — format() on an attached node re-applies
+        // ancestor block prefixes (e.g. "> " inside blockquotes).
+        let detached = markup.detachedFromParent
+        if detached is InlineMarkup {
+            return detached.format()
+        }
+        return detached.children
+            .map { $0.detachedFromParent.format() }
+            .joined()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/AgentBoardTests/MarkdownBlockParserTests.swift
+++ b/AgentBoardTests/MarkdownBlockParserTests.swift
@@ -1,0 +1,129 @@
+import AgentBoardCore
+import Foundation
+import Testing
+
+@Suite("Markdown block parser")
+struct MarkdownBlockParserTests {
+    @Test
+    func headingParsesWithLevel() {
+        let blocks = MarkdownBlockParser.parse("# Title")
+        guard case let .heading(level, text) = blocks.first else {
+            Issue.record("Expected heading, got \(blocks)")
+            return
+        }
+        #expect(level == 1)
+        #expect(String(text.characters) == "Title")
+    }
+
+    @Test
+    func paragraphPreservesInlineBold() {
+        let blocks = MarkdownBlockParser.parse("Hello **world**")
+        guard case let .paragraph(text) = blocks.first else {
+            Issue.record("Expected paragraph, got \(blocks)")
+            return
+        }
+        let hasBoldRun = text.runs.contains { run in
+            run.inlinePresentationIntent?.contains(.stronglyEmphasized) == true
+        }
+        #expect(hasBoldRun)
+        #expect(String(text.characters) == "Hello world")
+    }
+
+    @Test
+    func fencedCodeBlockKeepsLanguageAndBody() {
+        let blocks = MarkdownBlockParser.parse("```swift\nlet x = 1\n```")
+        guard case let .code(body, language) = blocks.first else {
+            Issue.record("Expected code block, got \(blocks)")
+            return
+        }
+        #expect(language == "swift")
+        #expect(body == "let x = 1")
+    }
+
+    @Test
+    func unorderedListYieldsItems() {
+        let blocks = MarkdownBlockParser.parse("- alpha\n- beta")
+        guard case let .list(items, ordered) = blocks.first else {
+            Issue.record("Expected list, got \(blocks)")
+            return
+        }
+        #expect(ordered == false)
+        #expect(items.count == 2)
+        #expect(items.allSatisfy { $0.depth == 0 })
+    }
+
+    @Test
+    func orderedListIsOrdered() {
+        let blocks = MarkdownBlockParser.parse("1. first\n2. second")
+        guard case let .list(_, ordered) = blocks.first else {
+            Issue.record("Expected list, got \(blocks)")
+            return
+        }
+        #expect(ordered == true)
+    }
+
+    @Test
+    func nestedListItemCarriesDepth() {
+        let blocks = MarkdownBlockParser.parse("- outer\n  - inner")
+        guard case let .list(items, _) = blocks.first else {
+            Issue.record("Expected list, got \(blocks)")
+            return
+        }
+        #expect(items.contains { $0.depth == 1 })
+    }
+
+    @Test
+    func blockquoteParses() {
+        let blocks = MarkdownBlockParser.parse("> quoted wisdom")
+        guard case let .blockquote(inner) = blocks.first else {
+            Issue.record("Expected blockquote, got \(blocks)")
+            return
+        }
+        guard case let .paragraph(text) = inner.first else {
+            Issue.record("Expected inner paragraph, got \(inner)")
+            return
+        }
+        #expect(String(text.characters) == "quoted wisdom")
+    }
+
+    @Test
+    func pipeTableParsesHeadersAndRows() {
+        let markdown = """
+        | Name | Role |
+        | ---- | ---- |
+        | Ada  | Eng  |
+        """
+        let blocks = MarkdownBlockParser.parse(markdown)
+        guard case let .table(headers, rows) = blocks.first else {
+            Issue.record("Expected table, got \(blocks)")
+            return
+        }
+        #expect(headers.map { String($0.characters) } == ["Name", "Role"])
+        #expect(rows.count == 1)
+        #expect(rows.first?.map { String($0.characters) } == ["Ada", "Eng"])
+    }
+
+    @Test
+    func thematicBreakParses() {
+        let blocks = MarkdownBlockParser.parse("above\n\n---\n\nbelow")
+        #expect(blocks.contains { block in
+            if case .thematicBreak = block { return true }
+            return false
+        })
+    }
+
+    @Test
+    func emptyInputYieldsNoBlocks() {
+        #expect(MarkdownBlockParser.parse("").isEmpty)
+    }
+
+    @Test
+    func mixedDocumentKeepsBlockOrder() {
+        let markdown = "# Head\n\nBody text\n\n```\ncode\n```"
+        let blocks = MarkdownBlockParser.parse(markdown)
+        #expect(blocks.count == 3)
+        if case .heading = blocks[0] {} else { Issue.record("blocks[0] should be heading") }
+        if case .paragraph = blocks[1] {} else { Issue.record("blocks[1] should be paragraph") }
+        if case .code = blocks[2] {} else { Issue.record("blocks[2] should be code") }
+    }
+}

--- a/AgentBoardUI/Components/MarkdownText.swift
+++ b/AgentBoardUI/Components/MarkdownText.swift
@@ -1,3 +1,4 @@
+import AgentBoardCore
 import SwiftUI
 
 struct MarkdownText: View {
@@ -5,102 +6,136 @@ struct MarkdownText: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
-                switch segment {
-                case let .prose(text):
-                    if let attributed = try? AttributedString(
-                        markdown: text,
-                        options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-                    ) {
-                        Text(attributed)
-                            .textSelection(.enabled)
-                            .foregroundStyle(.white)
-                            .fixedSize(horizontal: false, vertical: true)
-                    } else {
-                        Text(text)
-                            .textSelection(.enabled)
-                            .foregroundStyle(.white)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-
-                case let .code(code, language):
-                    VStack(alignment: .leading, spacing: 4) {
-                        if let language, !language.isEmpty {
-                            Text(language.uppercased())
-                                .font(.caption2.weight(.semibold))
-                                .tracking(1.2)
-                                .foregroundStyle(.white.opacity(0.5))
-                        }
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            Text(code)
-                                .font(.system(.footnote, design: .monospaced))
-                                .foregroundStyle(.green)
-                                .textSelection(.enabled)
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 8)
-                        }
-                    }
-                    .background(
-                        RoundedRectangle(cornerRadius: 10, style: .continuous)
-                            .fill(Color.black.opacity(0.32))
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 10, style: .continuous)
-                            .stroke(Color.white.opacity(0.06), lineWidth: 1)
-                    )
-                }
+            ForEach(Array(MarkdownBlockParser.parse(content).enumerated()), id: \.offset) { _, block in
+                MarkdownBlockView(block: block)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
+}
 
-    private enum Segment {
-        case prose(String)
-        case code(String, String?)
+/// Renders one block. A nominal type (not a `@ViewBuilder` function) so
+/// blockquotes can recurse without producing a self-referential opaque type.
+private struct MarkdownBlockView: View {
+    let block: MarkdownBlock
+
+    var body: some View {
+        blockView(block)
     }
 
-    private var segments: [Segment] {
-        var result: [Segment] = []
-        var remaining = content
+    @ViewBuilder
+    private func blockView(_ block: MarkdownBlock) -> some View {
+        switch block {
+        case let .paragraph(text):
+            proseText(text)
 
-        while !remaining.isEmpty {
-            if let fenceRange = remaining.range(of: "```") {
-                let before = String(remaining[remaining.startIndex ..< fenceRange.lowerBound])
-                if !before.isEmpty {
-                    result.append(.prose(before))
-                }
-                remaining = String(remaining[fenceRange.upperBound...])
+        case let .heading(level, text):
+            Text(text)
+                .font(.system(size: max(22 - CGFloat(level) * 2, 13), weight: .bold))
+                .textSelection(.enabled)
+                .foregroundStyle(.white)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, 2)
 
-                let firstLine = remaining.prefix(while: { $0 != "\n" })
-                let language = String(firstLine).trimmingCharacters(in: .whitespaces).isEmpty
-                    ? nil
-                    : String(firstLine).trimmingCharacters(in: .whitespaces)
+        case let .code(code, language):
+            codeBlock(code, language: language)
 
-                if !firstLine.isEmpty {
-                    remaining = String(remaining.dropFirst(firstLine.count))
-                }
-                if remaining.first == "\n" {
-                    remaining = String(remaining.dropFirst())
-                }
-
-                if let closingRange = remaining.range(of: "```") {
-                    let code = String(remaining[remaining.startIndex ..< closingRange.lowerBound])
-                        .trimmingCharacters(in: .newlines)
-                    result.append(.code(code, language))
-                    remaining = String(remaining[closingRange.upperBound...])
-                    if remaining.first == "\n" {
-                        remaining = String(remaining.dropFirst())
+        case let .list(items, ordered):
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Text(ordered && item.depth == 0 ? "\(orderedIndex(items, upTo: index))." : "•")
+                            .font(.callout.monospacedDigit())
+                            .foregroundStyle(.white.opacity(0.55))
+                        proseText(item.text)
                     }
-                } else {
-                    result.append(.code(remaining.trimmingCharacters(in: .newlines), language))
-                    remaining = ""
+                    .padding(.leading, CGFloat(item.depth) * 16)
                 }
-            } else {
-                result.append(.prose(remaining))
-                remaining = ""
+            }
+
+        case let .blockquote(inner):
+            HStack(alignment: .top, spacing: 8) {
+                RoundedRectangle(cornerRadius: 1.5)
+                    .fill(Color.white.opacity(0.35))
+                    .frame(width: 3)
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(Array(inner.enumerated()), id: \.offset) { _, innerBlock in
+                        MarkdownBlockView(block: innerBlock)
+                    }
+                }
+                .opacity(0.8)
+            }
+
+        case let .table(headers, rows):
+            ScrollView(.horizontal, showsIndicators: false) {
+                Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 6) {
+                    GridRow {
+                        ForEach(Array(headers.enumerated()), id: \.offset) { _, header in
+                            Text(header)
+                                .font(.footnote.weight(.semibold))
+                                .foregroundStyle(.white)
+                        }
+                    }
+                    Divider().overlay(Color.white.opacity(0.2))
+                    ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                        GridRow {
+                            ForEach(Array(row.enumerated()), id: \.offset) { _, cell in
+                                Text(cell)
+                                    .font(.footnote)
+                                    .foregroundStyle(.white.opacity(0.9))
+                            }
+                        }
+                    }
+                }
+                .padding(10)
+            }
+            .background(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(Color.black.opacity(0.24))
+            )
+
+        case .thematicBreak:
+            Divider().overlay(Color.white.opacity(0.2))
+        }
+    }
+
+    private func proseText(_ text: AttributedString) -> some View {
+        Text(text)
+            .textSelection(.enabled)
+            .foregroundStyle(.white)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    /// Ordinal for top-level ordered-list rows, skipping nested rows that are
+    /// flattened into the same item array.
+    private func orderedIndex(_ items: [MarkdownBlock.ListItem], upTo index: Int) -> Int {
+        items[...index].filter { $0.depth == 0 }.count
+    }
+
+    private func codeBlock(_ code: String, language: String?) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if let language, !language.isEmpty {
+                Text(language.uppercased())
+                    .font(.caption2.weight(.semibold))
+                    .tracking(1.2)
+                    .foregroundStyle(.white.opacity(0.5))
+            }
+            ScrollView(.horizontal, showsIndicators: false) {
+                Text(code)
+                    .font(.system(.footnote, design: .monospaced))
+                    .foregroundStyle(.green)
+                    .textSelection(.enabled)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
             }
         }
-
-        return result
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.black.opacity(0.32))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(Color.white.opacity(0.06), lineWidth: 1)
+        )
     }
 }

--- a/docs/superpowers/plans/2026-07-17-phase1-chat-completion.md
+++ b/docs/superpowers/plans/2026-07-17-phase1-chat-completion.md
@@ -30,15 +30,15 @@
 ### Task A1: MarkdownBlockParser
 
 **Files:**
-- Create: `AgentBoardUI/Components/MarkdownBlockParser.swift`
-- Modify: `project.yml` (add `swift-markdown` package, AgentBoardUI target dependency)
+- Create: `AgentBoardCore/Support/MarkdownBlockParser.swift` (Core, not UI — the test target imports only AgentBoardCore; UI sources compile into the app targets and are untestable)
+- Modify: `project.yml` (add `swift-markdown` package; dependency on the AgentBoardCore framework target)
 - Test: `AgentBoardTests/MarkdownBlockParserTests.swift` (new)
 
 **Interfaces:**
 - Produces: `enum MarkdownBlock: Equatable { case paragraph(AttributedString); case heading(level: Int, text: AttributedString); case code(String, language: String?); case list(items: [ListItem], ordered: Bool); case blockquote([MarkdownBlock]); case table(headers: [AttributedString], rows: [[AttributedString]]); case thematicBreak }` with `struct ListItem: Equatable { let blocks: [MarkdownBlock]; let depth: Int }`
 - Produces: `enum MarkdownBlockParser { static func parse(_ content: String) -> [MarkdownBlock] }` — walks the `swift-markdown` `Document` AST. Inline styling: re-serialize each block's inline children to markdown (`.format()`) and run through `AttributedString(markdown:options:.inlineOnlyPreservingWhitespace)`, falling back to plain text on parse failure. Unknown block types degrade to `.paragraph`.
 
-- [ ] **A1.1** Add to `project.yml` packages section (create the section if absent, matching how SwiftTerm is declared): `swift-markdown: { url: https://github.com/swiftlang/swift-markdown, from: 0.5.0 }`; add `package: swift-markdown, product: Markdown` to AgentBoardUI target dependencies. Run `xcodegen generate` and confirm `xcodebuild -resolvePackageDependencies` succeeds.
+- [ ] **A1.1** Add to `project.yml` packages section (matching how SwiftTerm is declared): `swift-markdown: { url: https://github.com/swiftlang/swift-markdown, from: 0.5.0 }`; add `package: swift-markdown, product: Markdown` to the AgentBoardCore target dependencies. Run `xcodegen generate` and confirm package resolution succeeds.
 - [ ] **A1.2** Write failing tests covering: `# H1` → `.heading(level:1)`; a paragraph with `**bold**` yields `.paragraph` whose AttributedString contains a bold run; fenced block with language → `.code("…", "swift")`; `- a\n- b` → `.list(ordered: false)` with 2 items; `1. a` → ordered list; nested list item has `depth: 1`; `> quote` → `.blockquote`; a 2×2 pipe table → `.table` with 2 headers + 1 row; `---` → `.thematicBreak`; empty string → `[]`; malformed markdown degrades to paragraphs without crashing.
 - [ ] **A1.3** Run tests → FAIL (type not found).
 - [ ] **A1.4** Implement `MarkdownBlockParser` using `import Markdown`: `Document(parsing: content)` then map `children`: `Heading` → heading (clamp level 1–6), `CodeBlock` → code, `UnorderedList`/`OrderedList` → flatten with recursion carrying depth, `BlockQuote` → recurse children, `Table` → map head/body cells, `ThematicBreak` → thematicBreak, anything else → paragraph via inline re-serialization.

--- a/docs/superpowers/plans/2026-07-17-phase1-chat-completion.md
+++ b/docs/superpowers/plans/2026-07-17-phase1-chat-completion.md
@@ -1,0 +1,183 @@
+# Phase 1 — Chat Feature-Complete Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the Hermes chat surface to feature-complete: block-level markdown, live tool-activity display, functional capability toggles + real `/skills`, Hermes-native remote history, and voice-note playback (issues #139–#142).
+
+**Architecture:** Four PR-sized slices against the real Hermes gateway API (verified 2026-07-17 against gateway v0.18.2 source + live probes):
+- Text streams as OpenAI `chat.completion.chunk` `delta.content`; tool activity arrives as custom SSE events `event: hermes.tool.progress` with `{tool, emoji, label, toolCallId, status: "running"|"completed"}` — NOT `delta.tool_calls`.
+- Remote history exists: `GET /api/sessions`, `GET /api/sessions/{id}/messages`; `X-Hermes-Session-Id` request/response headers bind an app conversation to a server session.
+- `/v1/chat/completions` accepts only `messages`, `stream`, `model` → capability toggles use system-prompt injection (labeled in `/status`).
+- `GET /v1/skills` returns `{"data":[{"name","description","category"}]}`.
+- The live API server listens on **8641** with a required bearer key; the app's hard-coded default of 8642 is stale.
+
+**Tech Stack:** Swift 6, SwiftUI, swift-markdown (new SPM dep, PR A only), AVFoundation (PR D), Swift Testing, xcodegen, SwiftLint.
+
+## Global Constraints
+
+- Swift 6 strict concurrency; stores `@MainActor @Observable`; no ObservableObject/@Published/CoreData/@StateObject/DispatchQueue.
+- TDD; tests in Swift Testing style (`@Test`, `#expect`) matching neighboring files.
+- Every interactive UI element gets `.accessibilityIdentifier("{screen}_{element}_{description}")`.
+- Per PR: all three schemes build, SwiftLint strict clean, full `AgentBoardTests` suite green.
+- Test command (mac-mini preferred; local gateway host is the sanctioned fallback — pass `-derivedDataPath ./DerivedData` locally):
+  `xcodebuild test -scheme AgentBoard -configuration Debug -destination 'platform=macOS' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -parallel-testing-enabled NO -only-testing:AgentBoardTests`
+- Run `xcodegen generate` after adding files. `ConversationMessage`/`ChatConversation` are Codable and cached — new fields must decode as optional/defaulted so old cache rows still load.
+
+---
+
+## PR A — Block-level markdown (#139)
+
+### Task A1: MarkdownBlockParser
+
+**Files:**
+- Create: `AgentBoardUI/Components/MarkdownBlockParser.swift`
+- Modify: `project.yml` (add `swift-markdown` package, AgentBoardUI target dependency)
+- Test: `AgentBoardTests/MarkdownBlockParserTests.swift` (new)
+
+**Interfaces:**
+- Produces: `enum MarkdownBlock: Equatable { case paragraph(AttributedString); case heading(level: Int, text: AttributedString); case code(String, language: String?); case list(items: [ListItem], ordered: Bool); case blockquote([MarkdownBlock]); case table(headers: [AttributedString], rows: [[AttributedString]]); case thematicBreak }` with `struct ListItem: Equatable { let blocks: [MarkdownBlock]; let depth: Int }`
+- Produces: `enum MarkdownBlockParser { static func parse(_ content: String) -> [MarkdownBlock] }` — walks the `swift-markdown` `Document` AST. Inline styling: re-serialize each block's inline children to markdown (`.format()`) and run through `AttributedString(markdown:options:.inlineOnlyPreservingWhitespace)`, falling back to plain text on parse failure. Unknown block types degrade to `.paragraph`.
+
+- [ ] **A1.1** Add to `project.yml` packages section (create the section if absent, matching how SwiftTerm is declared): `swift-markdown: { url: https://github.com/swiftlang/swift-markdown, from: 0.5.0 }`; add `package: swift-markdown, product: Markdown` to AgentBoardUI target dependencies. Run `xcodegen generate` and confirm `xcodebuild -resolvePackageDependencies` succeeds.
+- [ ] **A1.2** Write failing tests covering: `# H1` → `.heading(level:1)`; a paragraph with `**bold**` yields `.paragraph` whose AttributedString contains a bold run; fenced block with language → `.code("…", "swift")`; `- a\n- b` → `.list(ordered: false)` with 2 items; `1. a` → ordered list; nested list item has `depth: 1`; `> quote` → `.blockquote`; a 2×2 pipe table → `.table` with 2 headers + 1 row; `---` → `.thematicBreak`; empty string → `[]`; malformed markdown degrades to paragraphs without crashing.
+- [ ] **A1.3** Run tests → FAIL (type not found).
+- [ ] **A1.4** Implement `MarkdownBlockParser` using `import Markdown`: `Document(parsing: content)` then map `children`: `Heading` → heading (clamp level 1–6), `CodeBlock` → code, `UnorderedList`/`OrderedList` → flatten with recursion carrying depth, `BlockQuote` → recurse children, `Table` → map head/body cells, `ThematicBreak` → thematicBreak, anything else → paragraph via inline re-serialization.
+- [ ] **A1.5** Run tests → PASS. Commit: `feat: add MarkdownBlockParser for block-level chat markdown (#139)`.
+
+### Task A2: Render blocks in MarkdownText
+
+**Files:**
+- Modify: `AgentBoardUI/Components/MarkdownText.swift` (replace the private `segments` fence-splitter with `MarkdownBlockParser.parse`)
+- Test: extend `AgentBoardTests/MarkdownBlockParserTests.swift` only if new parser gaps surface (rendering itself is verified by build + existing DesignSemantics/accessibility tests)
+
+**Interfaces:**
+- Consumes: `MarkdownBlockParser.parse(_:) -> [MarkdownBlock]`
+- Produces: `MarkdownText(content: String)` — public interface unchanged; `ChatBubble` call sites untouched.
+
+- [ ] **A2.1** Rewrite `MarkdownText.body` to `ForEach` over parsed blocks: paragraph → existing `Text(attributed)` styling; heading → `.font(.system(size: 22 - CGFloat(level) * 2, weight: .bold))`; code → the existing code-block view verbatim (language label, monospaced green, horizontal scroll, rounded background); list → rows with bullet/number prefix indented `CGFloat(depth) * 16`; blockquote → leading 3pt accent bar + recursed content at 0.8 opacity; table → `Grid` inside `ScrollView(.horizontal)` with header row bolded and cell dividers; thematicBreak → `Divider().opacity(0.2)`.
+- [ ] **A2.2** All three schemes build; SwiftLint clean; full suite green. Commit: `feat: block-level markdown rendering in chat (#139)`, push branch `feat/issue-139-chat-block-markdown`, open PR (`Closes #139`).
+
+---
+
+## PR B — Tool-activity display (#140)
+
+### Task B1: Stream event type + SSE named-event parsing
+
+**Files:**
+- Modify: `AgentBoardCore/Services/HermesGatewayClient.swift` (`streamReply`, `consumeStream`)
+- Test: `AgentBoardTests/HermesGatewayClientTests.swift` (append; uses existing `MockURLProtocol`)
+
+**Interfaces:**
+- Produces: `public struct HermesToolProgress: Codable, Hashable, Sendable { public let tool: String; public let emoji: String?; public let label: String?; public let toolCallId: String; public let status: String }` (top-level in HermesGatewayClient.swift)
+- Produces: `public enum HermesStreamEvent: Sendable, Hashable { case text(String); case toolProgress(HermesToolProgress) }`
+- Changes: `streamReply(for:) -> AsyncThrowingStream<HermesStreamEvent, Error>` (was `<String, Error>`)
+
+- [ ] **B1.1** Write failing tests: an SSE body containing a `delta.content` chunk, then `event: hermes.tool.progress\ndata: {"tool":"web_search","emoji":"🔍","label":"Searching…","toolCallId":"c1","status":"running"}\n\n`, then a completed event, then `data: [DONE]` yields `[.text("Hello"), .toolProgress(running…), .toolProgress(completed…)]`; a malformed tool-progress `data:` line is skipped without throwing; a stream with no `event:` lines behaves exactly as before (regression: existing streaming tests updated to unwrap `.text`).
+- [ ] **B1.2** Run → FAIL (type mismatch).
+- [ ] **B1.3** Implement: in `consumeStream`, track `var pendingEventName: String?`; a line prefixed `event: ` sets it; a `data: ` line consumes it — when `pendingEventName == "hermes.tool.progress"`, decode `HermesToolProgress` (skip on decode failure) and `continuation.yield(.toolProgress(…))`, else existing OpenAI-chunk path yields `.text(content)`. Reset `pendingEventName` after each `data:` line and on blank lines. `didYieldContent` still tracks text only; tool events alone must not suppress the `emptyAssistantResponse` error.
+- [ ] **B1.4** Run → PASS. Commit: `feat: parse hermes.tool.progress SSE events in gateway client (#140)`.
+
+### Task B2: Thread tool activity into messages and render chips
+
+**Files:**
+- Modify: `AgentBoardCore/Models/DomainModels.swift` (ConversationMessage)
+- Modify: `AgentBoardCore/Stores/ChatStreamCoordinator.swift` (send loop)
+- Modify: `AgentBoardUI/Components/ChatBubble.swift`
+- Test: `AgentBoardTests/DomainModelsTests.swift` + `AgentBoardTests/ChatStoreTests.swift` (append)
+
+**Interfaces:**
+- Produces: `public struct ToolActivity: Codable, Hashable, Sendable, Identifiable { public var id: String  // toolCallId; public var tool: String; public var emoji: String?; public var label: String?; public var isComplete: Bool }`
+- Changes: `ConversationMessage.toolActivities: [ToolActivity]` — new stored property, default `[]`, decoded with `decodeIfPresent` so cached/companion rows without the key still decode (follow the existing backward-compatible decoder pattern in ConversationMessage).
+
+- [ ] **B2.1** Failing tests: `ConversationMessage` JSON without `toolActivities` decodes with `[]`; round-trips with activities; coordinator test (via ChatStore's existing mock plumbing) — a stream of `[.toolProgress(running c1), .text("Hi"), .toolProgress(completed c1)]` leaves the assistant message with `content == "Hi"` and one `ToolActivity(id: "c1", isComplete: true)`.
+- [ ] **B2.2** Run → FAIL.
+- [ ] **B2.3** Implement: model field + decoder; in `ChatStreamCoordinator.send`, switch on the event — `.text` appends to `assistantMessage.content`; `.toolProgress(p)` upserts by `toolCallId` (`status == "completed"` sets `isComplete = true`, completed-without-running is inserted already-complete); both paths call `callbacks.replaceMessages(…)`.
+- [ ] **B2.4** In `ChatBubble` (assistant messages with non-empty `toolActivities`): above the markdown body, a wrapping HStack of chips — emoji (fallback `wrench.and.screwdriver` symbol) + `label ?? tool` in caption font, capsule background; running chips show `ProgressView().controlSize(.mini)`, complete chips a small checkmark at reduced opacity. Chip gets `.accessibilityIdentifier("chat_chip_tool_\(activity.id)")`.
+- [ ] **B2.5** Full suite green; three schemes build. Commit: `feat: live tool-activity chips in chat transcript (#140)`, branch `feat/issue-140-tool-activity`, PR (`Closes #140`).
+
+---
+
+## PR C — Capability toggles + real /skills + correct gateway default (#141)
+
+### Task C1: Per-conversation capability flags with system-prompt injection
+
+**Files:**
+- Create: `AgentBoardCore/Models/ChatCapability.swift`
+- Modify: `AgentBoardCore/Stores/ChatStore.swift` (state), `AgentBoardCore/Stores/ChatStore+SlashCommands.swift` (`handleToggleCommand`, `statusMessageForSlashCommand`), `AgentBoardCore/Stores/ChatStreamCoordinator.swift` (inject synthetic system message), `AgentBoardCore/Services/SlashCommandHandler.swift` (`formatStatus` gains an `activeCapabilities: [String]` parameter)
+- Test: `AgentBoardTests/ChatStoreSlashCommandTests.swift` (append)
+
+**Interfaces:**
+- Produces: `public enum ChatCapability: String, Codable, CaseIterable, Sendable { case thinking, web, code, image, speak }` with `var promptInstruction: String` (e.g. `.thinking` → `"Think step-by-step and show deeper reasoning before answering."`) and `var displayName: String`.
+- Produces: `ChatStore.capabilities(for conversationID: UUID) -> Set<ChatCapability>` and `ChatStore.toggleCapability(_:for:) -> Bool` (returns new state). Storage: in-memory `[UUID: Set<ChatCapability>]`.
+- Changes: `ChatStreamRequest` gains `let capabilities: Set<ChatCapability>`; when non-empty the coordinator prepends one synthetic `ConversationMessage(role: .system, content: "Capability overrides (client-side): " + joined instructions)` to the outbound request messages ONLY (never persisted, never shown).
+
+- [ ] **C1.1** Failing tests: toggling `.thinking` flips state and returns true, toggling again returns false; `/think` command path appends a system message reading `"Thinking mode ON (client-side prompt injection)"` and marks the command handled (returns true — no longer falls through to the agent); `/status` output contains `"Active capabilities: Thinking (prompt-injected)"`; outbound request messages start with the synthetic system message when a capability is on (assert via the ChatStore mock client capture used by existing streaming tests).
+- [ ] **C1.2** Run → FAIL.
+- [ ] **C1.3** Implement. `handleToggleCommand` becomes: map `.toggleThinking → .thinking` etc.; `.showMemory`/`.showTools` keep their current passthrough behavior; toggles now `return true` (handled locally). `/status` labels every active capability `(prompt-injected)` per the spec's honesty requirement.
+- [ ] **C1.4** Run → PASS. Commit: `feat: functional capability toggles via system-prompt injection (#141)`.
+
+### Task C2: Wire /skills to GET /v1/skills
+
+**Files:**
+- Modify: `AgentBoardCore/Services/HermesGatewayClient.swift` (add `fetchSkills`), `AgentBoardCore/Stores/ChatStore+SlashCommands.swift` (`.showSkills`), `AgentBoardCore/Services/SlashCommandHandler.swift` (`formatSkills` takes `[HermesSkill]`)
+- Test: `AgentBoardTests/HermesGatewayClientTests.swift`, `AgentBoardTests/ChatStoreSlashCommandTests.swift`
+
+**Interfaces:**
+- Produces: `public struct HermesSkill: Codable, Hashable, Sendable { public let name: String; public let description: String? }`; `HermesGatewayClient.fetchSkills() async throws -> [HermesSkill]` — GET `v1/skills`, decode `{"data": […]}`, auth + validation identical to `fetchModels()`.
+
+- [ ] **C2.1** Failing tests: `fetchSkills` decodes the live payload shape (fixture with two skills incl. one `"category": null`); `.showSkills` renders fetched names + truncated descriptions and falls back to `"No skills reported by the gateway."` on error/empty.
+- [ ] **C2.2** Run → FAIL. Implement. Run → PASS. Commit: `feat: wire /skills to gateway skills API (#141)`.
+
+### Task C3: Correct the stale gateway default port
+
+**Files:**
+- Modify: `AgentBoardCore/Services/HermesGatewayClient.swift` (three `8642` literals → one `static let defaultBaseURL = "http://127.0.0.1:8641"`), plus any other `8642` hits from `grep -rn "8642" AgentBoardCore AgentBoardUI AgentBoard AgentBoardMobile`
+- Test: `AgentBoardTests/HermesGatewayClientTests.swift`
+
+- [ ] **C3.1** Failing test: `HermesGatewayConfiguration().baseURL == "http://127.0.0.1:8641"`. Implement; existing-user configured URLs in SettingsStore are untouched (default only applies when settings are blank). Update any test fixtures asserting 8642. Run → PASS. Commit: `fix: default Hermes gateway URL to live API server port 8641 (#141)`.
+- [ ] **C3.2** Gate + PR: branch `feat/issue-141-capability-toggles`, PR (`Closes #141`).
+
+---
+
+## PR D — Remote history via Hermes sessions + voice playback (#142)
+
+### Task D1: Bind conversations to Hermes sessions and fetch remote history
+
+**Files:**
+- Modify: `AgentBoardCore/Services/HermesGatewayClient.swift` (session header in/out, `fetchSessionMessages`, delete `loadConversationHistory` stub)
+- Modify: `AgentBoardCore/Models/DomainModels.swift` (`ChatConversation.hermesSessionID: String?`, backward-compatible decode)
+- Modify: `AgentBoardCore/Stores/ChatStreamCoordinator.swift` (pass/capture session id), `AgentBoardCore/Stores/ChatStore.swift` (hydrate empty synced conversations)
+- Modify: `docs/ADR.md` (append entry)
+- Test: `AgentBoardTests/HermesGatewayClientTests.swift`, `AgentBoardTests/DomainModelsTests.swift`, `AgentBoardTests/ChatStoreTests.swift`
+
+**Interfaces:**
+- Changes: `streamReply(for:sessionID:)` — when `sessionID != nil` sets request header `X-Hermes-Session-Id`; server then owns history (body still carries messages; server derives the user message from it). New stream event `case sessionID(String)` emitted once, from the response's `X-Hermes-Session-Id` header, before any text.
+- Produces: `fetchSessionMessages(sessionID: String) async throws -> [ConversationMessage]` — GET `api/sessions/{id}/messages`; map rows (`role`, `content`, `tool_calls`→ignored, `reasoning_content`→ignored) to `ConversationMessage`; non-user/assistant roles skipped.
+- ChatStore: after a stream completes with a new session id, persist it on the conversation (synced to other devices via the existing Companion conversation sync). `selectConversation` on a conversation with `hermesSessionID` set and zero local messages hydrates via `fetchSessionMessages` (best-effort; failures keep local state).
+
+- [ ] **D1.1** ADR: append to `docs/ADR.md` — "Hermes sessions are the remote chat-history authority (`/api/sessions`); the Companion remains the cross-device sync channel for conversation metadata + local snapshots. The `loadConversationHistory` stub is removed." Match the file's existing entry format.
+- [ ] **D1.2** Failing tests: request carries `X-Hermes-Session-Id` when set; `.sessionID` event surfaces the response header; `fetchSessionMessages` maps a two-row fixture (user+assistant) and skips a `tool` row; `ChatConversation` decodes legacy JSON without the field; store test: stream outcome writes `hermesSessionID` onto the conversation.
+- [ ] **D1.3** Run → FAIL. Implement (delete the stub at the old `HermesGatewayClient.swift:119`). Run → PASS. Commit: `feat: Hermes session-backed remote chat history (#142)`.
+
+### Task D2: Voice-note playback
+
+**Files:**
+- Create: `AgentBoardCore/Services/AudioPlaybackService.swift`
+- Modify: `AgentBoardUI/Components/Attachments/VoiceViews.swift` (`VoicePlaybackView`)
+- Test: `AgentBoardTests/AudioPlaybackServiceTests.swift` (new)
+
+**Interfaces:**
+- Produces: `@MainActor @Observable public final class AudioPlaybackService { public private(set) var activeAttachmentID: UUID?; public private(set) var progress: Double; public private(set) var isPlaying: Bool; public func togglePlayback(attachmentID: UUID, url: URL) throws; public func stop() }` — wraps `AVAudioPlayer` + a 0.1s progress `Task`; starting one attachment stops any other; `AVAudioPlayerDelegate` end-of-play resets state. Missing/undecodable file throws `PlaybackError.cannotPlay(String)`; the view surfaces it as a small error label.
+- `VoicePlaybackView` drops its local `isPlaying/progress` `@State` and observes a shared service instance (injected via `@Environment` — register one instance in both app roots); replaces the placeholder `"0:00"` with remaining time from `progress`.
+
+- [ ] **D2.1** Failing tests: playing a generated tiny WAV (write 0.2s of silence via `AVAudioFile` into a temp URL in-test) flips `isPlaying`/`activeAttachmentID`; toggling the same id pauses; a second id steals playback; a bogus URL throws `cannotPlay`.
+- [ ] **D2.2** Run → FAIL. Implement service + view wiring (play `payload.localURL ?? attachment.remoteURL` — remote URLs downloaded to a temp file first via `URLSession.shared.download`). Run → PASS. Commit: `feat: voice-note playback with AVAudioPlayer (#142)`.
+- [ ] **D2.3** Gate + PR: branch `feat/issue-142-history-voice`, PR (`Closes #142`).
+
+---
+
+## Self-review notes
+
+- Spec coverage: 1.1→PR A, 1.2→PR B, 1.3→PR C1/C2, 1.4→PR D1 (spike outcome: endpoint EXISTS, so the implement branch runs; ADR still records the authority split), 1.5→PR D2. Port-default fix folded into PR C as gateway hygiene surfaced by the spike.
+- The `streamReply` element-type change (B1) is source-breaking for `ChatStreamCoordinator` and any test unwrapping plain strings — B1/B2 land in the same PR so the tree never breaks between commits… each commit must still compile: B1's commit includes the mechanical `case .text` adaptation in the coordinator; B2 adds behavior.
+- D1's session header changes outbound semantics only when a session id exists; first-turn behavior is byte-identical to today.

--- a/project.yml
+++ b/project.yml
@@ -15,6 +15,9 @@ packages:
   SwiftTerm:
     url: https://github.com/migueldeicaza/SwiftTerm
     from: 1.10.0
+  swift-markdown:
+    url: https://github.com/swiftlang/swift-markdown
+    from: 0.5.0
 
 settings:
   base:
@@ -36,6 +39,9 @@ targets:
         SWIFT_VERSION: "6.0"
         MACOSX_DEPLOYMENT_TARGET: "26.0"
         IPHONEOS_DEPLOYMENT_TARGET: "26.0"
+    dependencies:
+      - package: swift-markdown
+        product: Markdown
 
   AgentBoardCompanionKit:
     type: framework


### PR DESCRIPTION
Phase 1 PR A of `docs/superpowers/plans/2026-07-17-phase1-chat-completion.md`.

- New `MarkdownBlockParser` (AgentBoardCore) on Apple's swift-markdown AST: headings, nested lists, blockquotes, tables, thematic breaks; degraded-but-safe on unknown nodes
- `MarkdownText` renders blocks (fenced-code treatment unchanged); recursion via nominal `MarkdownBlockView`
- 11 new parser tests; 403/403 suite green; all three schemes build

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)