### PR TITLE
feat: live tool-activity display in chat (#140)

### DIFF
--- a/AgentBoardCore/Models/DomainModels.swift
+++ b/AgentBoardCore/Models/DomainModels.swift
@@ -74,8 +74,8 @@ public struct HermesProfile: Codable, Hashable, Identifiable, Sendable {
 }
 
 public struct ToolActivity: Codable, Hashable, Sendable, Identifiable {
-    public var id: String
-    public var tool: String
+public let id: String
+    public let tool: String
     public var emoji: String?
     public var label: String?
     public var isComplete: Bool

--- a/AgentBoardCore/Models/DomainModels.swift
+++ b/AgentBoardCore/Models/DomainModels.swift
@@ -73,6 +73,22 @@ public struct HermesProfile: Codable, Hashable, Identifiable, Sendable {
     }
 }
 
+public struct ToolActivity: Codable, Hashable, Sendable, Identifiable {
+    public var id: String
+    public var tool: String
+    public var emoji: String?
+    public var label: String?
+    public var isComplete: Bool
+
+    public init(id: String, tool: String, emoji: String?, label: String?, isComplete: Bool) {
+        self.id = id
+        self.tool = tool
+        self.emoji = emoji
+        self.label = label
+        self.isComplete = isComplete
+    }
+}
+
 public struct ConversationMessage: Codable, Hashable, Identifiable, Sendable {
     public let id: UUID
     public let conversationID: UUID
@@ -81,6 +97,7 @@ public struct ConversationMessage: Codable, Hashable, Identifiable, Sendable {
     public let createdAt: Date
     public var isStreaming: Bool
     public var attachments: [ChatAttachment]
+    public var toolActivities: [ToolActivity]
     public init(
         id: UUID = UUID(),
         conversationID: UUID,
@@ -88,7 +105,8 @@ public struct ConversationMessage: Codable, Hashable, Identifiable, Sendable {
         content: String,
         createdAt: Date = .now,
         isStreaming: Bool = false,
-        attachments: [ChatAttachment] = []
+        attachments: [ChatAttachment] = [],
+        toolActivities: [ToolActivity] = []
     ) {
         self.id = id
         self.conversationID = conversationID
@@ -97,10 +115,11 @@ public struct ConversationMessage: Codable, Hashable, Identifiable, Sendable {
         self.createdAt = createdAt
         self.isStreaming = isStreaming
         self.attachments = attachments
+        self.toolActivities = toolActivities
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, conversationID, role, content, createdAt, isStreaming, attachments
+        case id, conversationID, role, content, createdAt, isStreaming, attachments, toolActivities
     }
 
     public init(from decoder: Decoder) throws {
@@ -112,6 +131,7 @@ public struct ConversationMessage: Codable, Hashable, Identifiable, Sendable {
         createdAt = try container.decode(Date.self, forKey: .createdAt)
         isStreaming = try container.decode(Bool.self, forKey: .isStreaming)
         attachments = try container.decodeIfPresent([ChatAttachment].self, forKey: .attachments) ?? []
+        toolActivities = try container.decodeIfPresent([ToolActivity].self, forKey: .toolActivities) ?? []
     }
 }
 

--- a/AgentBoardCore/Services/HermesGatewayClient.swift
+++ b/AgentBoardCore/Services/HermesGatewayClient.swift
@@ -16,6 +16,27 @@ public struct HermesGatewayConfiguration: Codable, Hashable, Sendable {
     }
 }
 
+public struct HermesToolProgress: Codable, Hashable, Sendable {
+    public let tool: String
+    public let emoji: String?
+    public let label: String?
+    public let toolCallId: String
+    public let status: String
+
+    public init(tool: String, emoji: String?, label: String?, toolCallId: String, status: String) {
+        self.tool = tool
+        self.emoji = emoji
+        self.label = label
+        self.toolCallId = toolCallId
+        self.status = status
+    }
+}
+
+public enum HermesStreamEvent: Sendable, Hashable {
+    case text(String)
+    case toolProgress(HermesToolProgress)
+}
+
 public actor HermesGatewayClient {
     public enum ClientError: LocalizedError, Equatable {
         case invalidGatewayURL
@@ -122,7 +143,7 @@ public actor HermesGatewayClient {
 
     public func streamReply(
         for conversation: [ConversationMessage]
-    ) async throws -> AsyncThrowingStream<String, Error> {
+    ) async throws -> AsyncThrowingStream<HermesStreamEvent, Error> {
         let request = try makeChatRequest(conversation: conversation)
 
         return AsyncThrowingStream { continuation in
@@ -280,54 +301,89 @@ public actor HermesGatewayClient {
         return request
     }
 
+    private enum DataLineOutcome {
+        case yieldedText
+        case finished
+        case ignored
+    }
+
+    private func processDataLine(
+        _ rawData: String,
+        pendingEventName: inout String?,
+        continuation: AsyncThrowingStream<HermesStreamEvent, Error>.Continuation
+    ) -> DataLineOutcome {
+        if pendingEventName == "hermes.tool.progress" {
+            pendingEventName = nil
+            if let jsonData = rawData.data(using: .utf8),
+               let progress = try? decoder.decode(HermesToolProgress.self, from: jsonData) {
+                continuation.yield(.toolProgress(progress))
+            }
+            return .ignored
+        }
+
+        if rawData == "[DONE]" {
+            continuation.finish()
+            return .finished
+        }
+
+        guard let jsonData = rawData.data(using: .utf8),
+              let chunk = try? decoder.decode(ChatCompletionChunk.self, from: jsonData),
+              let firstChoice = chunk.choices?.first else {
+            return .ignored
+        }
+
+        if let finishReason = firstChoice.finishReason, finishReason == "stop" {
+            continuation.finish()
+            return .finished
+        }
+
+        if let content = firstChoice.assistantContent, !content.isEmpty {
+            continuation.yield(.text(content))
+            return .yieldedText
+        }
+
+        return .ignored
+    }
+
     private func consumeStream(
         bytes: URLSession.AsyncBytes,
-        continuation: AsyncThrowingStream<String, Error>.Continuation
+        continuation: AsyncThrowingStream<HermesStreamEvent, Error>.Continuation
     ) async throws {
         var sawServerSentEvent = false
         var fallbackBodyLines: [String] = []
         var didYieldContent = false
+        var pendingEventName: String?
 
         for try await line in bytes.lines {
             guard !Task.isCancelled else {
                 throw CancellationError()
             }
 
+            if line.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                pendingEventName = nil
+                continue
+            }
+
+            if line.hasPrefix("event: ") {
+                pendingEventName = String(line.dropFirst(7)).trimmingCharacters(in: .whitespacesAndNewlines)
+                continue
+            }
+
             guard line.hasPrefix("data: ") else {
-                if !line.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    fallbackBodyLines.append(line)
-                }
+                fallbackBodyLines.append(line)
                 continue
             }
 
             sawServerSentEvent = true
             let rawData = String(line.dropFirst(6))
 
-            if rawData == "[DONE]" {
-                continuation.finish()
-                return
-            }
-
-            guard let jsonData = rawData.data(using: .utf8) else { continue }
-
-            let chunk: ChatCompletionChunk
-            do {
-                chunk = try decoder.decode(ChatCompletionChunk.self, from: jsonData)
-            } catch {
-                continue
-            }
-
-            guard let firstChoice = chunk.choices?.first else { continue }
-
-            if let finishReason = firstChoice.finishReason,
-               finishReason == "stop" {
-                continuation.finish()
-                return
-            }
-
-            if let content = firstChoice.assistantContent, !content.isEmpty {
+            switch processDataLine(rawData, pendingEventName: &pendingEventName, continuation: continuation) {
+            case .yieldedText:
                 didYieldContent = true
-                continuation.yield(content)
+            case .finished:
+                return
+            case .ignored:
+                break
             }
         }
 
@@ -335,7 +391,7 @@ public actor HermesGatewayClient {
             let fallbackBody = fallbackBodyLines.joined(separator: "\n")
             if let content = try extractFallbackAssistantContent(from: fallbackBody), !content.isEmpty {
                 didYieldContent = true
-                continuation.yield(content)
+                continuation.yield(.text(content))
             }
         }
 

--- a/AgentBoardCore/Stores/ChatStreamCoordinator.swift
+++ b/AgentBoardCore/Stores/ChatStreamCoordinator.swift
@@ -89,10 +89,13 @@ final class ChatStreamCoordinator {
             callbacks.setConnectionState(.connected)
 
             for try await event in stream {
-                if case let .text(chunk) = event {
+                switch event {
+                case let .text(chunk):
                     assistantMessage.content += chunk
-                    callbacks.replaceMessages(requestMessages + [assistantMessage])
+                case let .toolProgress(progress):
+                    Self.apply(progress, to: &assistantMessage.toolActivities)
                 }
+                callbacks.replaceMessages(requestMessages + [assistantMessage])
             }
 
             assistantMessage.isStreaming = false
@@ -127,6 +130,23 @@ final class ChatStreamCoordinator {
                 errorMessage: error.localizedDescription,
                 connectionState: .failed
             )
+        }
+    }
+
+    nonisolated static func apply(_ progress: HermesToolProgress, to activities: inout [ToolActivity]) {
+        let isComplete = progress.status == "completed"
+        if let index = activities.firstIndex(where: { $0.id == progress.toolCallId }) {
+            if let emoji = progress.emoji { activities[index].emoji = emoji }
+            if let label = progress.label { activities[index].label = label }
+            activities[index].isComplete = isComplete
+        } else {
+            activities.append(ToolActivity(
+                id: progress.toolCallId,
+                tool: progress.tool,
+                emoji: progress.emoji,
+                label: progress.label,
+                isComplete: isComplete
+            ))
         }
     }
 

--- a/AgentBoardCore/Stores/ChatStreamCoordinator.swift
+++ b/AgentBoardCore/Stores/ChatStreamCoordinator.swift
@@ -88,9 +88,11 @@ final class ChatStreamCoordinator {
             let stream = try await hermesClient.streamReply(for: requestMessages)
             callbacks.setConnectionState(.connected)
 
-            for try await chunk in stream {
-                assistantMessage.content += chunk
-                callbacks.replaceMessages(requestMessages + [assistantMessage])
+            for try await event in stream {
+                if case let .text(chunk) = event {
+                    assistantMessage.content += chunk
+                    callbacks.replaceMessages(requestMessages + [assistantMessage])
+                }
             }
 
             assistantMessage.isStreaming = false

--- a/AgentBoardTests/ChatStoreTests.swift
+++ b/AgentBoardTests/ChatStoreTests.swift
@@ -65,6 +65,70 @@ struct ChatStoreTests {
 
     @Test
     @MainActor
+    func sendDraftUpsertsToolActivitiesFromStreamedProgressEvents() async throws {
+        let hermesClient = HermesGatewayClient(session: makeMockSession { request in
+            #expect(request.url?.path == "/v1/chat/completions")
+
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/event-stream"]
+            )!
+            let payload = """
+            data: {"choices":[{"delta":{"content":"Fresh"},"finish_reason":null}]}
+
+            event: hermes.tool.progress
+            data: {"tool":"web_search","emoji":"🔍","label":"Searching the web…","toolCallId":"call_1","status":"running"}
+
+            data: {"choices":[{"delta":{"content":" reply"},"finish_reason":null}]}
+
+            event: hermes.tool.progress
+            data: {"tool":"web_search","toolCallId":"call_1","status":"completed"}
+
+            data: {"choices":[{"delta":{},"finish_reason":"stop"}]}
+
+            data: [DONE]
+
+            """
+            return (response, Data(payload.utf8))
+        })
+
+        let suiteName = "ChatStoreTests-\(UUID().uuidString)"
+        let repository = SettingsRepository(
+            suiteName: suiteName,
+            serviceName: "ChatStoreTests-\(UUID().uuidString)"
+        )
+        let settingsStore = SettingsStore(repository: repository)
+        settingsStore.hermesGatewayURL = "http://127.0.0.1:8642"
+        settingsStore.hermesModelID = "hermes-agent"
+
+        let cache = try AgentBoardCache(inMemory: true)
+        let store = ChatStore(
+            hermesClient: hermesClient,
+            cache: cache,
+            settingsStore: settingsStore,
+            companionClient: CompanionClient()
+        )
+
+        store.startNewConversation()
+        store.draft = "Search something"
+
+        await store.sendDraft()
+
+        #expect(store.messages.count == 2)
+        #expect(store.messages[1].content == "Fresh reply")
+        #expect(store.messages[1].toolActivities.count == 1)
+        let activity = try #require(store.messages[1].toolActivities.first)
+        #expect(activity.id == "call_1")
+        #expect(activity.tool == "web_search")
+        #expect(activity.emoji == "🔍")
+        #expect(activity.label == "Searching the web…")
+        #expect(activity.isComplete)
+    }
+
+    @Test
+    @MainActor
     func bootstrapLoadsCompanionMessagesInParallelAndTreatsFailuresAsEmpty() async throws {
         let firstID = UUID()
         let secondID = UUID()

--- a/AgentBoardTests/DomainModelsTests.swift
+++ b/AgentBoardTests/DomainModelsTests.swift
@@ -185,6 +185,40 @@ struct DomainModelsTests {
         #expect(message.attachments.isEmpty)
     }
 
+    @Test func conversationMessageDecodesWithMissingToolActivitiesDefaultsToEmpty() throws {
+        let conversationID = UUID().uuidString
+        let messageID = UUID().uuidString
+        let json = """
+        {
+          "id": "\(messageID)",
+          "conversationID": "\(conversationID)",
+          "role": "assistant",
+          "content": "Reply",
+          "createdAt": 731638800,
+          "isStreaming": true
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let message = try decoder.decode(ConversationMessage.self, from: Data(json.utf8))
+        #expect(message.toolActivities.isEmpty)
+    }
+
+    @Test func conversationMessageWithToolActivitiesRoundTripsThroughJSON() throws {
+        let original = ConversationMessage(
+            conversationID: UUID(),
+            role: .assistant,
+            content: "Reply",
+            toolActivities: [
+                ToolActivity(id: "call_1", tool: "web_search", emoji: "🔍", label: "Searching…", isComplete: false),
+                ToolActivity(id: "call_2", tool: "code_exec", emoji: nil, label: nil, isComplete: true)
+            ]
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ConversationMessage.self, from: data)
+        #expect(decoded.toolActivities == original.toolActivities)
+    }
+
     // MARK: - AgentBoardSettings decoding
 
     @Test func agentBoardSettingsDecodingFillsDefaultsForMissingKeys() throws {

--- a/AgentBoardTests/HermesGatewayClientTests.swift
+++ b/AgentBoardTests/HermesGatewayClientTests.swift
@@ -91,10 +91,155 @@ struct HermesGatewayClientTests {
         )
 
         var combined = ""
-        for try await chunk in stream {
-            combined += chunk
+        for try await event in stream {
+            if case let .text(chunk) = event {
+                combined += chunk
+            }
         }
 
         #expect(combined == "Fresh reply")
+    }
+
+    @Test
+    func streamReplyYieldsTextAndToolProgressEventsInOrder() async throws {
+        let client = HermesGatewayClient(session: makeMockSession { request in
+            #expect(request.url?.path == "/v1/chat/completions")
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/event-stream"]
+            )!
+            let payload = """
+            data: {"choices":[{"delta":{"content":"Fresh"},"finish_reason":null}]}
+
+            event: hermes.tool.progress
+            data: {"tool":"web_search","emoji":"🔍","label":"Searching the web…","toolCallId":"call_1","status":"running"}
+
+            event: hermes.tool.progress
+            data: {"tool":"web_search","toolCallId":"call_1","status":"completed"}
+
+            data: {"choices":[{"delta":{},"finish_reason":"stop"}]}
+
+            data: [DONE]
+
+            """
+            return (response, Data(payload.utf8))
+        })
+        try await client.configure(
+            baseURL: "http://127.0.0.1:8642",
+            apiKey: nil,
+            preferredModelID: "hermes-agent"
+        )
+
+        let stream = try await client.streamReply(
+            for: [
+                ConversationMessage(conversationID: UUID(), role: .user, content: "Hello")
+            ]
+        )
+
+        var events: [HermesStreamEvent] = []
+        for try await event in stream {
+            events.append(event)
+        }
+
+        #expect(events == [
+            .text("Fresh"),
+            .toolProgress(HermesToolProgress(
+                tool: "web_search",
+                emoji: "🔍",
+                label: "Searching the web…",
+                toolCallId: "call_1",
+                status: "running"
+            )),
+            .toolProgress(HermesToolProgress(
+                tool: "web_search",
+                emoji: nil,
+                label: nil,
+                toolCallId: "call_1",
+                status: "completed"
+            ))
+        ])
+    }
+
+    @Test
+    func streamReplySkipsMalformedToolProgressJSON() async throws {
+        let client = HermesGatewayClient(session: makeMockSession { request in
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/event-stream"]
+            )!
+            let payload = """
+            event: hermes.tool.progress
+            data: {"tool":"web_search"}
+
+            data: {"choices":[{"delta":{"content":"Hi"},"finish_reason":null}]}
+
+            data: {"choices":[{"delta":{},"finish_reason":"stop"}]}
+
+            data: [DONE]
+
+            """
+            return (response, Data(payload.utf8))
+        })
+        try await client.configure(
+            baseURL: "http://127.0.0.1:8642",
+            apiKey: nil,
+            preferredModelID: "hermes-agent"
+        )
+
+        let stream = try await client.streamReply(
+            for: [
+                ConversationMessage(conversationID: UUID(), role: .user, content: "Hello")
+            ]
+        )
+
+        var events: [HermesStreamEvent] = []
+        for try await event in stream {
+            events.append(event)
+        }
+
+        #expect(events == [.text("Hi")])
+    }
+
+    @Test
+    func streamReplyThrowsEmptyAssistantResponseWhenOnlyToolEventsArrive() async throws {
+        let client = HermesGatewayClient(session: makeMockSession { request in
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/event-stream"]
+            )!
+            let payload = """
+            event: hermes.tool.progress
+            data: {"tool":"web_search","emoji":"🔍","label":"Searching…","toolCallId":"call_1","status":"running"}
+
+            event: hermes.tool.progress
+            data: {"tool":"web_search","toolCallId":"call_1","status":"completed"}
+
+            """
+            return (response, Data(payload.utf8))
+        })
+        try await client.configure(
+            baseURL: "http://127.0.0.1:8642",
+            apiKey: nil,
+            preferredModelID: "hermes-agent"
+        )
+
+        let stream = try await client.streamReply(
+            for: [
+                ConversationMessage(conversationID: UUID(), role: .user, content: "Hello")
+            ]
+        )
+
+        do {
+            for try await _ in stream {}
+            Issue.record("Expected emptyAssistantResponse to be thrown")
+        } catch let error as HermesGatewayClient.ClientError {
+            #expect(error == .emptyAssistantResponse)
+        }
     }
 }

--- a/AgentBoardUI/Components/ChatBubble.swift
+++ b/AgentBoardUI/Components/ChatBubble.swift
@@ -33,6 +33,10 @@ struct NeuChatBubble: View {
                 }
             }
 
+            if message.role == .assistant, !message.toolActivities.isEmpty {
+                toolActivityChips
+            }
+
             if message.isStreaming, message.content.isEmpty {
                 Text("typing...")
                     .foregroundStyle(NeuPalette.textSecondary)
@@ -63,6 +67,50 @@ struct NeuChatBubble: View {
                 .stroke(NeuPalette.borderSoft, lineWidth: 1)
         )
         .shadow(color: NeuPalette.shadowDark.opacity(0.6), radius: 8, x: 0, y: 4)
+    }
+
+    private var toolActivityChips: some View {
+        HStack(spacing: 8) {
+            ForEach(message.toolActivities) { activity in
+                ToolActivityChip(activity: activity)
+            }
+        }
+    }
+}
+
+// MARK: - ToolActivityChip
+
+private struct ToolActivityChip: View {
+    let activity: ToolActivity
+
+    var body: some View {
+        HStack(spacing: 5) {
+            if let emoji = activity.emoji {
+                Text(emoji)
+            } else {
+                Image(systemName: "wrench.and.screwdriver")
+            }
+
+            Text(activity.label ?? activity.tool)
+                .lineLimit(1)
+
+            if activity.isComplete {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 9, weight: .semibold))
+            } else {
+                ProgressView()
+                    .controlSize(.mini)
+            }
+        }
+        .font(.caption)
+        .foregroundStyle(NeuPalette.textSecondary)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(
+            Capsule().fill(NeuPalette.surfaceHover)
+        )
+        .opacity(activity.isComplete ? 0.65 : 1.0)
+        .accessibilityIdentifier("chat_chip_tool_\(activity.id)")
     }
 }
 


### PR DESCRIPTION
Phase 1 PR B of `docs/superpowers/plans/2026-07-17-phase1-chat-completion.md`.

- `HermesGatewayClient` parses named SSE events: `hermes.tool.progress` → `HermesStreamEvent.toolProgress`; text still `.text` (OpenAI chunks). Malformed events skipped; tool-only streams still error as empty.
- `ConversationMessage.toolActivities` (backward-compatible decode) + coordinator upsert by `toolCallId`.
- Chat bubbles show running/completed tool chips (spinner → checkmark) with `chat_chip_tool_*` accessibility ids.
- 398/398 tests; all three schemes build; SwiftLint strict clean. Implemented by a Sonnet subagent, reviewed + verified here.

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)