### PR TITLE
feat: capability toggles, real /skills, correct gateway port (#141)

### DIFF
--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		709B1495522FEA1AABEDEC6A /* BoardChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D736CF52ACD4E2BD9D3ADC /* BoardChrome.swift */; };
 		735B9E32C6B9218218F1CB8D /* AttachmentPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E3C09A95E37674D30B6072F /* AttachmentPicker.swift */; };
 		736771D2489A4C0C6FBB4A83 /* KeyboardDismissal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196C90FC0E35E33601741243 /* KeyboardDismissal.swift */; };
+		73D0983941C6808FB4A17E35 /* ChatCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = A062681C1E251F786843C99C /* ChatCapability.swift */; };
 		73E3E44246ACF7764C2B96D9 /* AgentBoardCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; };
 		77E2DDC0D4C0CA009FD508F0 /* EmbeddedTerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A978B41E9572538A1E74E5C /* EmbeddedTerminalView.swift */; };
 		7AC30545E6D54E227C8831BA /* AgentBoardCompanionKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB3E71CE348AC298EB4048DE /* AgentBoardCompanionKit.framework */; };
@@ -91,6 +92,7 @@
 		8497E073979589F788921999 /* ChatConversationSyncCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80BC8F409E30E995C8CEA744 /* ChatConversationSyncCoordinator.swift */; };
 		86474D9EDB4C400C89B3F5FF /* QuickLaunchSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FFDF3222AEE5530E6C58DFC /* QuickLaunchSheet.swift */; };
 		87A19AEDBCBE0206D4D71EFE /* DemoFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20006E3DE0937110157F9D1 /* DemoFixtures.swift */; };
+		87DB33C3551F5D706D014514 /* ChatStreamCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DE53DBCDB728D1E417AC4E5 /* ChatStreamCoordinatorTests.swift */; };
 		891566BE5B53801826DE8CF0 /* LaunchSessionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AD61915721952F19190205 /* LaunchSessionSheet.swift */; };
 		8AD4D2CC8A4C831C10AD484D /* MediaViewerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A8E745C7552F0B5FDF7C25 /* MediaViewerView.swift */; };
 		8C7104C625A0B93586FAFF1F /* ChatEndpointValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 132785F0427381E3DB05BD8E /* ChatEndpointValidator.swift */; };
@@ -152,6 +154,7 @@
 		F18232EF1BD587C14FCCD06F /* SessionsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E0CE9F3A8E9CA87A6C3B95 /* SessionsStoreTests.swift */; };
 		F22F4D3D2D3D20A5B3DD6B20 /* AgentBoardAppModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C9640747C8B7AE6E92BB20 /* AgentBoardAppModel.swift */; };
 		F374477884080894A1322DCE /* AppDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78ED2576E35E0964839427AD /* AppDestination.swift */; };
+		F38D2C6FF496E145B50F6E4F /* ChatStoreCapabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 101D840E678502545284009E /* ChatStoreCapabilityTests.swift */; };
 		F3D458595223FE83DD26EDC5 /* NukeUI in Frameworks */ = {isa = PBXBuildFile; productRef = AA403A62FC0CC3B341A2D00B /* NukeUI */; };
 		F595A9354548F0B6A8A8F2E3 /* AgentBoardCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; };
 		F78742DD742A458919E091C0 /* AgentBoardCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -260,6 +263,7 @@
 		0B023A92D06AE2F3272FC200 /* NoopAgentBoardCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoopAgentBoardCacheTests.swift; sourceTree = "<group>"; };
 		0B7442B7AA1CFE33776582C1 /* AgentBoardMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBoardMobileApp.swift; sourceTree = "<group>"; };
 		0D0FBEDFA7766F71A98B48E3 /* SlashCommandHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandHandler.swift; sourceTree = "<group>"; };
+		101D840E678502545284009E /* ChatStoreCapabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStoreCapabilityTests.swift; sourceTree = "<group>"; };
 		132785F0427381E3DB05BD8E /* ChatEndpointValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatEndpointValidator.swift; sourceTree = "<group>"; };
 		17F872D9728B5938D841130C /* ChatMessageList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageList.swift; sourceTree = "<group>"; };
 		196C90FC0E35E33601741243 /* KeyboardDismissal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardDismissal.swift; sourceTree = "<group>"; };
@@ -290,6 +294,7 @@
 		4F7D59DE18AF7B3E0D84EF9A /* DesktopSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopSidebar.swift; sourceTree = "<group>"; };
 		52959B32060C120BA1BB1AB7 /* ShellEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvironment.swift; sourceTree = "<group>"; };
 		54CA712A46E969ED79300E4F /* LinkPreviewService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkPreviewService.swift; sourceTree = "<group>"; };
+		5DE53DBCDB728D1E417AC4E5 /* ChatStreamCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStreamCoordinatorTests.swift; sourceTree = "<group>"; };
 		5F60733BA5BCAD5BD388E855 /* AgentBoardMobile.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AgentBoardMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		63376B7513D3E5CFE45372D6 /* BoardPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardPalette.swift; sourceTree = "<group>"; };
 		6350F1AD876CFC0042771A6F /* NoopAgentBoardCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoopAgentBoardCache.swift; sourceTree = "<group>"; };
@@ -313,6 +318,7 @@
 		957114148477B05585A13D7C /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
 		959F1DE11FF3233AB9029B6D /* MobileRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileRootView.swift; sourceTree = "<group>"; };
 		A04B1F730472F1F23A283354 /* PRDComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRDComposer.swift; sourceTree = "<group>"; };
+		A062681C1E251F786843C99C /* ChatCapability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatCapability.swift; sourceTree = "<group>"; };
 		A06C1DAB866C77FF3A634D71 /* WorkStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkStore.swift; sourceTree = "<group>"; };
 		A1A2BE598EEDA7A998AEA8DE /* MarkdownText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownText.swift; sourceTree = "<group>"; };
 		A40E2B4B6D9AD354BA23C3BF /* ChatStreamCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStreamCoordinator.swift; sourceTree = "<group>"; };
@@ -424,8 +430,10 @@
 				08FC87E1E7EE82E2FE4C749F /* ChatEndpointValidatorTests.swift */,
 				E01910C75287C5F3B6650B2A /* ChatHeaderPickerTests.swift */,
 				30366B0DAB9553F53ACE2BE6 /* ChatStoreAdditionalTests.swift */,
+				101D840E678502545284009E /* ChatStoreCapabilityTests.swift */,
 				0551DF2CA889DD84A9EFF3B7 /* ChatStoreSlashCommandTests.swift */,
 				7F925ACBB136730BD7852D8B /* ChatStoreTests.swift */,
+				5DE53DBCDB728D1E417AC4E5 /* ChatStreamCoordinatorTests.swift */,
 				D165293786CA5ACAB31F2F12 /* CompanionClientEventsTests.swift */,
 				B56A44BC3ACA67014432FDD4 /* CompanionSQLiteStoreTests.swift */,
 				E15329720160FF009D5B1535 /* ConfigBackupServiceTests.swift */,
@@ -457,6 +465,7 @@
 				4542E208AACDF95595A0B0D4 /* AgentBoardDesignTheme.swift */,
 				78ED2576E35E0964839427AD /* AppDestination.swift */,
 				C9D42E5CA1B251EA0284E8C6 /* AttachmentModels.swift */,
+				A062681C1E251F786843C99C /* ChatCapability.swift */,
 				E20006E3DE0937110157F9D1 /* DemoFixtures.swift */,
 				043C2F07C2F7E6DFBC165E9A /* DomainModels.swift */,
 				0A55930915B4E8B29ECFC5DD /* KanbanModels.swift */,
@@ -958,8 +967,10 @@
 				34C9CEDCDFB2E84348A0EDB4 /* ChatEndpointValidatorTests.swift in Sources */,
 				171A150F155917F5196D7647 /* ChatHeaderPickerTests.swift in Sources */,
 				C6A73DFEFD3440E23C5AE028 /* ChatStoreAdditionalTests.swift in Sources */,
+				F38D2C6FF496E145B50F6E4F /* ChatStoreCapabilityTests.swift in Sources */,
 				B01C8989FACCB9D76DD46CDF /* ChatStoreSlashCommandTests.swift in Sources */,
 				FF4D3F1289548330CC170576 /* ChatStoreTests.swift in Sources */,
+				87DB33C3551F5D706D014514 /* ChatStreamCoordinatorTests.swift in Sources */,
 				44DFBA6A0CA31D48DE0A0961 /* CompanionClientEventsTests.swift in Sources */,
 				58446795E6F62924439AD001 /* CompanionSQLiteStoreTests.swift in Sources */,
 				AC9718464408D550B64EFB4E /* ConfigBackupServiceTests.swift in Sources */,
@@ -997,6 +1008,7 @@
 				A51107E477749B979572DD17 /* AttachmentModels.swift in Sources */,
 				0CE0E873675F3D87FC974CB1 /* AttachmentUploadService.swift in Sources */,
 				3D5547FD2C8499B8C8FA087B /* AudioRecorderService.swift in Sources */,
+				73D0983941C6808FB4A17E35 /* ChatCapability.swift in Sources */,
 				8497E073979589F788921999 /* ChatConversationSyncCoordinator.swift in Sources */,
 				8C7104C625A0B93586FAFF1F /* ChatEndpointValidator.swift in Sources */,
 				E79388194D430DAEC6569944 /* ChatStore+Internals.swift in Sources */,

--- a/AgentBoardCore/Models/ChatCapability.swift
+++ b/AgentBoardCore/Models/ChatCapability.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// A per-conversation capability toggle. Hermes' `/v1/chat/completions` endpoint accepts
+/// only `messages`, `stream`, and `model` — there is no server-side capability parameter —
+/// so these toggles are honestly implemented as client-side system-prompt injection.
+public enum ChatCapability: String, Codable, CaseIterable, Sendable {
+    case thinking
+    case web
+    case code
+    case image
+    case speak
+
+    public var displayName: String {
+        switch self {
+        case .thinking: "Thinking"
+        case .web: "Web Access"
+        case .code: "Code Execution"
+        case .image: "Image Generation"
+        case .speak: "Voice Output"
+        }
+    }
+
+    public var promptInstruction: String {
+        switch self {
+        case .thinking: "Think step-by-step and show deeper reasoning before answering."
+        case .web: "Use web search/browsing tools when they would improve the answer."
+        case .code: "Use code execution tools when they would improve the answer."
+        case .image: "Generate images when the user asks for visuals."
+        case .speak: "Keep replies concise and speakable; they may be read aloud."
+        }
+    }
+}

--- a/AgentBoardCore/Models/DomainModels.swift
+++ b/AgentBoardCore/Models/DomainModels.swift
@@ -496,7 +496,7 @@ public struct AgentBoardSettings: Codable, Hashable, Sendable {
     }
 
     public init(
-        hermesGatewayURL: String = "http://127.0.0.1:8642",
+        hermesGatewayURL: String = HermesGatewayConfiguration.defaultBaseURL,
         hermesModelID: String? = "hermes-agent",
         hermesProfiles: [HermesProfile]? = nil,
         selectedHermesProfileID: String? = nil,
@@ -518,7 +518,7 @@ public struct AgentBoardSettings: Codable, Hashable, Sendable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         hermesGatewayURL = try container.decodeIfPresent(String.self, forKey: .hermesGatewayURL)
-            ?? "http://127.0.0.1:8642"
+            ?? HermesGatewayConfiguration.defaultBaseURL
         hermesModelID = try container.decodeIfPresent(String.self, forKey: .hermesModelID)
         hermesProfiles = try container.decodeIfPresent([HermesProfile].self, forKey: .hermesProfiles)
         selectedHermesProfileID = try container.decodeIfPresent(String.self, forKey: .selectedHermesProfileID)

--- a/AgentBoardCore/Services/ChatEndpointValidator.swift
+++ b/AgentBoardCore/Services/ChatEndpointValidator.swift
@@ -43,7 +43,7 @@ public struct ChatEndpointValidator: Sendable {
 
     public func normalizedHermesGatewayURL(_ rawValue: String) -> URL {
         let baseURL = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        let fallbackURL = URL(string: "http://127.0.0.1:8642")!
+        let fallbackURL = URL(string: HermesGatewayConfiguration.defaultBaseURL)!
         guard let url = URL(string: baseURL) else {
             return fallbackURL
         }

--- a/AgentBoardCore/Services/HermesGatewayClient.swift
+++ b/AgentBoardCore/Services/HermesGatewayClient.swift
@@ -1,12 +1,16 @@
 import Foundation
 
 public struct HermesGatewayConfiguration: Codable, Hashable, Sendable {
+    /// The live Hermes gateway API server port. Kept as a single source of truth so the
+    /// client's unconfigured fallback always matches the actually-running gateway.
+    public static let defaultBaseURL = "http://127.0.0.1:8641"
+
     public var baseURL: String
     public var apiKey: String?
     public var preferredModelID: String?
 
     public init(
-        baseURL: String = "http://127.0.0.1:8642",
+        baseURL: String = HermesGatewayConfiguration.defaultBaseURL,
         apiKey: String? = nil,
         preferredModelID: String? = "hermes-agent"
     ) {
@@ -93,10 +97,12 @@ public actor HermesGatewayClient {
         preferredModelID: String?
     ) throws {
         let normalizedBaseURL = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let parsedURL = URL(string: normalizedBaseURL.isEmpty ? "http://127.0.0.1:8642" : normalizedBaseURL),
-              let scheme = parsedURL.scheme?.lowercased(),
-              ["http", "https"].contains(scheme),
-              parsedURL.host != nil else {
+        guard let parsedURL = URL(
+            string: normalizedBaseURL.isEmpty ? HermesGatewayConfiguration.defaultBaseURL : normalizedBaseURL
+        ),
+            let scheme = parsedURL.scheme?.lowercased(),
+            ["http", "https"].contains(scheme),
+            parsedURL.host != nil else {
             throw ClientError.invalidGatewayURL
         }
 
@@ -501,7 +507,7 @@ public actor HermesGatewayClient {
 
     private func endpointURL(_ path: String) -> URL {
         guard let baseURL = URL(string: configuration.baseURL) else {
-            return URL(string: "http://127.0.0.1:8642/\(path)")!
+            return URL(string: "\(HermesGatewayConfiguration.defaultBaseURL)/\(path)")!
         }
         return baseURL.appending(path: path)
     }

--- a/AgentBoardCore/Services/HermesGatewayClient.swift
+++ b/AgentBoardCore/Services/HermesGatewayClient.swift
@@ -37,6 +37,16 @@ public enum HermesStreamEvent: Sendable, Hashable {
     case toolProgress(HermesToolProgress)
 }
 
+public struct HermesSkill: Codable, Hashable, Sendable {
+    public let name: String
+    public let description: String?
+
+    public init(name: String, description: String?) {
+        self.name = name
+        self.description = description
+    }
+}
+
 public actor HermesGatewayClient {
     public enum ClientError: LocalizedError, Equatable {
         case invalidGatewayURL
@@ -135,6 +145,34 @@ public actor HermesGatewayClient {
 
         let ids = payload.data.map(\.id)
         return ids.isEmpty ? [configuration.preferredModelID ?? "hermes-agent"] : ids
+    }
+
+    private struct SkillListResponse: Decodable, Sendable {
+        struct Entry: Decodable, Sendable {
+            let name: String
+            let description: String?
+            let category: String?
+        }
+
+        let data: [Entry]
+    }
+
+    public func fetchSkills() async throws -> [HermesSkill] {
+        var request = URLRequest(url: endpointURL("v1/skills"))
+        request.timeoutInterval = 10
+        setAuth(&request)
+
+        let (data, response) = try await data(for: request)
+        try validate(response: response, fallbackBody: data)
+
+        let payload: SkillListResponse
+        do {
+            payload = try decoder.decode(SkillListResponse.self, from: data)
+        } catch {
+            throw ClientError.invalidResponse
+        }
+
+        return payload.data.map { HermesSkill(name: $0.name, description: $0.description) }
     }
 
     public func loadConversationHistory(conversationID _: UUID) async throws -> [ConversationMessage] {

--- a/AgentBoardCore/Services/SlashCommandHandler.swift
+++ b/AgentBoardCore/Services/SlashCommandHandler.swift
@@ -246,16 +246,24 @@ public enum SlashCommandHandler: Sendable {
         connectionState: String,
         model: String,
         conversationTitle: String,
-        messageCount: Int
+        messageCount: Int,
+        activeCapabilities: [String] = []
     ) -> String {
-        """
-        **Connection Status**
+        var lines = [
+            "**Connection Status**",
+            "",
+            "**State:** \(connectionState)",
+            "**Model:** \(model)",
+            "**Session:** \(conversationTitle)",
+            "**Messages:** \(messageCount)"
+        ]
 
-        **State:** \(connectionState)
-        **Model:** \(model)
-        **Session:** \(conversationTitle)
-        **Messages:** \(messageCount)
-        """
+        if !activeCapabilities.isEmpty {
+            let formatted = activeCapabilities.map { "\($0) (prompt-injected)" }.joined(separator: ", ")
+            lines.append("Active capabilities: \(formatted)")
+        }
+
+        return lines.joined(separator: "\n")
     }
 
     /// Formatted configuration display.

--- a/AgentBoardCore/Services/SlashCommandHandler.swift
+++ b/AgentBoardCore/Services/SlashCommandHandler.swift
@@ -292,19 +292,15 @@ public enum SlashCommandHandler: Sendable {
         return lines.joined(separator: "\n")
     }
 
-    /// Formatted skills listing.
-    public static func formatSkills(_ skills: [SlashCommand]) -> String {
+    /// Formatted skills listing, sourced from the live Hermes `/v1/skills` endpoint.
+    public static func formatSkills(_ skills: [HermesSkill]) -> String {
         if skills.isEmpty {
-            return "**Skills**\n\nNo skills currently installed. Use `/skill <name>` to activate a skill."
+            return "No skills reported by the gateway."
         }
 
-        var lines = ["**Installed Skills**", ""]
-        for skill in skills {
-            lines.append("`/\(skill.name)` — \(skill.description)")
-        }
-        lines.append("")
-        lines.append("Use `/skill <name>` to activate a skill.")
-        return lines.joined(separator: "\n")
+        return skills.map { skill in
+            "• \(skill.name) — \(String((skill.description ?? "").prefix(100)))"
+        }.joined(separator: "\n")
     }
 
     /// Formatted memory display.

--- a/AgentBoardCore/Stores/ChatStore+SlashCommands.swift
+++ b/AgentBoardCore/Stores/ChatStore+SlashCommands.swift
@@ -128,7 +128,7 @@ extension ChatStore {
             return SlashCommandHandler.formatSkills(skills)
         } catch {
             logger.error("Hermes skills fetch failed: \(error.localizedDescription, privacy: .public)")
-            return "No skills reported by the gateway."
+            return SlashCommandHandler.formatSkills([])
         }
     }
 

--- a/AgentBoardCore/Stores/ChatStore+SlashCommands.swift
+++ b/AgentBoardCore/Stores/ChatStore+SlashCommands.swift
@@ -32,7 +32,7 @@ extension ChatStore {
             return true
         case .showSkills:
             clearDraft()
-            await appendSystemMessage(SlashCommandHandler.formatSkills([]), to: conversationID)
+            await appendSystemMessage(await skillsMessageForSlashCommand(), to: conversationID)
             return true
         case let .activateSkill(name):
             clearDraft()
@@ -119,6 +119,17 @@ extension ChatStore {
             messageCount: messages.count,
             activeCapabilities: activeCapabilities.map(\.displayName).sorted()
         )
+    }
+
+    private func skillsMessageForSlashCommand() async -> String {
+        do {
+            try await configureClient()
+            let skills = try await hermesClient.fetchSkills()
+            return SlashCommandHandler.formatSkills(skills)
+        } catch {
+            logger.error("Hermes skills fetch failed: \(error.localizedDescription, privacy: .public)")
+            return "No skills reported by the gateway."
+        }
     }
 
     private func configMessageForSlashCommand() -> String {

--- a/AgentBoardCore/Stores/ChatStore+SlashCommands.swift
+++ b/AgentBoardCore/Stores/ChatStore+SlashCommands.swift
@@ -39,9 +39,11 @@ extension ChatStore {
             await appendSystemMessage("Activating skill: \(name)…", to: conversationID)
             statusMessage = "Skill '\(name)' activated"
             return true
-        case .showMemory, .showTools, .toggleThinking, .toggleWeb,
-             .toggleCode, .toggleImage, .toggleSpeak:
+        case .showMemory, .showTools:
             return await handleToggleCommand(result, conversationID: conversationID)
+        case .toggleThinking, .toggleWeb, .toggleCode, .toggleImage, .toggleSpeak:
+            guard let capability = Self.capability(for: result) else { return false }
+            return await handleCapabilityToggle(capability, conversationID: conversationID)
         case .resetConversation:
             clearDraft()
             startNewConversation()
@@ -67,15 +69,38 @@ extension ChatStore {
         let message = switch result {
         case .showMemory: "Memory lookup sent to Hermes. Response will appear below."
         case .showTools: "Tool listing sent to Hermes. Response will appear below."
-        case .toggleThinking: "Toggled thinking mode. Sent to agent."
-        case .toggleWeb: "Toggled web access. Sent to agent."
-        case .toggleCode: "Toggled code execution. Sent to agent."
-        case .toggleImage: "Toggled image generation. Sent to agent."
-        case .toggleSpeak: "Toggled voice output. Sent to agent."
         default: "Command sent to agent."
         }
         await appendSystemMessage(message, to: conversationID)
         return false
+    }
+
+    private static func capability(for result: SlashCommandResult) -> ChatCapability? {
+        switch result {
+        case .toggleThinking: .thinking
+        case .toggleWeb: .web
+        case .toggleCode: .code
+        case .toggleImage: .image
+        case .toggleSpeak: .speak
+        default: nil
+        }
+    }
+
+    /// Capability toggles are honestly labeled: Hermes has no capability parameter, so these
+    /// are handled entirely locally by flipping a per-conversation flag that gets folded into
+    /// a client-side system-prompt instruction on future sends — never forwarded as a command.
+    func handleCapabilityToggle(
+        _ capability: ChatCapability,
+        conversationID: UUID
+    ) async -> Bool {
+        clearDraft()
+        let isOn = toggleCapability(capability, for: conversationID)
+        let state = isOn ? "ON" : "OFF"
+        await appendSystemMessage(
+            "\(capability.displayName) mode \(state) (client-side prompt injection)",
+            to: conversationID
+        )
+        return true
     }
 
     private func statusMessageForSlashCommand() -> String {
@@ -86,11 +111,13 @@ extension ChatStore {
         case .reconnecting: "Reconnecting"
         case .failed: "Failed"
         }
+        let activeCapabilities = selectedConversationID.map { capabilities(for: $0) } ?? []
         return SlashCommandHandler.formatStatus(
             connectionState: state,
             model: settingsStore.hermesModelID,
             conversationTitle: selectedConversation?.title ?? "None",
-            messageCount: messages.count
+            messageCount: messages.count,
+            activeCapabilities: activeCapabilities.map(\.displayName).sorted()
         )
     }
 

--- a/AgentBoardCore/Stores/ChatStore.swift
+++ b/AgentBoardCore/Stores/ChatStore.swift
@@ -30,6 +30,7 @@ public final class ChatStore {
 
     var messagesByConversationID: [UUID: [ConversationMessage]] = [:]
     var didBootstrap = false
+    private var conversationCapabilities: [UUID: Set<ChatCapability>] = [:]
 
     public init(
         hermesClient: HermesGatewayClient,
@@ -135,6 +136,25 @@ public final class ChatStore {
 
         statusMessage = "Using \(trimmedModelID)."
         errorMessage = nil
+    }
+
+    public func capabilities(for conversationID: UUID) -> Set<ChatCapability> {
+        conversationCapabilities[conversationID] ?? []
+    }
+
+    @discardableResult
+    public func toggleCapability(_ capability: ChatCapability, for conversationID: UUID) -> Bool {
+        var current = conversationCapabilities[conversationID] ?? []
+        let isOn: Bool
+        if current.contains(capability) {
+            current.remove(capability)
+            isOn = false
+        } else {
+            current.insert(capability)
+            isOn = true
+        }
+        conversationCapabilities[conversationID] = current
+        return isOn
     }
 
     public func addAttachment(_ attachment: ChatAttachment) {
@@ -283,7 +303,8 @@ public final class ChatStore {
                 text: trimmed,
                 attachments: attachmentsToSend,
                 conversation: selectedConversation ?? ChatConversation(id: conversationID, title: "Conversation"),
-                currentMessages: messagesByConversationID[conversationID] ?? []
+                currentMessages: messagesByConversationID[conversationID] ?? [],
+                capabilities: capabilities(for: conversationID)
             ),
             callbacks: streamCallbacks(for: conversationID)
         )

--- a/AgentBoardCore/Stores/ChatStreamCoordinator.swift
+++ b/AgentBoardCore/Stores/ChatStreamCoordinator.swift
@@ -7,6 +7,7 @@ struct ChatStreamRequest: Sendable {
     let attachments: [ChatAttachment]
     let conversation: ChatConversation
     let currentMessages: [ConversationMessage]
+    let capabilities: Set<ChatCapability>
 }
 
 struct ChatStreamCallbacks: Sendable {
@@ -70,8 +71,8 @@ final class ChatStreamCoordinator {
             isStreaming: true
         )
 
-        let requestMessages = request.currentMessages + [userMessage]
-        callbacks.replaceMessages(requestMessages + [assistantMessage])
+        let displayMessages = request.currentMessages + [userMessage]
+        callbacks.replaceMessages(displayMessages + [assistantMessage])
 
         if conversation.title == "New Conversation" {
             conversation.title = String(request.text.prefix(48))
@@ -85,7 +86,12 @@ final class ChatStreamCoordinator {
 
         do {
             try await configureClient()
-            let stream = try await hermesClient.streamReply(for: requestMessages)
+            let outboundMessages = Self.buildOutboundMessages(
+                displayMessages: displayMessages,
+                capabilities: request.capabilities,
+                conversationID: request.conversationID
+            )
+            let stream = try await hermesClient.streamReply(for: outboundMessages)
             callbacks.setConnectionState(.connected)
 
             for try await event in stream {
@@ -95,11 +101,11 @@ final class ChatStreamCoordinator {
                 case let .toolProgress(progress):
                     Self.apply(progress, to: &assistantMessage.toolActivities)
                 }
-                callbacks.replaceMessages(requestMessages + [assistantMessage])
+                callbacks.replaceMessages(displayMessages + [assistantMessage])
             }
 
             assistantMessage.isStreaming = false
-            callbacks.replaceMessages(requestMessages + [assistantMessage])
+            callbacks.replaceMessages(displayMessages + [assistantMessage])
             callbacks.setIsStreaming(false)
 
             conversation.updatedAt = .now
@@ -118,10 +124,10 @@ final class ChatStreamCoordinator {
             callbacks.setIsStreaming(false)
 
             if assistantMessage.content.isEmpty {
-                callbacks.replaceMessages(requestMessages)
+                callbacks.replaceMessages(displayMessages)
             } else {
                 assistantMessage.isStreaming = false
-                callbacks.replaceMessages(requestMessages + [assistantMessage])
+                callbacks.replaceMessages(displayMessages + [assistantMessage])
             }
             await callbacks.persist()
 
@@ -131,6 +137,29 @@ final class ChatStreamCoordinator {
                 connectionState: .failed
             )
         }
+    }
+
+    /// Builds the message list actually sent to Hermes. When capabilities are active, a
+    /// synthetic system message carrying their prompt instructions is prepended — but only
+    /// for this outbound call. It must never be persisted or displayed, so callers must use
+    /// `displayMessages` (not this function's result) for `replaceMessages`/persistence.
+    nonisolated static func buildOutboundMessages(
+        displayMessages: [ConversationMessage],
+        capabilities: Set<ChatCapability>,
+        conversationID: UUID
+    ) -> [ConversationMessage] {
+        guard !capabilities.isEmpty else { return displayMessages }
+
+        let instructions = capabilities
+            .map(\.promptInstruction)
+            .sorted()
+            .joined(separator: " ")
+        let syntheticSystemMessage = ConversationMessage(
+            conversationID: conversationID,
+            role: .system,
+            content: "Capability overrides (client-side): " + instructions
+        )
+        return [syntheticSystemMessage] + displayMessages
     }
 
     nonisolated static func apply(_ progress: HermesToolProgress, to activities: inout [ToolActivity]) {

--- a/AgentBoardCore/Stores/SettingsStore.swift
+++ b/AgentBoardCore/Stores/SettingsStore.swift
@@ -9,7 +9,7 @@ public final class SettingsStore {
     private let repository: SettingsRepository
     private let requiresRemoteCompanionHost: Bool
 
-    public var hermesGatewayURL = "http://127.0.0.1:8642"
+    public var hermesGatewayURL = HermesGatewayConfiguration.defaultBaseURL
     public var hermesModelID = "hermes-agent"
     public var hermesAPIKey = ""
     public var hermesProfiles: [HermesProfile] = []
@@ -34,7 +34,7 @@ public final class SettingsStore {
 
     public var settingsSnapshot: AgentBoardSettings {
         AgentBoardSettings(
-            hermesGatewayURL: hermesGatewayURL.trimmedOrNil ?? "http://127.0.0.1:8642",
+            hermesGatewayURL: hermesGatewayURL.trimmedOrNil ?? HermesGatewayConfiguration.defaultBaseURL,
             hermesModelID: hermesModelID.trimmedOrNil,
             hermesProfiles: hermesProfiles,
             selectedHermesProfileID: selectedHermesProfileID,

--- a/AgentBoardTests/ChatStoreCapabilityTests.swift
+++ b/AgentBoardTests/ChatStoreCapabilityTests.swift
@@ -1,0 +1,114 @@
+import AgentBoardCore
+import Foundation
+import Testing
+
+@Suite("ChatStore — capability toggles", .serialized)
+struct ChatStoreCapabilityTests {
+    @MainActor
+    private func makeStore(hermesURL: String = "http://127.0.0.1:8642") throws -> ChatStore {
+        let session = makeMockSession { _ in
+            let response = try HTTPURLResponse(
+                url: URL(string: "http://127.0.0.1:8642/health")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data())
+        }
+        let hermesClient = HermesGatewayClient(session: session)
+        let cache = try AgentBoardCache(inMemory: true)
+        let repo = SettingsRepository(
+            suiteName: "CapabilityTests-\(UUID().uuidString)",
+            serviceName: "CapabilityTests-\(UUID().uuidString)"
+        )
+        let settingsStore = SettingsStore(repository: repo)
+        settingsStore.hermesGatewayURL = hermesURL
+        settingsStore.hermesModelID = "hermes-agent"
+        let store = ChatStore(
+            hermesClient: hermesClient,
+            cache: cache,
+            settingsStore: settingsStore,
+            companionClient: CompanionClient()
+        )
+        store.startNewConversation()
+        return store
+    }
+
+    // MARK: - Capability toggles are handled locally (never forwarded to the agent)
+
+    @Test
+    @MainActor
+    func thinkCommandIsHandledLocallyAndTogglesOn() async throws {
+        let store = try makeStore()
+        let conversationID = try #require(store.selectedConversationID)
+        #expect(store.capabilities(for: conversationID).isEmpty)
+
+        store.draft = "/think"
+        await store.sendDraft()
+
+        #expect(store.capabilities(for: conversationID).contains(.thinking))
+        let content = try #require(store.messages.last?.content)
+        #expect(content.contains("Thinking mode ON (client-side prompt injection)"))
+        // Handled locally means only the notification message is present — no
+        // separate agent-forwarded exchange was triggered.
+        #expect(store.messages.count == 1)
+    }
+
+    @Test
+    @MainActor
+    func thinkCommandTwiceTogglesOffAgain() async throws {
+        let store = try makeStore()
+        let conversationID = try #require(store.selectedConversationID)
+
+        store.draft = "/think"
+        await store.sendDraft()
+        #expect(store.capabilities(for: conversationID).contains(.thinking))
+
+        store.draft = "/think"
+        await store.sendDraft()
+        #expect(!store.capabilities(for: conversationID).contains(.thinking))
+        let content = try #require(store.messages.last?.content)
+        #expect(content.contains("Thinking mode OFF (client-side prompt injection)"))
+    }
+
+    @Test
+    @MainActor
+    func capabilityTogglesArePerConversation() async throws {
+        let store = try makeStore()
+        let conversationA = try #require(store.selectedConversationID)
+
+        store.draft = "/think"
+        await store.sendDraft()
+        #expect(store.capabilities(for: conversationA).contains(.thinking))
+
+        store.startNewConversation()
+        let conversationB = try #require(store.selectedConversationID)
+        #expect(conversationB != conversationA)
+        #expect(store.capabilities(for: conversationB).isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func statusCommandListsActiveCapabilitiesWhenToggled() async throws {
+        let store = try makeStore()
+        store.draft = "/think"
+        await store.sendDraft()
+
+        store.draft = "/status"
+        await store.sendDraft()
+
+        let content = try #require(store.messages.last?.content)
+        #expect(content.contains("Thinking (prompt-injected)"))
+    }
+
+    @Test
+    @MainActor
+    func statusCommandOmitsCapabilitiesLineWhenNoneActive() async throws {
+        let store = try makeStore()
+        store.draft = "/status"
+        await store.sendDraft()
+
+        let content = try #require(store.messages.last?.content)
+        #expect(!content.contains("prompt-injected"))
+    }
+}

--- a/AgentBoardTests/ChatStoreTests.swift
+++ b/AgentBoardTests/ChatStoreTests.swift
@@ -129,6 +129,65 @@ struct ChatStoreTests {
 
     @Test
     @MainActor
+    func sendDraftInjectsCapabilityInstructionsOutboundOnlyNeverDisplayed() async throws {
+        // ChatStreamCoordinatorTests.buildOutboundMessagesPrependsSyntheticSystemMessage…
+        // covers the outbound side directly. This test guards the other half of the
+        // invariant: the synthetic message must never leak into the persisted/displayed
+        // transcript that the user (and the cache) sees.
+        let hermesClient = HermesGatewayClient(session: makeMockSession { request in
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/event-stream"]
+            )!
+            let payload = """
+            data: {"choices":[{"delta":{"content":"Reply"},"finish_reason":null}]}
+
+            data: {"choices":[{"delta":{},"finish_reason":"stop"}]}
+
+            data: [DONE]
+
+            """
+            return (response, Data(payload.utf8))
+        })
+
+        let suiteName = "ChatStoreTests-\(UUID().uuidString)"
+        let repository = SettingsRepository(
+            suiteName: suiteName,
+            serviceName: "ChatStoreTests-\(UUID().uuidString)"
+        )
+        let settingsStore = SettingsStore(repository: repository)
+        settingsStore.hermesGatewayURL = "http://127.0.0.1:8642"
+        settingsStore.hermesModelID = "hermes-agent"
+
+        let cache = try AgentBoardCache(inMemory: true)
+        let store = ChatStore(
+            hermesClient: hermesClient,
+            cache: cache,
+            settingsStore: settingsStore,
+            companionClient: CompanionClient()
+        )
+
+        store.startNewConversation()
+        let conversationID = try #require(store.selectedConversationID)
+
+        store.draft = "/think"
+        await store.sendDraft()
+        #expect(store.capabilities(for: conversationID).contains(.thinking))
+
+        store.draft = "Plan the launch"
+        await store.sendDraft()
+
+        // The synthetic capability system message must never reach the persisted/displayed
+        // transcript — only the outbound request to Hermes should carry it.
+        #expect(!store.messages.contains { $0.content.contains("Capability overrides") })
+        let cachedMessages = try cache.loadMessages(conversationID: conversationID)
+        #expect(!cachedMessages.contains { $0.content.contains("Capability overrides") })
+    }
+
+    @Test
+    @MainActor
     func bootstrapLoadsCompanionMessagesInParallelAndTreatsFailuresAsEmpty() async throws {
         let firstID = UUID()
         let secondID = UUID()

--- a/AgentBoardTests/ChatStreamCoordinatorTests.swift
+++ b/AgentBoardTests/ChatStreamCoordinatorTests.swift
@@ -1,0 +1,43 @@
+@testable import AgentBoardCore
+import Foundation
+import Testing
+
+@Suite("ChatStreamCoordinator — outbound message assembly")
+struct ChatStreamCoordinatorTests {
+    @Test
+    func buildOutboundMessagesReturnsDisplayMessagesUnchangedWhenNoCapabilitiesActive() {
+        let conversationID = UUID()
+        let displayMessages = [
+            ConversationMessage(conversationID: conversationID, role: .user, content: "Hi")
+        ]
+
+        let outbound = ChatStreamCoordinator.buildOutboundMessages(
+            displayMessages: displayMessages,
+            capabilities: [],
+            conversationID: conversationID
+        )
+
+        #expect(outbound == displayMessages)
+    }
+
+    @Test
+    func buildOutboundMessagesPrependsSyntheticSystemMessageWithSortedInstructions() {
+        let conversationID = UUID()
+        let displayMessages = [
+            ConversationMessage(conversationID: conversationID, role: .user, content: "Hi")
+        ]
+
+        let outbound = ChatStreamCoordinator.buildOutboundMessages(
+            displayMessages: displayMessages,
+            capabilities: [.web, .thinking],
+            conversationID: conversationID
+        )
+
+        #expect(outbound.count == 2)
+        #expect(outbound[0].role == .system)
+        #expect(outbound[0].content.hasPrefix("Capability overrides (client-side): "))
+        #expect(outbound[0].content.contains(ChatCapability.thinking.promptInstruction))
+        #expect(outbound[0].content.contains(ChatCapability.web.promptInstruction))
+        #expect(outbound[1] == displayMessages[0])
+    }
+}

--- a/AgentBoardTests/DomainModelsTests.swift
+++ b/AgentBoardTests/DomainModelsTests.swift
@@ -224,7 +224,7 @@ struct DomainModelsTests {
     @Test func agentBoardSettingsDecodingFillsDefaultsForMissingKeys() throws {
         let json = "{}"
         let settings = try JSONDecoder().decode(AgentBoardSettings.self, from: Data(json.utf8))
-        #expect(settings.hermesGatewayURL == "http://127.0.0.1:8642")
+        #expect(settings.hermesGatewayURL == "http://127.0.0.1:8641")
         #expect(settings.companionURL == "http://127.0.0.1:8742")
         #expect(settings.repositories.isEmpty)
         #expect(settings.autoRefreshInterval == 30)

--- a/AgentBoardTests/HermesGatewayClientTests.swift
+++ b/AgentBoardTests/HermesGatewayClientTests.swift
@@ -92,6 +92,13 @@ struct HermesGatewayClientTests {
     }
 
     @Test
+    func defaultConfigurationUsesLiveGatewayPort() {
+        let configuration = HermesGatewayConfiguration()
+        #expect(configuration.baseURL == "http://127.0.0.1:8641")
+        #expect(HermesGatewayConfiguration.defaultBaseURL == "http://127.0.0.1:8641")
+    }
+
+    @Test
     func streamReplyYieldsStreamingContent() async throws {
         let client = HermesGatewayClient(session: makeMockSession { request in
             #expect(request.url?.path == "/v1/chat/completions")

--- a/AgentBoardTests/HermesGatewayClientTests.swift
+++ b/AgentBoardTests/HermesGatewayClientTests.swift
@@ -57,6 +57,41 @@ struct HermesGatewayClientTests {
     }
 
     @Test
+    func fetchSkillsDecodesNameAndDescription() async throws {
+        let client = HermesGatewayClient(session: makeMockSession { request in
+            #expect(request.url?.path == "/v1/skills")
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            let longDescription = String(repeating: "x", count: 150)
+            let payload = """
+            {
+              "object": "list",
+              "data": [
+                {"name": "code-review", "description": "Reviews a diff.", "category": null},
+                {"name": "deep-research", "description": "\(longDescription)", "category": "research"}
+              ]
+            }
+            """
+            return (response, Data(payload.utf8))
+        })
+        try await client.configure(
+            baseURL: "http://127.0.0.1:8642",
+            apiKey: nil,
+            preferredModelID: "hermes-agent"
+        )
+
+        let skills = try await client.fetchSkills()
+        #expect(skills == [
+            HermesSkill(name: "code-review", description: "Reviews a diff."),
+            HermesSkill(name: "deep-research", description: String(repeating: "x", count: 150))
+        ])
+    }
+
+    @Test
     func streamReplyYieldsStreamingContent() async throws {
         let client = HermesGatewayClient(session: makeMockSession { request in
             #expect(request.url?.path == "/v1/chat/completions")

--- a/AgentBoardTests/SlashCommandHandlerTests.swift
+++ b/AgentBoardTests/SlashCommandHandlerTests.swift
@@ -174,6 +174,18 @@ struct SlashCommandHandlerTests {
         #expect(status.contains("5"))
     }
 
+    @Test func formatStatusIncludesActiveCapabilitiesWhenProvided() {
+        let status = SlashCommandHandler.formatStatus(
+            connectionState: "Connected",
+            model: "hermes-pro",
+            conversationTitle: "Test Chat",
+            messageCount: 5,
+            activeCapabilities: ["Thinking", "Web Access"]
+        )
+        #expect(status.contains("Thinking (prompt-injected)"))
+        #expect(status.contains("Web Access (prompt-injected)"))
+    }
+
     @Test func formatConfigIncludesURLAndModel() {
         let config = SlashCommandHandler.formatConfig(
             gatewayURL: "http://127.0.0.1:8642",

--- a/AgentBoardTests/SlashCommandHandlerTests.swift
+++ b/AgentBoardTests/SlashCommandHandlerTests.swift
@@ -186,6 +186,25 @@ struct SlashCommandHandlerTests {
         #expect(status.contains("Web Access (prompt-injected)"))
     }
 
+    @Test func formatSkillsReturnsFallbackWhenEmpty() {
+        let text = SlashCommandHandler.formatSkills([])
+        #expect(text == "No skills reported by the gateway.")
+    }
+
+    @Test func formatSkillsRendersBulletedNameAndTruncatedDescription() {
+        let longDescription = String(repeating: "x", count: 150)
+        let skills = [
+            HermesSkill(name: "code-review", description: "Reviews a diff."),
+            HermesSkill(name: "no-description", description: nil),
+            HermesSkill(name: "deep-research", description: longDescription)
+        ]
+        let text = SlashCommandHandler.formatSkills(skills)
+        #expect(text.contains("• code-review — Reviews a diff."))
+        #expect(text.contains("• no-description — "))
+        #expect(text.contains("• deep-research — " + String(repeating: "x", count: 100)))
+        #expect(!text.contains(String(repeating: "x", count: 101)))
+    }
+
     @Test func formatConfigIncludesURLAndModel() {
         let config = SlashCommandHandler.formatConfig(
             gatewayURL: "http://127.0.0.1:8642",


### PR DESCRIPTION
Phase 1 PR C of `docs/superpowers/plans/2026-07-17-phase1-chat-completion.md`. **Stacked on #149** — merge that first; GitHub will retarget this to main.

- `/think` `/web` `/code` `/image` `/speak` now flip real per-conversation flags; active capabilities inject a synthetic system message into the outbound request only (never the displayed transcript) and are labeled `(prompt-injected)` in `/status` — the gateway accepts no capability params, verified against source
- `/skills` now lists real skills from `GET /v1/skills`
- Default gateway URL corrected to the live API server port **8641** everywhere the 8642 default was compiled in (client, SettingsStore, AgentBoardSettings, endpoint validator); user-persisted URLs untouched
- 411/411 tests; all three schemes build; SwiftLint strict clean. Implemented by a Sonnet subagent, reviewed + verified here.

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)