### PR TITLE
fix: main does not compile — restore broken if/else in VoicePlaybackView

### DIFF
--- a/AgentBoardUI/Components/Attachments/VoiceViews.swift
+++ b/AgentBoardUI/Components/Attachments/VoiceViews.swift
@@ -204,18 +204,18 @@ struct VoicePlaybackView: View {
         do {
             if let localURL = attachment.payload.localURL {
                 try playback.togglePlayback(attachmentID: attachmentUUID, url: localURL)
-} else if let remoteURL = attachment.remoteURL {
-    let (tempURL, _) = try await URLSession.shared.download(from: remoteURL)
+            } else if let remoteURL = attachment.remoteURL {
+                let (tempURL, _) = try await URLSession.shared.download(from: remoteURL)
 
-    let cachedURL = FileManager.default.temporaryDirectory
-        .appendingPathComponent("voice-\(attachmentUUID.uuidString)-\(tempURL.lastPathComponent)")
-    if FileManager.default.fileExists(atPath: cachedURL.path) {
-        try? FileManager.default.removeItem(at: cachedURL)
-    }
-    try FileManager.default.moveItem(at: tempURL, to: cachedURL)
+                let cachedURL = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("voice-\(attachmentUUID.uuidString)-\(tempURL.lastPathComponent)")
+                if FileManager.default.fileExists(atPath: cachedURL.path) {
+                    try? FileManager.default.removeItem(at: cachedURL)
+                }
+                try FileManager.default.moveItem(at: tempURL, to: cachedURL)
 
-    try playback.togglePlayback(attachmentID: attachmentUUID, url: cachedURL)
-}
+                try playback.togglePlayback(attachmentID: attachmentUUID, url: cachedURL)
+            } else {
                 errorMessage = "No audio available"
             }
         } catch {


### PR DESCRIPTION
**Merge this first — main is currently broken.** The "Potential fix for pull request finding" commit that landed with the #151 merge left `VoicePlaybackView.togglePlayback()` with a dangling `else if` and mismatched braces, so no scheme builds on main. This restores the intended structure (same caching logic, correct braces); found by the Phase 2 subagent when its baseline build failed with 0 tests runnable.

Verified: AgentBoard (macOS) builds on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)