### PR TITLE
feat: drag-and-drop between agent board columns (#143)

### DIFF
--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -11,8 +11,8 @@
 		00D4FD7D1E850E381301E79B /* BoardPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63376B7513D3E5CFE45372D6 /* BoardPalette.swift */; };
 		011B0517E71FDF2B9BB75A97 /* ChatBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFBB71134457F46E6F2B247 /* ChatBubble.swift */; };
 		02A1ED4D473E2364438AEF82 /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = AD7CA2BAC6FD5DFD28FC0BCD /* Nuke */; };
-		06A2E173031971B030DA8DCE /* AudioPlaybackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877DCCB45A0AFBD92AFAB650 /* AudioPlaybackService.swift */; };
 		03601128965EFC35A0097F79 /* MarkdownBlockParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E8BA0A7421FAF69CBF5AD4F /* MarkdownBlockParser.swift */; };
+		06A2E173031971B030DA8DCE /* AudioPlaybackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877DCCB45A0AFBD92AFAB650 /* AudioPlaybackService.swift */; };
 		06B09775C2F43ADB9D2A7DDB /* CreateIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 702A0D71A27F07711AF96C4A /* CreateIssueSheet.swift */; };
 		09EBE4FCFB3B4A5DFA3E0B8B /* AudioPlaybackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9DDB4F3F626262EACA72A8 /* AudioPlaybackServiceTests.swift */; };
 		0B3C6DC24A36FE8A19357506 /* KanbanAssigneePickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0D9C21BA312AB952D0E48B /* KanbanAssigneePickerTests.swift */; };
@@ -109,6 +109,7 @@
 		97BD3D8CCE198A034A5E0C2F /* AttachmentPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E3C09A95E37674D30B6072F /* AttachmentPicker.swift */; };
 		9A90C5EF45CA6630C7EA64CD /* SessionLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B1DC901AD1D60B3855D38 /* SessionLauncherTests.swift */; };
 		9EAAAF4FFBF10F8A576AF5BD /* SessionLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B7CE4C138A75D87781C1DB /* SessionLauncher.swift */; };
+		9EAC1A69746A2ABCB376F952 /* KanbanBoardMoveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3540D69FA92919FFD0494695 /* KanbanBoardMoveTests.swift */; };
 		A51107E477749B979572DD17 /* AttachmentModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D42E5CA1B251EA0284E8C6 /* AttachmentModels.swift */; };
 		A66CDAEC61CF81C8BC905B61 /* AgentsStoreSummariesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E84FB91863EEFC0DABE3E113 /* AgentsStoreSummariesTests.swift */; };
 		A86A0A76B46CE6265194C0A6 /* PRDComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04B1F730472F1F23A283354 /* PRDComposer.swift */; };
@@ -128,6 +129,7 @@
 		C03DE2AB570D615F55142A44 /* AgentBoardCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3024AF0B4A66DE64BDB27E15 /* AgentBoardCache.swift */; };
 		C23BCB5CF1615F000459D9E7 /* HermesGatewayClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7B2891F313F2E1804101D36 /* HermesGatewayClient.swift */; };
 		C32F8741DFBEF1D329D356E0 /* KanbanDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9896F487D5B25505452683B /* KanbanDataService.swift */; };
+		C533F4D91531479ECC82DC9E /* KanbanBoardMove.swift in Sources */ = {isa = PBXBuildFile; fileRef = 275D2D504EF7D2F320157884 /* KanbanBoardMove.swift */; };
 		C6A73DFEFD3440E23C5AE028 /* ChatStoreAdditionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30366B0DAB9553F53ACE2BE6 /* ChatStoreAdditionalTests.swift */; };
 		C6F5E2BE0559A438785BBCF8 /* FoundationExtras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ABBA014D0943EA3DA8EEB96 /* FoundationExtras.swift */; };
 		C94A55ED7CCDD9540A5BF068 /* ChatMessageList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F872D9728B5938D841130C /* ChatMessageList.swift */; };
@@ -279,6 +281,7 @@
 		1FFDF3222AEE5530E6C58DFC /* QuickLaunchSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLaunchSheet.swift; sourceTree = "<group>"; };
 		26A31E0F643092B573A4DB9D /* IssueDetailSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailSheet.swift; sourceTree = "<group>"; };
 		26BDC7F11FD4398428433E67 /* AgentsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsStore.swift; sourceTree = "<group>"; };
+		275D2D504EF7D2F320157884 /* KanbanBoardMove.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanBoardMove.swift; sourceTree = "<group>"; };
 		2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AgentBoardCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2E342B801493E6187C7DFC1E /* AgentBoardTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AgentBoardTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3024AF0B4A66DE64BDB27E15 /* AgentBoardCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBoardCache.swift; sourceTree = "<group>"; };
@@ -287,6 +290,7 @@
 		33A8E745C7552F0B5FDF7C25 /* MediaViewerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaViewerView.swift; sourceTree = "<group>"; };
 		34D736CF52ACD4E2BD9D3ADC /* BoardChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardChrome.swift; sourceTree = "<group>"; };
 		351F53C221B69731A024B864 /* AgentBoard.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AgentBoard.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3540D69FA92919FFD0494695 /* KanbanBoardMoveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanBoardMoveTests.swift; sourceTree = "<group>"; };
 		3736AF6A2D292014811DA50A /* ChatStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStore.swift; sourceTree = "<group>"; };
 		376B52FEC631A3F6F0383459 /* AttachmentModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentModelsTests.swift; sourceTree = "<group>"; };
 		39E1BE6A2B2B66CFAF5F4AC0 /* AudioRecorderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderService.swift; sourceTree = "<group>"; };
@@ -461,6 +465,7 @@
 				6C0ED2A504BC7E3CA18E4094 /* GitHubWorkServiceTests.swift */,
 				1F06E0C2FFE9CAC90D48662B /* HermesGatewayClientTests.swift */,
 				6A0D9C21BA312AB952D0E48B /* KanbanAssigneePickerTests.swift */,
+				3540D69FA92919FFD0494695 /* KanbanBoardMoveTests.swift */,
 				AE3F349D2B17FA90738CCDD5 /* KanbanModelsTests.swift */,
 				8562113DB3BC11316C4B4A50 /* LabelSchemaTests.swift */,
 				4637D9675B1C126E65C54970 /* MarkdownBlockParserTests.swift */,
@@ -487,6 +492,7 @@
 				A062681C1E251F786843C99C /* ChatCapability.swift */,
 				E20006E3DE0937110157F9D1 /* DemoFixtures.swift */,
 				043C2F07C2F7E6DFBC165E9A /* DomainModels.swift */,
+				275D2D504EF7D2F320157884 /* KanbanBoardMove.swift */,
 				0A55930915B4E8B29ECFC5DD /* KanbanModels.swift */,
 				AE2A97A08B0556443C6746EC /* LabelSchema.swift */,
 			);
@@ -1005,6 +1011,7 @@
 				D2F03218C8433B59598A04D5 /* GitHubWorkServiceTests.swift in Sources */,
 				62108DFBD6C8CF3265C4F8A5 /* HermesGatewayClientTests.swift in Sources */,
 				0B3C6DC24A36FE8A19357506 /* KanbanAssigneePickerTests.swift in Sources */,
+				9EAC1A69746A2ABCB376F952 /* KanbanBoardMoveTests.swift in Sources */,
 				DAAA6677EBC51F4C7796E505 /* KanbanModelsTests.swift in Sources */,
 				E9D09CAC0D952EE1295DFA60 /* LabelSchemaTests.swift in Sources */,
 				FD12EEBFD3C62E6F30A61E92 /* MarkdownBlockParserTests.swift in Sources */,
@@ -1049,6 +1056,7 @@
 				C6F5E2BE0559A438785BBCF8 /* FoundationExtras.swift in Sources */,
 				AB66AFF4128BA91808D24DB5 /* GitHubWorkService.swift in Sources */,
 				C23BCB5CF1615F000459D9E7 /* HermesGatewayClient.swift in Sources */,
+				C533F4D91531479ECC82DC9E /* KanbanBoardMove.swift in Sources */,
 				2DC5A28990E375C68274D794 /* KanbanCLIWriter.swift in Sources */,
 				248C1EBCB463381663C02F10 /* KanbanDataReading.swift in Sources */,
 				C32F8741DFBEF1D329D356E0 /* KanbanDataService.swift in Sources */,

--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		F374477884080894A1322DCE /* AppDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78ED2576E35E0964839427AD /* AppDestination.swift */; };
 		F38D2C6FF496E145B50F6E4F /* ChatStoreCapabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 101D840E678502545284009E /* ChatStoreCapabilityTests.swift */; };
 		F3D458595223FE83DD26EDC5 /* NukeUI in Frameworks */ = {isa = PBXBuildFile; productRef = AA403A62FC0CC3B341A2D00B /* NukeUI */; };
+		F48A4EE8A94BD511FD764029 /* AgentsStoreMoveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0419C766B0215E27D4A7FD5B /* AgentsStoreMoveTests.swift */; };
 		F595A9354548F0B6A8A8F2E3 /* AgentBoardCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; };
 		F78742DD742A458919E091C0 /* AgentBoardCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		FD03671AAB65C52CE827D3DA /* AgentBoardCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; };
@@ -257,6 +258,7 @@
 		0117F7D499C266663690C9B6 /* CompanionServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionServer.swift; sourceTree = "<group>"; };
 		035DCBF4EE40EE6A14CFE890 /* CompanionClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionClient.swift; sourceTree = "<group>"; };
 		03AD61915721952F19190205 /* LaunchSessionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchSessionSheet.swift; sourceTree = "<group>"; };
+		0419C766B0215E27D4A7FD5B /* AgentsStoreMoveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsStoreMoveTests.swift; sourceTree = "<group>"; };
 		043C2F07C2F7E6DFBC165E9A /* DomainModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainModels.swift; sourceTree = "<group>"; };
 		0551DF2CA889DD84A9EFF3B7 /* ChatStoreSlashCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStoreSlashCommandTests.swift; sourceTree = "<group>"; };
 		05A145F7A1A70B53DF066DBD /* SessionDetailSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDetailSheet.swift; sourceTree = "<group>"; };
@@ -445,6 +447,7 @@
 				7F57CF813491E81109CBBEE1 /* AccessibilityIdentifierTests.swift */,
 				C8ECD5A8D1C4F9C4099CBB9C /* AgentBoardCacheTests.swift */,
 				F5C500C7AF3B484DBB847E3A /* AgentsStoreCreateTaskTests.swift */,
+				0419C766B0215E27D4A7FD5B /* AgentsStoreMoveTests.swift */,
 				E84FB91863EEFC0DABE3E113 /* AgentsStoreSummariesTests.swift */,
 				6FCC4B5C12958567A1D6D69E /* AppDestinationTests.swift */,
 				376B52FEC631A3F6F0383459 /* AttachmentModelsTests.swift */,
@@ -991,6 +994,7 @@
 				D66940F899C73350695B1CDE /* AccessibilityIdentifierTests.swift in Sources */,
 				BAFAE9A54D7EB126DB951F33 /* AgentBoardCacheTests.swift in Sources */,
 				31F4BD470BD142ABB72D00E8 /* AgentsStoreCreateTaskTests.swift in Sources */,
+				F48A4EE8A94BD511FD764029 /* AgentsStoreMoveTests.swift in Sources */,
 				A66CDAEC61CF81C8BC905B61 /* AgentsStoreSummariesTests.swift in Sources */,
 				E931C3D8A3044AEA6C7F36BD /* AppDestinationTests.swift in Sources */,
 				96C502A1BD49F2AE81F03313 /* AttachmentModelsTests.swift in Sources */,

--- a/AgentBoardCore/Models/KanbanBoardMove.swift
+++ b/AgentBoardCore/Models/KanbanBoardMove.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Legal semantic transitions the agent board can request from `hermes kanban`.
+/// Hermes has no generic "set status" — only these named transitions exist, so
+/// a drag-and-drop drop must map onto one of them or be rejected.
+public enum KanbanBoardMove: Equatable, Sendable {
+    case promote // triage/todo → ready
+    case block // any non-terminal → blocked
+    case unblock // blocked → ready
+    case complete // any non-terminal → done
+
+    /// The legal move for a drag from `from` to `to`, or `nil` if the drop
+    /// is not a legal user-initiated transition.
+    public static func forDrag(from: KanbanStatus, to: KanbanStatus) -> KanbanBoardMove? {
+        guard from != to else { return nil }
+        guard from != .done else { return nil }
+
+        switch to {
+        case .done:
+            return .complete
+        case .blocked:
+            return .block
+        case .ready:
+            switch from {
+            case .blocked: return .unblock
+            case .triage, .todo: return .promote
+            default: return nil
+            }
+        default:
+            return nil
+        }
+    }
+
+    /// Human explanation for a rejected drop.
+    public static func rejectionMessage(from: KanbanStatus, to: KanbanStatus) -> String {
+        switch to {
+        case .running:
+            return "Tasks enter Running when an agent claims them."
+        case .triage, .todo, .archived:
+            return "Tasks can't be dragged to \(to.title)."
+        default:
+            if from == to {
+                return "Task is already in \(to.title)."
+            }
+            if from == .done {
+                return "Completed tasks can't be moved."
+            }
+            return "That move isn't supported."
+        }
+    }
+}

--- a/AgentBoardCore/Models/KanbanBoardMove.swift
+++ b/AgentBoardCore/Models/KanbanBoardMove.swift
@@ -32,20 +32,21 @@ public enum KanbanBoardMove: Equatable, Sendable {
     }
 
     /// Human explanation for a rejected drop.
-    public static func rejectionMessage(from: KanbanStatus, to: KanbanStatus) -> String {
-        switch to {
-        case .running:
-            return "Tasks enter Running when an agent claims them."
-        case .triage, .todo, .archived:
-            return "Tasks can't be dragged to \(to.title)."
-        default:
-            if from == to {
-                return "Task is already in \(to.title)."
-            }
-            if from == .done {
-                return "Completed tasks can't be moved."
-            }
-            return "That move isn't supported."
-        }
+public static func rejectionMessage(from: KanbanStatus, to: KanbanStatus) -> String {
+    if from == .done {
+        return "Completed tasks can't be moved."
+    }
+
+    if from == to {
+        return "Task is already in \(to.title)."
+    }
+
+    switch to {
+    case .running:
+        return "Tasks enter Running when an agent claims them."
+    case .triage, .todo, .archived:
+        return "Tasks can't be dragged to \(to.title)."
+    default:
+        return "That move isn't supported."
     }
 }

--- a/AgentBoardCore/Services/KanbanCLIWriter.swift
+++ b/AgentBoardCore/Services/KanbanCLIWriter.swift
@@ -8,6 +8,7 @@ public protocol KanbanCLIWriting: Sendable {
     func complete(taskID: String, summary: String) async throws
     func block(taskID: String, reason: String) async throws
     func unblock(taskID: String) async throws
+    func promote(taskID: String) async throws
     func archive(taskID: String) async throws
     func assign(taskID: String, assignee: String) async throws
 }
@@ -96,6 +97,13 @@ public actor KanbanCLIWriter: KanbanCLIWriting {
 
     public func unblock(taskID: String) async throws {
         let args = ["kanban", "unblock", taskID]
+        _ = try await runHermes(args)
+    }
+
+    // MARK: - Promote
+
+    public func promote(taskID: String) async throws {
+        let args = ["kanban", "promote", taskID]
         _ = try await runHermes(args)
     }
 

--- a/AgentBoardCore/Stores/AgentsStore.swift
+++ b/AgentBoardCore/Stores/AgentsStore.swift
@@ -213,11 +213,9 @@ lastFingerprint = fingerprint(tasks: tasks, summaries: summaries)
             statusMessage = "Moved \"\(task.title)\" to \(target.title)."
             errorMessage = nil
         } catch {
-            logger.error("Failed to move task: \(error.localizedDescription, privacy: .public)")
-            var reverted = updated
-            reverted.status = previousStatus
-            upsert(reverted)
-            lastFingerprint = fingerprint(tasks: tasks, summaries: summaries)
+logger.error("Failed to move task: \(error.localizedDescription, privacy: .public)")
+upsert(task)
+lastFingerprint = fingerprint(tasks: tasks, summaries: summaries)
             errorMessage = error.localizedDescription
         }
     }

--- a/AgentBoardCore/Stores/AgentsStore.swift
+++ b/AgentBoardCore/Stores/AgentsStore.swift
@@ -191,11 +191,14 @@ public final class AgentsStore {
             return
         }
 
-        var updated = task
-        updated.status = target
-        upsert(updated)
-        lastFingerprint = fingerprint(tasks: tasks, summaries: summaries)
-
+var updated = task
+updated.status = target
+if move == .complete {
+    updated.completedAt = .now
+    updated.result = "Completed from board"
+}
+upsert(updated)
+lastFingerprint = fingerprint(tasks: tasks, summaries: summaries)
         do {
             switch move {
             case .promote:

--- a/AgentBoardCore/Stores/AgentsStore.swift
+++ b/AgentBoardCore/Stores/AgentsStore.swift
@@ -176,6 +176,49 @@ public final class AgentsStore {
         }
     }
 
+    // MARK: - Board Drag-and-Drop
+
+    /// Move a task to `target` via drag-and-drop. Illegal drops (per
+    /// `KanbanBoardMove.forDrag`) never touch the CLI — they just surface a
+    /// rejection message. Legal drops update optimistically, then revert and
+    /// surface an error if the CLI write fails.
+    public func moveTask(id: String, to target: KanbanStatus) async {
+        guard let task = tasks.first(where: { $0.id == id }) else { return }
+        let previousStatus = task.status
+
+        guard let move = KanbanBoardMove.forDrag(from: previousStatus, to: target) else {
+            statusMessage = KanbanBoardMove.rejectionMessage(from: previousStatus, to: target)
+            return
+        }
+
+        var updated = task
+        updated.status = target
+        upsert(updated)
+        lastFingerprint = fingerprint(tasks: tasks, summaries: summaries)
+
+        do {
+            switch move {
+            case .promote:
+                try await cliWriter.promote(taskID: id)
+            case .block:
+                try await cliWriter.block(taskID: id, reason: "Blocked from board")
+            case .unblock:
+                try await cliWriter.unblock(taskID: id)
+            case .complete:
+                try await cliWriter.complete(taskID: id, summary: "Completed from board")
+            }
+            statusMessage = "Moved \"\(task.title)\" to \(target.title)."
+            errorMessage = nil
+        } catch {
+            logger.error("Failed to move task: \(error.localizedDescription, privacy: .public)")
+            var reverted = updated
+            reverted.status = previousStatus
+            upsert(reverted)
+            lastFingerprint = fingerprint(tasks: tasks, summaries: summaries)
+            errorMessage = error.localizedDescription
+        }
+    }
+
     public func archiveTask(id: String) async {
         do {
             try await cliWriter.archive(taskID: id)

--- a/AgentBoardTests/AgentsStoreCreateTaskTests.swift
+++ b/AgentBoardTests/AgentsStoreCreateTaskTests.swift
@@ -131,6 +131,7 @@ private struct SuccessWriter: KanbanCLIWriting {
     func complete(taskID _: String, summary _: String) async throws {}
     func block(taskID _: String, reason _: String) async throws {}
     func unblock(taskID _: String) async throws {}
+    func promote(taskID _: String) async throws {}
     func archive(taskID _: String) async throws {}
     func assign(taskID _: String, assignee _: String) async throws {}
 }
@@ -146,6 +147,7 @@ private struct FailingWriter: KanbanCLIWriting {
     func complete(taskID _: String, summary _: String) async throws {}
     func block(taskID _: String, reason _: String) async throws {}
     func unblock(taskID _: String) async throws {}
+    func promote(taskID _: String) async throws {}
     func archive(taskID _: String) async throws {}
     func assign(taskID _: String, assignee _: String) async throws {}
 }
@@ -174,6 +176,7 @@ private actor ToggleWriter: KanbanCLIWriting {
     func complete(taskID _: String, summary _: String) async throws {}
     func block(taskID _: String, reason _: String) async throws {}
     func unblock(taskID _: String) async throws {}
+    func promote(taskID _: String) async throws {}
     func archive(taskID _: String) async throws {}
     func assign(taskID _: String, assignee _: String) async throws {}
 }
@@ -192,6 +195,7 @@ private struct FixedIdWriter: KanbanCLIWriting {
     func complete(taskID _: String, summary _: String) async throws {}
     func block(taskID _: String, reason _: String) async throws {}
     func unblock(taskID _: String) async throws {}
+    func promote(taskID _: String) async throws {}
     func archive(taskID _: String) async throws {}
     func assign(taskID _: String, assignee _: String) async throws {}
 }
@@ -222,6 +226,7 @@ private actor SequencedSuccessWriter: KanbanCLIWriting {
     func complete(taskID _: String, summary _: String) async throws {}
     func block(taskID _: String, reason _: String) async throws {}
     func unblock(taskID _: String) async throws {}
+    func promote(taskID _: String) async throws {}
     func archive(taskID _: String) async throws {}
     func assign(taskID _: String, assignee _: String) async throws {}
 }

--- a/AgentBoardTests/AgentsStoreMoveTests.swift
+++ b/AgentBoardTests/AgentsStoreMoveTests.swift
@@ -1,0 +1,205 @@
+@testable import AgentBoardCore
+import Foundation
+import Testing
+
+/// Contract tests for `AgentsStore.moveTask`, the drag-and-drop entry point
+/// for the agent kanban board (issue #143). Hermes exposes only semantic
+/// transitions (promote/block/unblock/complete) — there is no generic
+/// set-status — so the store must map a drop onto the one legal CLI call,
+/// or reject it without ever touching the CLI.
+@Suite("AgentsStore.moveTask (issue #143)")
+@MainActor
+struct AgentsStoreMoveTests {
+    @Test func legalPromoteUpdatesStatusAndCallsWriter() async {
+        let writer = RecordingWriter(seedTask: makeTask(id: "t1", status: .todo))
+        let store = await makeStore(cliWriter: writer)
+
+        await store.moveTask(id: "t1", to: .ready)
+
+        #expect(store.tasks.first(where: { $0.id == "t1" })?.status == .ready)
+        let calls = await writer.calls
+        #expect(calls == [.promote(taskID: "t1")])
+        #expect(store.errorMessage == nil)
+    }
+
+    @Test func legalBlockUpdatesStatusAndCallsWriterWithReason() async {
+        let writer = RecordingWriter(seedTask: makeTask(id: "t1", status: .ready))
+        let store = await makeStore(cliWriter: writer)
+
+        await store.moveTask(id: "t1", to: .blocked)
+
+        #expect(store.tasks.first(where: { $0.id == "t1" })?.status == .blocked)
+        let calls = await writer.calls
+        #expect(calls == [.block(taskID: "t1", reason: "Blocked from board")])
+    }
+
+    @Test func legalUnblockUpdatesStatusAndCallsWriter() async {
+        let writer = RecordingWriter(seedTask: makeTask(id: "t1", status: .blocked))
+        let store = await makeStore(cliWriter: writer)
+
+        await store.moveTask(id: "t1", to: .ready)
+
+        #expect(store.tasks.first(where: { $0.id == "t1" })?.status == .ready)
+        let calls = await writer.calls
+        #expect(calls == [.unblock(taskID: "t1")])
+    }
+
+    @Test func legalCompleteUpdatesStatusAndCallsWriterWithSummary() async {
+        let writer = RecordingWriter(seedTask: makeTask(id: "t1", status: .running))
+        let store = await makeStore(cliWriter: writer)
+
+        await store.moveTask(id: "t1", to: .done)
+
+        #expect(store.tasks.first(where: { $0.id == "t1" })?.status == .done)
+        let calls = await writer.calls
+        #expect(calls == [.complete(taskID: "t1", summary: "Completed from board")])
+    }
+
+    @Test func writerFailureRevertsOptimisticUpdateAndSetsError() async {
+        let writer = FailingWriter(seedTask: makeTask(id: "t1", status: .todo), message: "hermes timed out")
+        let store = await makeStore(cliWriter: writer)
+
+        await store.moveTask(id: "t1", to: .ready)
+
+        #expect(store.tasks.first(where: { $0.id == "t1" })?.status == .todo)
+        #expect(store.errorMessage?.contains("hermes timed out") == true)
+    }
+
+    @Test func illegalDropNeverCallsWriterAndSetsRejectionMessage() async {
+        let writer = RecordingWriter(seedTask: makeTask(id: "t1", status: .todo))
+        let store = await makeStore(cliWriter: writer)
+
+        await store.moveTask(id: "t1", to: .running)
+
+        #expect(store.tasks.first(where: { $0.id == "t1" })?.status == .todo)
+        let calls = await writer.calls
+        #expect(calls.isEmpty)
+        #expect(store.statusMessage == "Tasks enter Running when an agent claims them.")
+    }
+
+    @Test func illegalSameColumnDropNeverCallsWriter() async {
+        let writer = RecordingWriter(seedTask: makeTask(id: "t1", status: .ready))
+        let store = await makeStore(cliWriter: writer)
+
+        await store.moveTask(id: "t1", to: .ready)
+
+        let calls = await writer.calls
+        #expect(calls.isEmpty)
+        #expect(store.statusMessage == "Task is already in Ready.")
+    }
+
+    @Test func unknownTaskIdIsANoOp() async {
+        let writer = RecordingWriter(seedTask: makeTask(id: "t1", status: .todo))
+        let store = await makeStore(cliWriter: writer)
+
+        await store.moveTask(id: "missing", to: .ready)
+
+        let calls = await writer.calls
+        #expect(calls.isEmpty)
+        #expect(store.tasks.count == 1)
+    }
+
+    // MARK: - Helpers
+
+    private func makeTask(id: String, status: KanbanStatus) -> KanbanTask {
+        KanbanTask(id: id, title: "Task \(id)", status: status)
+    }
+
+    /// Builds a store wired to `cliWriter` and seeds it with the writer's
+    /// `create()` response via the public `createTask` API (there is no
+    /// internal seam for injecting `tasks` directly).
+    private func makeStore(cliWriter: any KanbanCLIWriting) async -> AgentsStore {
+        let suffix = UUID().uuidString
+        let repo = SettingsRepository(
+            suiteName: "AgentsStoreMoveTests-\(suffix)",
+            serviceName: "AgentsStoreMoveTests-\(suffix)"
+        )
+        let settings = SettingsStore(repository: repo)
+        let store = AgentsStore(
+            kanbanData: KanbanDataService(databasePath: "/dev/null"),
+            cliWriter: cliWriter,
+            settingsStore: settings
+        )
+        await store.createTask(KanbanCreateDraft(title: "seed"))
+        store.errorMessage = nil
+        store.statusMessage = nil
+        return store
+    }
+}
+
+// MARK: - Test doubles
+
+/// Returns a fixed seed task from `create` and records every subsequent
+/// write call. Used to assert which CLI verb (if any) a drag maps onto.
+private actor RecordingWriter: KanbanCLIWriting {
+    enum Call: Equatable {
+        case complete(taskID: String, summary: String)
+        case block(taskID: String, reason: String)
+        case unblock(taskID: String)
+        case promote(taskID: String)
+    }
+
+    private let seedTask: KanbanTask
+    private(set) var calls: [Call] = []
+
+    init(seedTask: KanbanTask) {
+        self.seedTask = seedTask
+    }
+
+    func create(_: KanbanCreateDraft) async throws -> KanbanTask {
+        seedTask
+    }
+
+    func comment(taskID _: String, body _: String) async throws {}
+
+    func complete(taskID: String, summary: String) async throws {
+        calls.append(.complete(taskID: taskID, summary: summary))
+    }
+
+    func block(taskID: String, reason: String) async throws {
+        calls.append(.block(taskID: taskID, reason: reason))
+    }
+
+    func unblock(taskID: String) async throws {
+        calls.append(.unblock(taskID: taskID))
+    }
+
+    func promote(taskID: String) async throws {
+        calls.append(.promote(taskID: taskID))
+    }
+
+    func archive(taskID _: String) async throws {}
+    func assign(taskID _: String, assignee _: String) async throws {}
+}
+
+/// Seeds via `create`, then fails every subsequent write call. Used to
+/// verify the optimistic-update revert path.
+private struct FailingWriter: KanbanCLIWriting {
+    let seedTask: KanbanTask
+    let message: String
+
+    func create(_: KanbanCreateDraft) async throws -> KanbanTask {
+        seedTask
+    }
+
+    func comment(taskID _: String, body _: String) async throws {}
+
+    func complete(taskID _: String, summary _: String) async throws {
+        throw KanbanCLIWriter.WriteError.commandFailed(message)
+    }
+
+    func block(taskID _: String, reason _: String) async throws {
+        throw KanbanCLIWriter.WriteError.commandFailed(message)
+    }
+
+    func unblock(taskID _: String) async throws {
+        throw KanbanCLIWriter.WriteError.commandFailed(message)
+    }
+
+    func promote(taskID _: String) async throws {
+        throw KanbanCLIWriter.WriteError.commandFailed(message)
+    }
+
+    func archive(taskID _: String) async throws {}
+    func assign(taskID _: String, assignee _: String) async throws {}
+}

--- a/AgentBoardTests/KanbanBoardMoveTests.swift
+++ b/AgentBoardTests/KanbanBoardMoveTests.swift
@@ -1,0 +1,121 @@
+@testable import AgentBoardCore
+import Testing
+
+/// Full-matrix coverage of `KanbanBoardMove.forDrag`. Hermes only exposes
+/// semantic transitions (promote/block/unblock/complete) — there is no
+/// generic set-status, so every board column pair must map to exactly the
+/// move the CLI supports, or `nil` if the drop is illegal.
+@Suite("KanbanBoardMove")
+struct KanbanBoardMoveTests {
+    /// Key for a (from, to) column pair.
+    private struct Pair: Hashable {
+        let from: KanbanStatus
+        let to: KanbanStatus
+    }
+
+    /// Every legal (from, to) pair over `KanbanStatus.boardColumns` and the
+    /// move it maps to. Any pair absent from this table is expected to be
+    /// illegal (`forDrag` returns `nil`).
+    private static let expectedMoves: [Pair: KanbanBoardMove] = [
+        Pair(from: .triage, to: .ready): .promote,
+        Pair(from: .triage, to: .blocked): .block,
+        Pair(from: .triage, to: .done): .complete,
+        Pair(from: .todo, to: .ready): .promote,
+        Pair(from: .todo, to: .blocked): .block,
+        Pair(from: .todo, to: .done): .complete,
+        Pair(from: .ready, to: .blocked): .block,
+        Pair(from: .ready, to: .done): .complete,
+        Pair(from: .running, to: .blocked): .block,
+        Pair(from: .running, to: .done): .complete,
+        Pair(from: .blocked, to: .ready): .unblock,
+        Pair(from: .blocked, to: .done): .complete
+    ]
+
+    @Test func fullMatrixMatchesLegalTransitionTable() {
+        for from in KanbanStatus.boardColumns {
+            for to in KanbanStatus.boardColumns {
+                let expected = Self.expectedMoves[Pair(from: from, to: to)]
+                let actual = KanbanBoardMove.forDrag(from: from, to: to)
+                #expect(
+                    actual == expected,
+                    "from \(from) to \(to): expected \(String(describing: expected)), got \(String(describing: actual))"
+                )
+            }
+        }
+    }
+
+    // MARK: - Named cases
+
+    @Test func promoteFromTriageOrTodoToReady() {
+        #expect(KanbanBoardMove.forDrag(from: .triage, to: .ready) == .promote)
+        #expect(KanbanBoardMove.forDrag(from: .todo, to: .ready) == .promote)
+    }
+
+    @Test func unblockFromBlockedToReady() {
+        #expect(KanbanBoardMove.forDrag(from: .blocked, to: .ready) == .unblock)
+    }
+
+    @Test func blockFromAnyNonTerminalToBlocked() {
+        #expect(KanbanBoardMove.forDrag(from: .triage, to: .blocked) == .block)
+        #expect(KanbanBoardMove.forDrag(from: .todo, to: .blocked) == .block)
+        #expect(KanbanBoardMove.forDrag(from: .ready, to: .blocked) == .block)
+        #expect(KanbanBoardMove.forDrag(from: .running, to: .blocked) == .block)
+    }
+
+    @Test func completeFromAnyNonTerminalToDone() {
+        #expect(KanbanBoardMove.forDrag(from: .triage, to: .done) == .complete)
+        #expect(KanbanBoardMove.forDrag(from: .todo, to: .done) == .complete)
+        #expect(KanbanBoardMove.forDrag(from: .ready, to: .done) == .complete)
+        #expect(KanbanBoardMove.forDrag(from: .running, to: .done) == .complete)
+        #expect(KanbanBoardMove.forDrag(from: .blocked, to: .done) == .complete)
+    }
+
+    @Test func sameColumnDropIsIllegal() {
+        for status in KanbanStatus.boardColumns {
+            #expect(KanbanBoardMove.forDrag(from: status, to: status) == nil)
+        }
+    }
+
+    @Test func dropIntoRunningIsAlwaysIllegal() {
+        for status in KanbanStatus.boardColumns where status != .running {
+            #expect(KanbanBoardMove.forDrag(from: status, to: .running) == nil)
+        }
+    }
+
+    @Test func dropIntoTriageTodoOrArchivedIsAlwaysIllegal() {
+        for status in KanbanStatus.boardColumns {
+            #expect(KanbanBoardMove.forDrag(from: status, to: .triage) == nil)
+            #expect(KanbanBoardMove.forDrag(from: status, to: .todo) == nil)
+            #expect(KanbanBoardMove.forDrag(from: status, to: .archived) == nil)
+        }
+    }
+
+    @Test func doneIsTerminalAndNeverMovesAgain() {
+        for status in KanbanStatus.boardColumns {
+            #expect(KanbanBoardMove.forDrag(from: .done, to: status) == nil)
+        }
+    }
+
+    // MARK: - Rejection messages
+
+    @Test func rejectionMessageForRunningExplainsAgentClaim() {
+        #expect(
+            KanbanBoardMove.rejectionMessage(from: .todo, to: .running)
+                == "Tasks enter Running when an agent claims them."
+        )
+    }
+
+    @Test func rejectionMessageForSameColumnNamesTheColumn() {
+        #expect(
+            KanbanBoardMove.rejectionMessage(from: .ready, to: .ready)
+                == "Task is already in Ready."
+        )
+    }
+
+    @Test func rejectionMessageForDoneExplainsTerminalState() {
+        #expect(
+            KanbanBoardMove.rejectionMessage(from: .done, to: .blocked)
+                == "Completed tasks can't be moved."
+        )
+    }
+}

--- a/AgentBoardUI/Components/Attachments/VoiceViews.swift
+++ b/AgentBoardUI/Components/Attachments/VoiceViews.swift
@@ -204,18 +204,18 @@ struct VoicePlaybackView: View {
         do {
             if let localURL = attachment.payload.localURL {
                 try playback.togglePlayback(attachmentID: attachmentUUID, url: localURL)
-} else if let remoteURL = attachment.remoteURL {
-    let (tempURL, _) = try await URLSession.shared.download(from: remoteURL)
+            } else if let remoteURL = attachment.remoteURL {
+                let (tempURL, _) = try await URLSession.shared.download(from: remoteURL)
 
-    let cachedURL = FileManager.default.temporaryDirectory
-        .appendingPathComponent("voice-\(attachmentUUID.uuidString)-\(tempURL.lastPathComponent)")
-    if FileManager.default.fileExists(atPath: cachedURL.path) {
-        try? FileManager.default.removeItem(at: cachedURL)
-    }
-    try FileManager.default.moveItem(at: tempURL, to: cachedURL)
+                let cachedURL = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("voice-\(attachmentUUID.uuidString)-\(tempURL.lastPathComponent)")
+                if FileManager.default.fileExists(atPath: cachedURL.path) {
+                    try? FileManager.default.removeItem(at: cachedURL)
+                }
+                try FileManager.default.moveItem(at: tempURL, to: cachedURL)
 
-    try playback.togglePlayback(attachmentID: attachmentUUID, url: cachedURL)
-}
+                try playback.togglePlayback(attachmentID: attachmentUUID, url: cachedURL)
+            } else {
                 errorMessage = "No audio available"
             }
         } catch {

--- a/AgentBoardUI/Screens/AgentsScreen.swift
+++ b/AgentBoardUI/Screens/AgentsScreen.swift
@@ -1,5 +1,7 @@
 import AgentBoardCore
+import CoreTransferable
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct AgentsScreen: View {
     @Environment(AgentBoardAppModel.self) private var appModel
@@ -152,7 +154,11 @@ struct AgentsScreen: View {
                                             onLaunch: { launchTask = task }
                                         )
                                         .accessibilityIdentifier("kanban_cell_task_\(task.id)")
+                                        .draggable(KanbanTaskID(task.id))
                                     }
+                                }
+                                .dropDestination(for: KanbanTaskID.self) { ids, _ in
+                                    handleDrop(ids, to: status)
                                 }
                             }
                         }
@@ -203,6 +209,7 @@ struct AgentsScreen: View {
                                                 onLaunch: { launchTask = task }
                                             )
                                             .accessibilityIdentifier("kanban_cell_task_\(task.id)")
+                                            .draggable(KanbanTaskID(task.id))
                                         }
                                     }
                                     .padding(.bottom, 12)
@@ -217,6 +224,9 @@ struct AgentsScreen: View {
                             RoundedRectangle(cornerRadius: 14, style: .continuous)
                                 .stroke(NeuPalette.borderSoft, lineWidth: 1)
                         }
+                        .dropDestination(for: KanbanTaskID.self) { ids, _ in
+                            handleDrop(ids, to: status)
+                        }
                     }
                 }
                 .frame(minWidth: proxy.size.width, alignment: .topLeading)
@@ -224,6 +234,17 @@ struct AgentsScreen: View {
                 .padding(.bottom, 28)
             }
         }
+    }
+
+    /// Drops a dragged task onto `status`. `AgentsStore.moveTask` maps the
+    /// drop onto the one legal Hermes transition (or surfaces a rejection
+    /// message) — this just forwards the drag payload.
+    private func handleDrop(_ ids: [KanbanTaskID], to status: KanbanStatus) -> Bool {
+        guard let id = ids.first?.rawValue else { return false }
+        Task { @MainActor in
+            await appModel.agentsStore.moveTask(id: id, to: status)
+        }
+        return true
     }
 
     private func kanbanColumnHeader(status: KanbanStatus, count: Int) -> some View {
@@ -420,6 +441,20 @@ private struct KanbanTaskRow: View {
             Button("Cancel", role: .cancel) {}
                 .accessibilityIdentifier("kanban_alert_button_cancel")
         }
+    }
+}
+
+// MARK: - Drag Payload
+
+private struct KanbanTaskID: Codable, Hashable, Transferable {
+    let rawValue: String
+
+    init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    static var transferRepresentation: some TransferRepresentation {
+        CodableRepresentation(contentType: .plainText)
     }
 }
 

--- a/docs/superpowers/plans/2026-07-17-phase2-agent-kanban.md
+++ b/docs/superpowers/plans/2026-07-17-phase2-agent-kanban.md
@@ -1,0 +1,89 @@
+# Phase 2 — Agent Task Kanban Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the agent task board (AgentsScreen) to parity with the Work board: drag-and-drop between columns, offline SwiftData cache, and real per-agent session counts (issues #143, #144).
+
+**Architecture:** Two stacked PRs. Drag-and-drop mirrors WorkScreen's `Transferable` + `.draggable`/`.dropDestination` pattern, but Hermes is the write authority and its CLI exposes only **semantic transitions** — there is no generic "set status". Drops map through a legal-transition table; illegal drops (anything → running/triage, etc.) revert with an explanatory status message. The cache extends `AgentBoardCacheProtocol` (which ripples to `AgentBoardCache`, `NoopAgentBoardCache`, and test fakes). Session counts flow from `SessionsStore` into `AgentsStore` via `AgentBoardAppModel`, which already owns both.
+
+**Tech Stack:** Swift 6, SwiftUI, SwiftData, Swift Testing, xcodegen, SwiftLint.
+
+## Global Constraints
+
+Same as Phase 1 (see `2026-07-17-phase1-chat-completion.md`): strict concurrency, TDD, Swift Testing style, accessibility identifiers on every interactive element, all three schemes build, SwiftLint strict, full AgentBoardTests suite green per PR, `xcodegen generate` after adding files, local test command uses `-derivedDataPath ./DerivedData`.
+
+## Verified CLI ground truth (hermes kanban, 2026-07-17)
+
+Available transition verbs: `promote <id> [reason]` (todo/blocked → ready), `block <ids> [reason]`, `unblock <ids> [--reason]` (blocked/scheduled → ready), `complete <ids>` (→ done), `archive <id>`, `assign`. `running` is entered ONLY by an agent claiming a task (`claim`) — never by the UI. `KanbanCLIWriter` already wraps: create/comment/complete/block/unblock/archive/assign.
+
+---
+
+## PR E — Drag-and-drop on the agent board (#143)
+
+### Task E1: Legal-transition table (Core, pure + testable)
+
+**Files:** Create `AgentBoardCore/Models/KanbanBoardMove.swift`; test `AgentBoardTests/KanbanBoardMoveTests.swift` (new).
+
+**Interfaces:**
+```swift
+public enum KanbanBoardMove: Equatable, Sendable {
+    case promote          // triage/todo/blocked → ready (blocked uses unblock)
+    case block            // any non-terminal → blocked
+    case unblock          // blocked → ready
+    case complete         // any non-terminal → done
+
+    /// nil when the drop is not a legal user-initiated transition.
+    public static func forDrag(from: KanbanStatus, to: KanbanStatus) -> KanbanBoardMove?
+    /// Human explanation for a rejected drop (e.g. dragging into Running).
+    public static func rejectionMessage(from: KanbanStatus, to: KanbanStatus) -> String
+}
+```
+Mapping: `→ .done` = complete (from triage/todo/ready/running/blocked); `→ .blocked` = block (from triage/todo/ready/running); `blocked → .ready` = unblock; `triage/todo → .ready` = promote; same-column = nil; `→ .running` = nil ("Tasks enter Running when an agent claims them."); `→ .triage`/`→ .todo`/`→ .archived` = nil; `done → anything` = nil. Tests enumerate the full matrix (use two nested loops over `KanbanStatus.boardColumns` plus targeted assertions for the named cases).
+
+### Task E2: AgentsStore.moveTask + CLI wiring
+
+**Files:** Modify `AgentBoardCore/Stores/AgentsStore.swift`, `AgentBoardCore/Services/KanbanCLIWriter.swift` (add `promote(taskID:)` wrapping `hermes kanban promote <id> --json` if `--json` is supported, else plain; mirror the existing wrapper style); test `AgentBoardTests/AgentsStoreMoveTests.swift` (new) using whatever fake/mock pattern AgentsStore tests already use (read `AgentsStoreCreateTaskTests.swift` first — reuse its writer fake).
+
+**Interfaces:**
+```swift
+// AgentsStore
+public func moveTask(id: String, to target: KanbanStatus) async
+```
+Behavior: look up the task; compute `KanbanBoardMove.forDrag`; if nil set `statusMessage` to the rejection message and return. Otherwise optimistically update the local task's status, call the matching writer method (`complete(taskID:summary:"Completed from board")`, `block(taskID:reason:"Blocked from board")`, `unblock(taskID:)`, `promote(taskID:)`), and on throw revert the optimistic change and set an error message. Tests: legal move updates status + calls writer; writer failure reverts; illegal move never calls writer and sets the rejection message.
+
+### Task E3: Board DnD UI
+
+**Files:** Modify `AgentBoardUI/Screens/AgentsScreen.swift`. Mirror `WorkScreen.swift` exactly: a `private struct KanbanTaskID: Codable, Hashable, Transferable` (see `WorkItemID` at WorkScreen.swift:461), `.draggable(KanbanTaskID(task.id))` on cards in the wide-layout column ForEach (~line 199) AND the compact stacked layout (~line 148), `.dropDestination(for: KanbanTaskID.self)` on each column container calling `appModel.agentsStore.moveTask(id:to:)` in a Task. Keep existing context menus/sheets untouched. No new interactive elements without accessibility identifiers (the drop target itself needs none; cards already have ids).
+
+Gate: full suite, three schemes, SwiftLint. Branch `feat/issue-143-kanban-dnd`, commits `feat: legal-transition table for kanban board drags (#143)`, `feat: drag-and-drop between agent board columns (#143)` (E2+E3 may share the second commit if E3 is view-only).
+
+---
+
+## PR F — Kanban cache + real agent activity (#144), stacked on PR E
+
+### Task F1: Kanban tasks in the SwiftData cache
+
+**Files:** Modify `AgentBoardCore/Persistence/AgentBoardCacheProtocol.swift` (+2 requirements), `AgentBoardCore/Persistence/AgentBoardCache.swift` (new `CachedKanbanTaskRecord` @Model with ALL KanbanTask fields it round-trips — check `KanbanModels.swift` for the full field list and store complex sub-structures as JSON-encoded Data columns if needed; follow the existing record patterns), `AgentBoardCore/Persistence/NoopAgentBoardCache.swift`, plus every test fake that conforms to the protocol (grep `AgentBoardCacheProtocol` in AgentBoardTests). Test: extend `AgentBoardTests/AgentBoardCacheTests.swift` with a full-fidelity round-trip (every field asserted, including status/priority/assignee/timestamps — Phase 1 caught a silent field-drop here; don't repeat it).
+
+**Interfaces:**
+```swift
+func loadKanbanTasks() throws -> [KanbanTask]
+func replaceKanbanTasks(_ tasks: [KanbanTask]) throws
+```
+
+### Task F2: AgentsStore hydrates from cache
+
+**Files:** Modify `AgentBoardCore/Stores/AgentsStore.swift` (init gains `cache: any AgentBoardCacheProtocol`), `AgentBoardCore/Stores/AgentBoardAppModel.swift` (`makeLiveAppModel` passes the shared cache; `AgentsStore(settingsStore:)` call site), all AgentsStore test constructions. Behavior: `bootstrap()` loads cached tasks first (instant render), then refreshes from `KanbanDataService`; a successful refresh calls `replaceKanbanTasks`; a failed refresh (kanban.db missing) keeps cached tasks and sets a "showing cached tasks" status message instead of clearing the board. Tests: bootstrap renders cache before refresh completes; refresh failure retains cached tasks; successful refresh persists.
+
+### Task F3: Real activeSessionCount
+
+**Files:** Modify `AgentBoardCore/Stores/AgentsStore.swift` (`buildAgentSummaries(from:)` gains `sessionCounts: [String: Int]` parameter — the hard-coded `activeSessionCount: 0` at ~line 238 uses `sessionCounts[assignee] ?? 0`; add `public func updateActiveSessionCounts(_ counts: [String: Int])` that stores counts and rebuilds summaries), `AgentBoardCore/Stores/AgentBoardAppModel.swift` (after `sessionsStore.refresh()` in `refreshAll`/the refresh loop/companion event handling, derive counts from `sessionsStore.sessions` — inspect `AgentSession` in DomainModels.swift for the agent-name field and what marks a session active — and call `updateActiveSessionCounts`). Tests: extend `AgentsStoreSummariesTests.swift` — summaries reflect injected counts; unknown assignees default 0; AppModel-level derivation tested if the existing AppModel test fixtures allow (check `AgentBoardAppModel` testability — if it can't be constructed in tests, test the pure derivation via a static helper `AgentBoardAppModel.activeSessionCounts(from: [AgentSession]) -> [String: Int]`).
+
+Gate: full suite, three schemes, SwiftLint. Branch `feat/issue-144-kanban-cache-activity` (stacked on PR E), commits `feat: cache kanban tasks in SwiftData (#144)`, `feat: real per-agent session counts on the board rail (#144)`.
+
+---
+
+## Self-review notes
+- The spec's "drag between columns" is deliberately narrowed to legal Hermes transitions — the CLI has no generic set-status, and `running` is agent-claimed by design. Rejections surface a message rather than silently snapping back.
+- Protocol additions in F1 are the riskiest ripple (three conformers + fakes); the compiler enumerates them.
+- `KanbanCLIWriter.promote` is the only new CLI wrapper; verify its flags with `hermes kanban promote --help` before writing it (done — positional id + optional reason; `--json` flag exists).


### PR DESCRIPTION
Phase 2 PR E of `docs/superpowers/plans/2026-07-17-phase2-agent-kanban.md`. **Merge #153 first** — this branch carries the same one-commit compile hotfix (identical patch; it deduplicates on merge).

- New `KanbanBoardMove` legal-transition table: Hermes CLI has no generic set-status, so drags map to semantic verbs — promote (triage/todo→ready), unblock (blocked→ready), block, complete. Illegal drops (into Running/Triage/Todo/Archived, out of Done, same column) revert with an explanatory message; Running is agent-claimed by design.
- `AgentsStore.moveTask(id:to:)`: optimistic update → CLI write (`promote` wrapper added to `KanbanCLIWriter`) → revert + error on failure.
- `AgentsScreen` cards draggable in both layouts, columns are drop targets — mirrors the WorkScreen pattern.
- 452/452 tests (+20); all three schemes build; SwiftLint strict clean. Implemented by a Sonnet subagent, reviewed + verified here.

Known gap (follow-up filed): compact layout hides empty columns entirely, so they can't receive drops on iPhone.

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)