### PR TITLE
feat: kanban SwiftData cache + real per-agent session counts (#144)

### DIFF
--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		9781E0240F8A4C6FC3DC30B7 /* NativeSwiftUIInterfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5CC5206E88A59FBD80A856 /* NativeSwiftUIInterfaceTests.swift */; };
 		97BD3D8CCE198A034A5E0C2F /* AttachmentPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E3C09A95E37674D30B6072F /* AttachmentPicker.swift */; };
 		9A90C5EF45CA6630C7EA64CD /* SessionLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B1DC901AD1D60B3855D38 /* SessionLauncherTests.swift */; };
+		9D005EDAE8079475FA09FE67 /* AgentBoardAppModelActiveSessionCountsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E105E4FF286F13A9AB9E6E /* AgentBoardAppModelActiveSessionCountsTests.swift */; };
 		9EAAAF4FFBF10F8A576AF5BD /* SessionLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B7CE4C138A75D87781C1DB /* SessionLauncher.swift */; };
 		9EAC1A69746A2ABCB376F952 /* KanbanBoardMoveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3540D69FA92919FFD0494695 /* KanbanBoardMoveTests.swift */; };
 		A51107E477749B979572DD17 /* AttachmentModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D42E5CA1B251EA0284E8C6 /* AttachmentModels.swift */; };
@@ -313,6 +314,7 @@
 		5A9DDB4F3F626262EACA72A8 /* AudioPlaybackServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlaybackServiceTests.swift; sourceTree = "<group>"; };
 		5DE53DBCDB728D1E417AC4E5 /* ChatStreamCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStreamCoordinatorTests.swift; sourceTree = "<group>"; };
 		5F60733BA5BCAD5BD388E855 /* AgentBoardMobile.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AgentBoardMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		61E105E4FF286F13A9AB9E6E /* AgentBoardAppModelActiveSessionCountsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBoardAppModelActiveSessionCountsTests.swift; sourceTree = "<group>"; };
 		63376B7513D3E5CFE45372D6 /* BoardPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardPalette.swift; sourceTree = "<group>"; };
 		6350F1AD876CFC0042771A6F /* NoopAgentBoardCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoopAgentBoardCache.swift; sourceTree = "<group>"; };
 		651B64AF0921713BAE550D2D /* TaskDetailSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailSheet.swift; sourceTree = "<group>"; };
@@ -449,6 +451,7 @@
 			isa = PBXGroup;
 			children = (
 				7F57CF813491E81109CBBEE1 /* AccessibilityIdentifierTests.swift */,
+				61E105E4FF286F13A9AB9E6E /* AgentBoardAppModelActiveSessionCountsTests.swift */,
 				C8ECD5A8D1C4F9C4099CBB9C /* AgentBoardCacheTests.swift */,
 				E8CF0F5C192569919CF193BC /* AgentsStoreCacheTests.swift */,
 				F5C500C7AF3B484DBB847E3A /* AgentsStoreCreateTaskTests.swift */,
@@ -998,6 +1001,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D66940F899C73350695B1CDE /* AccessibilityIdentifierTests.swift in Sources */,
+				9D005EDAE8079475FA09FE67 /* AgentBoardAppModelActiveSessionCountsTests.swift in Sources */,
 				BAFAE9A54D7EB126DB951F33 /* AgentBoardCacheTests.swift in Sources */,
 				5DC0B92D03F399A54BFFE28F /* AgentsStoreCacheTests.swift in Sources */,
 				31F4BD470BD142ABB72D00E8 /* AgentsStoreCreateTaskTests.swift in Sources */,

--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		37F82839F098968527158CC9 /* EmbeddedTerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A978B41E9572538A1E74E5C /* EmbeddedTerminalView.swift */; };
 		38E1089316EEC57E444A6FB1 /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957114148477B05585A13D7C /* MockURLProtocol.swift */; };
 		3D5547FD2C8499B8C8FA087B /* AudioRecorderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E1BE6A2B2B66CFAF5F4AC0 /* AudioRecorderService.swift */; };
+		3EE1B666C90DC07CC4346BC0 /* AgentBoardCache+KanbanTasks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4A3C7FF45B9DFB948ABE9F /* AgentBoardCache+KanbanTasks.swift */; };
 		3FDBA88CC8E8D63388C757C6 /* ConfigBackupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9679A2004F1CFD39A588CC7 /* ConfigBackupService.swift */; };
 		41487A7506D835D9946C1B9E /* ChatScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FDDFF5030B377E6973E969 /* ChatScreen.swift */; };
 		44025BC27B4AC9D5100A392F /* ChatMessageList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F872D9728B5938D841130C /* ChatMessageList.swift */; };
@@ -60,6 +61,7 @@
 		58446795E6F62924439AD001 /* CompanionSQLiteStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56A44BC3ACA67014432FDD4 /* CompanionSQLiteStoreTests.swift */; };
 		593E56157C2853690F31D9F4 /* SessionTerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDFAB3DEE21BBA70FAF2EBD /* SessionTerminalView.swift */; };
 		5B810A52F3C78D394BE76608 /* SettingsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55C723CBBB22E568A7E3D63 /* SettingsRepository.swift */; };
+		5DC0B92D03F399A54BFFE28F /* AgentsStoreCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8CF0F5C192569919CF193BC /* AgentsStoreCacheTests.swift */; };
 		6140061EE8C8004E8BB033F2 /* AgentBoardMobileApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7442B7AA1CFE33776582C1 /* AgentBoardMobileApp.swift */; };
 		61D20F70FEBDECFDE252645F /* AgentBoardCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		62108DFBD6C8CF3265C4F8A5 /* HermesGatewayClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F06E0C2FFE9CAC90D48662B /* HermesGatewayClientTests.swift */; };
@@ -298,6 +300,7 @@
 		39E1BE6A2B2B66CFAF5F4AC0 /* AudioRecorderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderService.swift; sourceTree = "<group>"; };
 		3ADA8E5D658DD9FC115C700D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		3B9B576059ADDC3B5D219868 /* FoundationExtrasTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationExtrasTests.swift; sourceTree = "<group>"; };
+		3D4A3C7FF45B9DFB948ABE9F /* AgentBoardCache+KanbanTasks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AgentBoardCache+KanbanTasks.swift"; sourceTree = "<group>"; };
 		3E3C09A95E37674D30B6072F /* AttachmentPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentPicker.swift; sourceTree = "<group>"; };
 		3FEBA7BFDBBBF6316B340FAA /* VoiceViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceViews.swift; sourceTree = "<group>"; };
 		4542E208AACDF95595A0B0D4 /* AgentBoardDesignTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBoardDesignTheme.swift; sourceTree = "<group>"; };
@@ -374,6 +377,7 @@
 		E52428296B715E26DCC31E00 /* KanbanCLIWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanCLIWriter.swift; sourceTree = "<group>"; };
 		E5D0E8B7659AAF04AFAA20AD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		E84FB91863EEFC0DABE3E113 /* AgentsStoreSummariesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsStoreSummariesTests.swift; sourceTree = "<group>"; };
+		E8CF0F5C192569919CF193BC /* AgentsStoreCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsStoreCacheTests.swift; sourceTree = "<group>"; };
 		EA26177C115F337F0AC82395 /* SlashCommandHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandHandlerTests.swift; sourceTree = "<group>"; };
 		F31C11E46072F7E4A9FFADDB /* AttachmentInteractions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentInteractions.swift; sourceTree = "<group>"; };
 		F5C500C7AF3B484DBB847E3A /* AgentsStoreCreateTaskTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsStoreCreateTaskTests.swift; sourceTree = "<group>"; };
@@ -446,6 +450,7 @@
 			children = (
 				7F57CF813491E81109CBBEE1 /* AccessibilityIdentifierTests.swift */,
 				C8ECD5A8D1C4F9C4099CBB9C /* AgentBoardCacheTests.swift */,
+				E8CF0F5C192569919CF193BC /* AgentsStoreCacheTests.swift */,
 				F5C500C7AF3B484DBB847E3A /* AgentsStoreCreateTaskTests.swift */,
 				0419C766B0215E27D4A7FD5B /* AgentsStoreMoveTests.swift */,
 				E84FB91863EEFC0DABE3E113 /* AgentsStoreSummariesTests.swift */,
@@ -628,6 +633,7 @@
 			isa = PBXGroup;
 			children = (
 				3024AF0B4A66DE64BDB27E15 /* AgentBoardCache.swift */,
+				3D4A3C7FF45B9DFB948ABE9F /* AgentBoardCache+KanbanTasks.swift */,
 				D3A2A89ABC8C35C2FB32C909 /* AgentBoardCacheProtocol.swift */,
 				6350F1AD876CFC0042771A6F /* NoopAgentBoardCache.swift */,
 				A55C723CBBB22E568A7E3D63 /* SettingsRepository.swift */,
@@ -993,6 +999,7 @@
 			files = (
 				D66940F899C73350695B1CDE /* AccessibilityIdentifierTests.swift in Sources */,
 				BAFAE9A54D7EB126DB951F33 /* AgentBoardCacheTests.swift in Sources */,
+				5DC0B92D03F399A54BFFE28F /* AgentsStoreCacheTests.swift in Sources */,
 				31F4BD470BD142ABB72D00E8 /* AgentsStoreCreateTaskTests.swift in Sources */,
 				F48A4EE8A94BD511FD764029 /* AgentsStoreMoveTests.swift in Sources */,
 				A66CDAEC61CF81C8BC905B61 /* AgentsStoreSummariesTests.swift in Sources */,
@@ -1037,6 +1044,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F22F4D3D2D3D20A5B3DD6B20 /* AgentBoardAppModel.swift in Sources */,
+				3EE1B666C90DC07CC4346BC0 /* AgentBoardCache+KanbanTasks.swift in Sources */,
 				C03DE2AB570D615F55142A44 /* AgentBoardCache.swift in Sources */,
 				95B74484E3270FC9A0F596CE /* AgentBoardCacheProtocol.swift in Sources */,
 				30B2D9B7D1BFC77B6964A96C /* AgentBoardDesignTheme.swift in Sources */,

--- a/AgentBoardCore/Persistence/AgentBoardCache+KanbanTasks.swift
+++ b/AgentBoardCore/Persistence/AgentBoardCache+KanbanTasks.swift
@@ -1,0 +1,161 @@
+import Foundation
+import SwiftData
+
+@Model
+final class CachedKanbanTaskRecord {
+    @Attribute(.unique) var id: String
+    var title: String
+    var body: String?
+    var assignee: String?
+    var status: String
+    var priority: Int
+    var createdBy: String?
+    var createdAt: Date
+    var startedAt: Date?
+    var completedAt: Date?
+    var workspaceKind: String
+    var workspacePath: String?
+    var tenant: String?
+    var result: String?
+    /// Nil means `KanbanTask.skills == nil`; non-nil (possibly encoding `[]`)
+    /// means the task has a skills array. Keeps nil vs. empty distinct.
+    var skillsData: Data?
+
+    init(
+        id: String,
+        title: String,
+        body: String?,
+        assignee: String?,
+        status: String,
+        priority: Int,
+        createdBy: String?,
+        createdAt: Date,
+        startedAt: Date?,
+        completedAt: Date?,
+        workspaceKind: String,
+        workspacePath: String?,
+        tenant: String?,
+        result: String?,
+        skillsData: Data?
+    ) {
+        self.id = id
+        self.title = title
+        self.body = body
+        self.assignee = assignee
+        self.status = status
+        self.priority = priority
+        self.createdBy = createdBy
+        self.createdAt = createdAt
+        self.startedAt = startedAt
+        self.completedAt = completedAt
+        self.workspaceKind = workspaceKind
+        self.workspacePath = workspacePath
+        self.tenant = tenant
+        self.result = result
+        self.skillsData = skillsData
+    }
+
+    func update(from task: KanbanTask, skillsData: Data?) -> Bool {
+        var didChange = false
+        didChange = assignIfNeeded(self, \.title, to: task.title) || didChange
+        didChange = assignIfNeeded(self, \.body, to: task.body) || didChange
+        didChange = assignIfNeeded(self, \.assignee, to: task.assignee) || didChange
+        didChange = assignIfNeeded(self, \.status, to: task.status.rawValue) || didChange
+        didChange = assignIfNeeded(self, \.priority, to: task.priority) || didChange
+        didChange = assignIfNeeded(self, \.createdBy, to: task.createdBy) || didChange
+        didChange = assignIfNeeded(self, \.createdAt, to: task.createdAt) || didChange
+        didChange = assignIfNeeded(self, \.startedAt, to: task.startedAt) || didChange
+        didChange = assignIfNeeded(self, \.completedAt, to: task.completedAt) || didChange
+        didChange = assignIfNeeded(self, \.workspaceKind, to: task.workspaceKind.rawValue) || didChange
+        didChange = assignIfNeeded(self, \.workspacePath, to: task.workspacePath) || didChange
+        didChange = assignIfNeeded(self, \.tenant, to: task.tenant) || didChange
+        didChange = assignIfNeeded(self, \.result, to: task.result) || didChange
+        didChange = assignIfNeeded(self, \.skillsData, to: skillsData) || didChange
+        return didChange
+    }
+}
+
+extension AgentBoardCache {
+    public func loadKanbanTasks() throws -> [KanbanTask] {
+        let descriptor = FetchDescriptor<CachedKanbanTaskRecord>(
+            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+        )
+        return try context.fetch(descriptor).map { record in
+            KanbanTask(
+                id: record.id,
+                title: record.title,
+                body: record.body,
+                assignee: record.assignee,
+                status: KanbanStatus(rawValue: record.status) ?? .todo,
+                priority: record.priority,
+                createdBy: record.createdBy,
+                createdAt: record.createdAt,
+                startedAt: record.startedAt,
+                completedAt: record.completedAt,
+                workspaceKind: KanbanWorkspaceKind(rawValue: record.workspaceKind) ?? .scratch,
+                workspacePath: record.workspacePath,
+                tenant: record.tenant,
+                result: record.result,
+                skills: decodeOptionalStrings(record.skillsData)
+            )
+        }
+    }
+
+    public func replaceKanbanTasks(_ tasks: [KanbanTask]) throws {
+        let existing = try context.fetch(FetchDescriptor<CachedKanbanTaskRecord>())
+        let existingByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
+        var incomingIDs = Set<String>()
+        var didChange = false
+
+        for task in tasks {
+            incomingIDs.insert(task.id)
+            let skillsData = encodeOptionalStrings(task.skills)
+
+            if let record = existingByID[task.id] {
+                didChange = record.update(from: task, skillsData: skillsData) || didChange
+            } else {
+                context.insert(makeKanbanTaskRecord(task, skillsData: skillsData))
+                didChange = true
+            }
+        }
+
+        for record in existing where !incomingIDs.contains(record.id) {
+            context.delete(record)
+            didChange = true
+        }
+
+        if didChange {
+            try context.save()
+        }
+    }
+
+    private func makeKanbanTaskRecord(_ task: KanbanTask, skillsData: Data?) -> CachedKanbanTaskRecord {
+        CachedKanbanTaskRecord(
+            id: task.id,
+            title: task.title,
+            body: task.body,
+            assignee: task.assignee,
+            status: task.status.rawValue,
+            priority: task.priority,
+            createdBy: task.createdBy,
+            createdAt: task.createdAt,
+            startedAt: task.startedAt,
+            completedAt: task.completedAt,
+            workspaceKind: task.workspaceKind.rawValue,
+            workspacePath: task.workspacePath,
+            tenant: task.tenant,
+            result: task.result,
+            skillsData: skillsData
+        )
+    }
+
+    fileprivate func encodeOptionalStrings(_ values: [String]?) -> Data? {
+        guard let values else { return nil }
+        return try? encoder.encode(values)
+    }
+
+    fileprivate func decodeOptionalStrings(_ data: Data?) -> [String]? {
+        guard let data else { return nil }
+        return try? decoder.decode([String].self, from: data)
+    }
+}

--- a/AgentBoardCore/Persistence/AgentBoardCache.swift
+++ b/AgentBoardCore/Persistence/AgentBoardCache.swift
@@ -228,7 +228,7 @@ private final class CachedAgentRecord {
     }
 }
 
-private func assignIfNeeded<Record: AnyObject, Value: Equatable>(
+func assignIfNeeded<Record: AnyObject, Value: Equatable>(
     _ record: Record,
     _ keyPath: ReferenceWritableKeyPath<Record, Value>,
     to value: Value
@@ -240,12 +240,12 @@ private func assignIfNeeded<Record: AnyObject, Value: Equatable>(
 
 @MainActor
 public final class AgentBoardCache {
-    private let encoder = JSONEncoder()
-    private let decoder = JSONDecoder()
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
 
     public let modelContainer: ModelContainer
 
-    private var context: ModelContext {
+    var context: ModelContext {
         modelContainer.mainContext
     }
 
@@ -257,6 +257,7 @@ public final class AgentBoardCache {
             CachedWorkItemRecord.self,
             CachedSessionRecord.self,
             CachedAgentRecord.self,
+            CachedKanbanTaskRecord.self,
             configurations: configuration
         )
     }

--- a/AgentBoardCore/Persistence/AgentBoardCacheProtocol.swift
+++ b/AgentBoardCore/Persistence/AgentBoardCacheProtocol.swift
@@ -26,4 +26,9 @@ public protocol AgentBoardCacheProtocol: SessionsCacheStoring, Sendable {
     // loadSessions/replaceSessions are inherited from SessionsCacheStoring.
     func loadAgentSummaries() throws -> [AgentSummary]
     func replaceAgentSummaries(_ agents: [AgentSummary]) throws
+
+    // MARK: - Kanban tasks (AgentsStore)
+
+    func loadKanbanTasks() throws -> [KanbanTask]
+    func replaceKanbanTasks(_ tasks: [KanbanTask]) throws
 }

--- a/AgentBoardCore/Persistence/NoopAgentBoardCache.swift
+++ b/AgentBoardCore/Persistence/NoopAgentBoardCache.swift
@@ -37,4 +37,10 @@ public final class NoopAgentBoardCache: AgentBoardCacheProtocol {
     }
 
     public func replaceAgentSummaries(_: [AgentSummary]) throws {}
+
+    public func loadKanbanTasks() throws -> [KanbanTask] {
+        []
+    }
+
+    public func replaceKanbanTasks(_: [KanbanTask]) throws {}
 }

--- a/AgentBoardCore/Stores/AgentBoardAppModel.swift
+++ b/AgentBoardCore/Stores/AgentBoardAppModel.swift
@@ -54,6 +54,10 @@ public final class AgentBoardAppModel {
         await workStore.bootstrap()
         await agentsStore.bootstrap()
         await sessionsStore.bootstrap()
+        agentsStore.updateActiveSessionCounts(Self.activeSessionCounts(
+            from: sessionsStore.sessions,
+            tasks: agentsStore.tasks
+        ))
 
         didBootstrap = true
         isBootstrapping = false
@@ -69,6 +73,10 @@ public final class AgentBoardAppModel {
         await workStore.refresh()
         await agentsStore.refresh()
         await sessionsStore.refresh()
+        agentsStore.updateActiveSessionCounts(Self.activeSessionCounts(
+            from: sessionsStore.sessions,
+            tasks: agentsStore.tasks
+        ))
     }
 
     public func saveSettingsAndReconnect() async {
@@ -146,6 +154,10 @@ public final class AgentBoardAppModel {
                 await self.workStore.refresh()
                 await self.agentsStore.refresh()
                 await self.sessionsStore.refresh()
+                self.agentsStore.updateActiveSessionCounts(Self.activeSessionCounts(
+                    from: self.sessionsStore.sessions,
+                    tasks: self.agentsStore.tasks
+                ))
             }
         }
     }
@@ -153,11 +165,45 @@ public final class AgentBoardAppModel {
     private func handle(event: CompanionEvent) async {
         statusMessage = "Companion update: \(event.kind.rawValue)"
         await sessionsStore.handle(event: event.kind)
+        agentsStore.updateActiveSessionCounts(Self.activeSessionCounts(
+            from: sessionsStore.sessions,
+            tasks: agentsStore.tasks
+        ))
 
         // Route conversation sync events to ChatStore for cross-device sync
         if event.kind == .conversationsChanged {
             await chatStore.refreshConversationsFromCompanion()
         }
+    }
+
+    // MARK: - Session Counts
+
+    /// Derive per-agent active session counts by joining each session's
+    /// `linkedTaskID` to the kanban task it references, then keying by that
+    /// task's (trimmed) assignee — the same namespace `AgentsStore` groups
+    /// tasks by. `source` (machine name) and `model` (tool name, e.g. "Codex")
+    /// are NOT agent identity in this sense, so they can't be used directly;
+    /// the task assignee is the only field session and task share meaning
+    /// for. "Active" means the session's status is `.running`. Sessions with
+    /// no `linkedTaskID`, or whose linked task has no assignee, contribute to
+    /// no agent's count.
+    nonisolated static func activeSessionCounts(
+        from sessions: [AgentSession],
+        tasks: [KanbanTask]
+    ) -> [String: Int] {
+        let assigneeByTaskID = Dictionary(
+            uniqueKeysWithValues: tasks.compactMap { task -> (String, String)? in
+                guard let assignee = task.assignee?.trimmedOrNil else { return nil }
+                return (task.id, assignee)
+            }
+        )
+
+        var counts: [String: Int] = [:]
+        for session in sessions where session.status == .running {
+            guard let taskID = session.linkedTaskID, let assignee = assigneeByTaskID[taskID] else { continue }
+            counts[assignee, default: 0] += 1
+        }
+        return counts
     }
 }
 

--- a/AgentBoardCore/Stores/AgentBoardAppModel.swift
+++ b/AgentBoardCore/Stores/AgentBoardAppModel.swift
@@ -196,7 +196,7 @@ public enum AgentBoardBootstrap {
             cache: cache,
             settingsStore: settingsStore
         )
-        let agentsStore = AgentsStore(settingsStore: settingsStore)
+        let agentsStore = AgentsStore(cache: cache, settingsStore: settingsStore)
         let sessionsStore = SessionsStore(
             companionClient: companionClient,
             cache: cache,

--- a/AgentBoardCore/Stores/AgentsStore.swift
+++ b/AgentBoardCore/Stores/AgentsStore.swift
@@ -8,6 +8,7 @@ public final class AgentsStore {
     private let logger = Logger(subsystem: "com.agentboard.modern", category: "AgentsStore")
     private let kanbanData: any KanbanDataReading
     private let cliWriter: any KanbanCLIWriting
+    private let cache: any AgentBoardCacheProtocol
     private let settingsStore: SettingsStore
 
     public private(set) var tasks: [KanbanTask] = []
@@ -22,10 +23,12 @@ public final class AgentsStore {
     public init(
         kanbanData: any KanbanDataReading = KanbanDataService(),
         cliWriter: any KanbanCLIWriting = KanbanCLIWriter(),
+        cache: any AgentBoardCacheProtocol,
         settingsStore: SettingsStore
     ) {
         self.kanbanData = kanbanData
         self.cliWriter = cliWriter
+        self.cache = cache
         self.settingsStore = settingsStore
     }
 
@@ -56,7 +59,19 @@ public final class AgentsStore {
     public func bootstrap() async {
         guard !didBootstrap else { return }
 
-        // Always refresh from kanban.db — no cache layer for kanban tasks yet.
+        // Load the cache first so the board renders instantly, then refresh
+        // from kanban.db for the live snapshot.
+        do {
+            let cachedTasks = try cache.loadKanbanTasks()
+            if !cachedTasks.isEmpty {
+                tasks = cachedTasks
+                summaries = Self.buildAgentSummaries(from: tasks)
+                lastFingerprint = fingerprint(tasks: tasks, summaries: summaries)
+            }
+        } catch {
+            logger.error("Failed to load kanban cache: \(error.localizedDescription, privacy: .public)")
+        }
+
         await refresh()
         didBootstrap = true
     }
@@ -80,8 +95,14 @@ public final class AgentsStore {
                 tasks = freshTasks
                 summaries = freshSummaries
                 lastFingerprint = newFingerprint
+
+                do {
+                    try cache.replaceKanbanTasks(tasks)
+                } catch {
+                    logger.error("Failed to persist kanban cache: \(error.localizedDescription, privacy: .public)")
+                }
             }
-            // Data unchanged — skip SwiftUI invalidation
+            // Data unchanged — skip SwiftUI invalidation and the cache write
 
             errorMessage = nil
             if tasks.isEmpty {
@@ -91,8 +112,11 @@ public final class AgentsStore {
             }
         } catch {
             logger.error("Failed to refresh kanban: \(error.localizedDescription, privacy: .public)")
+            // Keep any cached/previous tasks visible rather than clearing the board.
             if tasks.isEmpty {
                 errorMessage = error.localizedDescription
+            } else {
+                statusMessage = "Showing cached tasks — kanban refresh failed."
             }
         }
 

--- a/AgentBoardCore/Stores/AgentsStore.swift
+++ b/AgentBoardCore/Stores/AgentsStore.swift
@@ -19,6 +19,7 @@ public final class AgentsStore {
 
     private var didBootstrap = false
     private var lastFingerprint: String = ""
+    private var sessionCounts: [String: Int] = [:]
 
     public init(
         kanbanData: any KanbanDataReading = KanbanDataService(),
@@ -65,7 +66,7 @@ public final class AgentsStore {
             let cachedTasks = try cache.loadKanbanTasks()
             if !cachedTasks.isEmpty {
                 tasks = cachedTasks
-                summaries = Self.buildAgentSummaries(from: tasks)
+                summaries = Self.buildAgentSummaries(from: tasks, sessionCounts: sessionCounts)
                 lastFingerprint = fingerprint(tasks: tasks, summaries: summaries)
             }
         } catch {
@@ -88,7 +89,7 @@ public final class AgentsStore {
 
             // Build pseudo agent summaries from task assignees (companion still
             // handles real agent health / session data separately)
-            let freshSummaries = Self.buildAgentSummaries(from: freshTasks)
+            let freshSummaries = Self.buildAgentSummaries(from: freshTasks, sessionCounts: sessionCounts)
 
             let newFingerprint = fingerprint(tasks: freshTasks, summaries: freshSummaries)
             if newFingerprint != lastFingerprint {
@@ -121,6 +122,16 @@ public final class AgentsStore {
         }
 
         isLoading = false
+    }
+
+    // MARK: - Session Counts
+
+    /// Store real per-agent active session counts (from `SessionsStore`, via
+    /// `AgentBoardAppModel`) and rebuild summaries so the rail reflects them.
+    public func updateActiveSessionCounts(_ counts: [String: Int]) {
+        sessionCounts = counts
+        summaries = Self.buildAgentSummaries(from: tasks, sessionCounts: sessionCounts)
+        lastFingerprint = fingerprint(tasks: tasks, summaries: summaries)
     }
 
     // MARK: - Create Task
@@ -284,9 +295,16 @@ public final class AgentsStore {
     }
 
     /// Build lightweight agent summaries from task assignees.
-    /// The companion service still owns actual agent health / session data.
+    /// The companion service still owns actual agent health / session data,
+    /// except for `activeSessionCount`, which comes from `sessionCounts`
+    /// (keyed by the same trimmed-assignee string used to group tasks — see
+    /// `AgentBoardAppModel.activeSessionCounts(from:tasks:)`). An assignee
+    /// with no entry in `sessionCounts` defaults to 0.
     /// Internal so the kanban picker data source can be unit tested directly.
-    nonisolated static func buildAgentSummaries(from tasks: [KanbanTask]) -> [AgentSummary] {
+    nonisolated static func buildAgentSummaries(
+        from tasks: [KanbanTask],
+        sessionCounts: [String: Int]
+    ) -> [AgentSummary] {
         let assignees = Set(tasks.compactMap { $0.assignee?.trimmedOrNil })
 
         return assignees.map { name in
@@ -302,7 +320,7 @@ public final class AgentsStore {
                 name: name,
                 health: activeCount > 0 ? .online : .idle,
                 activeTaskCount: activeCount,
-                activeSessionCount: 0,
+                activeSessionCount: sessionCounts[name] ?? 0,
                 recentActivity: recentTask?.title ?? "No recent activity",
                 updatedAt: recentTask?.createdAt ?? .now
             )

--- a/AgentBoardCore/Stores/AgentsStore.swift
+++ b/AgentBoardCore/Stores/AgentsStore.swift
@@ -117,6 +117,7 @@ public final class AgentsStore {
             if tasks.isEmpty {
                 errorMessage = error.localizedDescription
             } else {
+                errorMessage = nil
                 statusMessage = "Showing cached tasks — kanban refresh failed."
             }
         }

--- a/AgentBoardTests/AgentBoardAppModelActiveSessionCountsTests.swift
+++ b/AgentBoardTests/AgentBoardAppModelActiveSessionCountsTests.swift
@@ -1,0 +1,105 @@
+@testable import AgentBoardCore
+import Foundation
+import Testing
+
+/// Contract tests for `AgentBoardAppModel.activeSessionCounts(from:tasks:)`
+/// (issue #144). `AgentSession` has no agent-name field of its own — `source`
+/// is the host machine name and `model` is the coding-tool name (Codex,
+/// Claude, ...), neither of which shares a namespace with `KanbanTask
+/// .assignee` (e.g. "daneel", "quentin"). The only structurally valid join is
+/// `session.linkedTaskID -> KanbanTask.id -> .assignee`, so these tests
+/// exercise that join directly rather than `AgentBoardAppModel`, which needs
+/// a full set of live stores to construct.
+@Suite("AgentBoardAppModel.activeSessionCounts (issue #144)")
+struct AgentBoardAppModelActiveSessionCountsTests {
+    @Test func countsRunningSessionsByLinkedTaskAssignee() {
+        let tasks = [makeTask(id: "task-1", assignee: "daneel")]
+        let sessions = [
+            makeSession(id: "s1", status: .running, linkedTaskID: "task-1"),
+            makeSession(id: "s2", status: .running, linkedTaskID: "task-1")
+        ]
+
+        let counts = AgentBoardAppModel.activeSessionCounts(from: sessions, tasks: tasks)
+
+        #expect(counts["daneel"] == 2)
+    }
+
+    @Test func onlyRunningSessionsCount() {
+        let tasks = [makeTask(id: "task-1", assignee: "daneel")]
+        let sessions = [
+            makeSession(id: "s1", status: .running, linkedTaskID: "task-1"),
+            makeSession(id: "s2", status: .idle, linkedTaskID: "task-1"),
+            makeSession(id: "s3", status: .stopped, linkedTaskID: "task-1")
+        ]
+
+        let counts = AgentBoardAppModel.activeSessionCounts(from: sessions, tasks: tasks)
+
+        #expect(counts["daneel"] == 1)
+    }
+
+    @Test func sessionsWithNoLinkedTaskContributeToNoCount() {
+        let sessions = [makeSession(id: "s1", status: .running, linkedTaskID: nil)]
+
+        let counts = AgentBoardAppModel.activeSessionCounts(from: sessions, tasks: [])
+
+        #expect(counts.isEmpty)
+    }
+
+    @Test func sessionLinkedToUnknownTaskIdIsIgnored() {
+        let tasks = [makeTask(id: "task-1", assignee: "daneel")]
+        let sessions = [makeSession(id: "s1", status: .running, linkedTaskID: "does-not-exist")]
+
+        let counts = AgentBoardAppModel.activeSessionCounts(from: sessions, tasks: tasks)
+
+        #expect(counts.isEmpty)
+    }
+
+    @Test func linkedTaskWithNilAssigneeContributesToNoCount() {
+        let tasks = [makeTask(id: "task-1", assignee: nil)]
+        let sessions = [makeSession(id: "s1", status: .running, linkedTaskID: "task-1")]
+
+        let counts = AgentBoardAppModel.activeSessionCounts(from: sessions, tasks: tasks)
+
+        #expect(counts.isEmpty)
+    }
+
+    @Test func keysByTrimmedAssigneeMatchingAgentsStoreNamespace() {
+        let tasks = [makeTask(id: "task-1", assignee: "  daneel  ")]
+        let sessions = [makeSession(id: "s1", status: .running, linkedTaskID: "task-1")]
+
+        let counts = AgentBoardAppModel.activeSessionCounts(from: sessions, tasks: tasks)
+
+        #expect(counts["daneel"] == 1)
+    }
+
+    @Test func distinctAgentsCountedSeparately() {
+        let tasks = [
+            makeTask(id: "task-1", assignee: "daneel"),
+            makeTask(id: "task-2", assignee: "quentin")
+        ]
+        let sessions = [
+            makeSession(id: "s1", status: .running, linkedTaskID: "task-1"),
+            makeSession(id: "s2", status: .running, linkedTaskID: "task-2"),
+            makeSession(id: "s3", status: .running, linkedTaskID: "task-2")
+        ]
+
+        let counts = AgentBoardAppModel.activeSessionCounts(from: sessions, tasks: tasks)
+
+        #expect(counts["daneel"] == 1)
+        #expect(counts["quentin"] == 2)
+    }
+
+    // MARK: - Helpers
+
+    private func makeTask(id: String, assignee: String?) -> KanbanTask {
+        KanbanTask(id: id, title: "Task \(id)", assignee: assignee)
+    }
+
+    private func makeSession(
+        id: String,
+        status: AgentSessionStatus,
+        linkedTaskID: String?
+    ) -> AgentSession {
+        AgentSession(id: id, source: "Test Machine", status: status, linkedTaskID: linkedTaskID)
+    }
+}

--- a/AgentBoardTests/AgentBoardCacheTests.swift
+++ b/AgentBoardTests/AgentBoardCacheTests.swift
@@ -264,4 +264,104 @@ struct AgentBoardCacheTests {
         #expect(loaded[0].activeTaskCount == 3)
         #expect(loaded[0].recentActivity == "Implementing tests.")
     }
+
+    // MARK: - Kanban Tasks
+
+    @Test func kanbanTaskRoundTripPreservesEveryField() throws {
+        let cache = try AgentBoardCache(inMemory: true)
+        let task = KanbanTask(
+            id: "task-1",
+            title: "Ship the cache",
+            body: "Some body text",
+            assignee: "daneel",
+            status: .blocked,
+            priority: 2,
+            createdBy: "quentin",
+            createdAt: Date(timeIntervalSinceReferenceDate: 100),
+            startedAt: Date(timeIntervalSinceReferenceDate: 200),
+            completedAt: Date(timeIntervalSinceReferenceDate: 300),
+            workspaceKind: .worktree,
+            workspacePath: "/tmp/worktree",
+            tenant: "tenant-a",
+            result: "All good",
+            skills: ["swift", "testing"]
+        )
+
+        try cache.replaceKanbanTasks([task])
+
+        let loaded = try #require(cache.loadKanbanTasks().first)
+        #expect(loaded.id == task.id)
+        #expect(loaded.title == task.title)
+        #expect(loaded.body == task.body)
+        #expect(loaded.assignee == task.assignee)
+        #expect(loaded.status == task.status)
+        #expect(loaded.priority == task.priority)
+        #expect(loaded.createdBy == task.createdBy)
+        #expect(loaded.createdAt == task.createdAt)
+        #expect(loaded.startedAt == task.startedAt)
+        #expect(loaded.completedAt == task.completedAt)
+        #expect(loaded.workspaceKind == task.workspaceKind)
+        #expect(loaded.workspacePath == task.workspacePath)
+        #expect(loaded.tenant == task.tenant)
+        #expect(loaded.result == task.result)
+        #expect(loaded.skills == task.skills)
+    }
+
+    @Test func kanbanTaskWithNilSkillsRoundTripsAsNil() throws {
+        // Distinguishing nil from [] matters: nil means "unknown", [] means
+        // "known to have no skills". A naive Data-column encoding could
+        // silently collapse both to the same on-disk representation.
+        let cache = try AgentBoardCache(inMemory: true)
+        let task = KanbanTask(id: "task-2", title: "No skills recorded", skills: nil)
+
+        try cache.replaceKanbanTasks([task])
+
+        let loaded = try #require(cache.loadKanbanTasks().first)
+        #expect(loaded.skills == nil)
+    }
+
+    @Test func kanbanTaskWithEmptySkillsRoundTripsAsEmptyArrayNotNil() throws {
+        let cache = try AgentBoardCache(inMemory: true)
+        let task = KanbanTask(id: "task-3", title: "Empty skills array", skills: [])
+
+        try cache.replaceKanbanTasks([task])
+
+        let loaded = try #require(cache.loadKanbanTasks().first)
+        #expect(loaded.skills != nil)
+        #expect(loaded.skills?.isEmpty == true)
+    }
+
+    @Test func replaceKanbanTasksClearsExisting() throws {
+        let cache = try AgentBoardCache(inMemory: true)
+        let task1 = KanbanTask(id: "task-1", title: "One")
+        let task2 = KanbanTask(id: "task-2", title: "Two")
+
+        try cache.replaceKanbanTasks([task1, task2])
+        try cache.replaceKanbanTasks([task1])
+
+        let loaded = try cache.loadKanbanTasks()
+        #expect(loaded.count == 1)
+        #expect(loaded[0].id == "task-1")
+    }
+
+    @Test func replaceKanbanTasksUpdatesExistingRecord() throws {
+        let cache = try AgentBoardCache(inMemory: true)
+        let original = KanbanTask(id: "task-1", title: "Original", status: .todo)
+        let updated = KanbanTask(
+            id: "task-1",
+            title: "Updated",
+            assignee: "daneel",
+            status: .ready,
+            priority: 1
+        )
+
+        try cache.replaceKanbanTasks([original])
+        try cache.replaceKanbanTasks([updated])
+
+        let loaded = try #require(cache.loadKanbanTasks().first)
+        #expect(loaded.title == "Updated")
+        #expect(loaded.assignee == "daneel")
+        #expect(loaded.status == .ready)
+        #expect(loaded.priority == 1)
+    }
 }

--- a/AgentBoardTests/AgentsStoreCacheTests.swift
+++ b/AgentBoardTests/AgentsStoreCacheTests.swift
@@ -1,0 +1,137 @@
+@testable import AgentBoardCore
+import Foundation
+import Testing
+
+/// Contract tests for the SwiftData cache layer added to `AgentsStore` for
+/// offline kanban support (issue #144). Mirrors `WorkStore`'s cache contract:
+/// `bootstrap()` renders whatever is cached before the live refresh
+/// resolves, a successful refresh persists the fresh snapshot, and a failed
+/// refresh keeps the cached tasks visible instead of clearing the board.
+@Suite("AgentsStore cache hydration (issue #144)")
+@MainActor
+struct AgentsStoreCacheTests {
+    @Test func bootstrapRendersCachedTasksBeforeAnySuccessfulRefresh() async throws {
+        // kanbanData points at /dev/null, so the live refresh always fails —
+        // isolating what bootstrap() does with the cache on its own.
+        let cache = try AgentBoardCache(inMemory: true)
+        let cachedTask = KanbanTask(id: "cached-1", title: "From cache", status: .todo)
+        try cache.replaceKanbanTasks([cachedTask])
+
+        let store = makeStore(kanbanData: KanbanDataService(databasePath: "/dev/null"), cache: cache)
+
+        await store.bootstrap()
+
+        #expect(store.tasks.map(\.id) == ["cached-1"])
+    }
+
+    @Test func failedRefreshRetainsCachedTasksAndSetsStatusMessage() async throws {
+        let cache = try AgentBoardCache(inMemory: true)
+        let cachedTask = KanbanTask(id: "cached-1", title: "From cache", status: .todo)
+        try cache.replaceKanbanTasks([cachedTask])
+
+        let store = makeStore(kanbanData: FakeKanbanData(mode: .failure), cache: cache)
+
+        await store.bootstrap()
+
+        #expect(store.tasks.map(\.id) == ["cached-1"])
+        #expect(store.statusMessage == "Showing cached tasks — kanban refresh failed.")
+        #expect(store.errorMessage == nil)
+    }
+
+    @Test func successfulRefreshReplacesCacheWithFreshTasks() async throws {
+        let cache = try AgentBoardCache(inMemory: true)
+        let cachedTask = KanbanTask(id: "cached-1", title: "From cache", status: .todo)
+        try cache.replaceKanbanTasks([cachedTask])
+
+        let freshTask = KanbanTask(id: "fresh-1", title: "From refresh", status: .todo)
+        let store = makeStore(kanbanData: FakeKanbanData(mode: .success([freshTask])), cache: cache)
+
+        await store.bootstrap()
+
+        #expect(store.tasks.map(\.id) == ["fresh-1"])
+        let persisted = try cache.loadKanbanTasks()
+        #expect(persisted.map(\.id) == ["fresh-1"])
+    }
+
+    @Test func bootstrapWithEmptyCacheAndFailingRefreshLeavesTasksEmptyWithError() async throws {
+        let cache = try AgentBoardCache(inMemory: true)
+        let store = makeStore(kanbanData: FakeKanbanData(mode: .failure), cache: cache)
+
+        await store.bootstrap()
+
+        #expect(store.tasks.isEmpty)
+        #expect(store.errorMessage != nil)
+    }
+
+    // MARK: - Helpers
+
+    private func makeStore(kanbanData: any KanbanDataReading, cache: any AgentBoardCacheProtocol) -> AgentsStore {
+        let suffix = UUID().uuidString
+        let repo = SettingsRepository(
+            suiteName: "AgentsStoreCacheTests-\(suffix)",
+            serviceName: "AgentsStoreCacheTests-\(suffix)"
+        )
+        let settings = SettingsStore(repository: repo)
+        return AgentsStore(
+            kanbanData: kanbanData,
+            cliWriter: NoopCLIWriter(),
+            cache: cache,
+            settingsStore: settings
+        )
+    }
+}
+
+// MARK: - Test doubles
+
+private enum FakeKanbanDataError: Error {
+    case boom
+}
+
+private struct FakeKanbanData: KanbanDataReading {
+    enum Mode {
+        case success([KanbanTask])
+        case failure
+    }
+
+    let mode: Mode
+
+    func refresh() async throws -> Bool {
+        if case .failure = mode {
+            throw FakeKanbanDataError.boom
+        }
+        return true
+    }
+
+    func fetchTasks(status _: KanbanStatus?, tenant _: String?, excludeArchived _: Bool) async throws -> [KanbanTask] {
+        switch mode {
+        case let .success(tasks): return tasks
+        case .failure: throw FakeKanbanDataError.boom
+        }
+    }
+
+    func fetchLinks(for _: String) async throws -> (parents: [String], children: [String]) {
+        ([], [])
+    }
+
+    func fetchComments(for _: String) async throws -> [KanbanComment] {
+        []
+    }
+
+    func fetchRuns(for _: String) async throws -> [KanbanRun] {
+        []
+    }
+}
+
+private struct NoopCLIWriter: KanbanCLIWriting {
+    func create(_ draft: KanbanCreateDraft) async throws -> KanbanTask {
+        KanbanTask(id: UUID().uuidString, title: draft.title)
+    }
+
+    func comment(taskID _: String, body _: String) async throws {}
+    func complete(taskID _: String, summary _: String) async throws {}
+    func block(taskID _: String, reason _: String) async throws {}
+    func unblock(taskID _: String) async throws {}
+    func promote(taskID _: String) async throws {}
+    func archive(taskID _: String) async throws {}
+    func assign(taskID _: String, assignee _: String) async throws {}
+}

--- a/AgentBoardTests/AgentsStoreCreateTaskTests.swift
+++ b/AgentBoardTests/AgentsStoreCreateTaskTests.swift
@@ -18,8 +18,8 @@ import Testing
 @Suite("AgentsStore.createTask wait-for-completion contract (issue #86)")
 @MainActor
 struct AgentsStoreCreateTaskTests {
-    @Test func successAppendsTaskAndClearsStaleErrorMessage() async {
-        let store = makeStore(cliWriter: SuccessWriter())
+    @Test func successAppendsTaskAndClearsStaleErrorMessage() async throws {
+        let store = try makeStore(cliWriter: SuccessWriter())
         store.errorMessage = "stale error from earlier refresh"
 
         await store.createTask(KanbanCreateDraft(title: "Investigate flake"))
@@ -28,8 +28,8 @@ struct AgentsStoreCreateTaskTests {
         #expect(store.errorMessage == nil)
     }
 
-    @Test func failurePopulatesErrorMessageAndLeavesTasksUntouched() async {
-        let store = makeStore(cliWriter: FailingWriter(message: "hermes timed out"))
+    @Test func failurePopulatesErrorMessageAndLeavesTasksUntouched() async throws {
+        let store = try makeStore(cliWriter: FailingWriter(message: "hermes timed out"))
 
         await store.createTask(KanbanCreateDraft(title: "Investigate flake"))
 
@@ -37,12 +37,12 @@ struct AgentsStoreCreateTaskTests {
         #expect(store.errorMessage?.contains("hermes timed out") == true)
     }
 
-    @Test func retryAfterFailureClearsErrorAndAppendsTask() async {
+    @Test func retryAfterFailureClearsErrorAndAppendsTask() async throws {
         // The user-facing flow the bug fix unlocked: sheet stays open after a
         // failure, user retries with the same draft, the next write succeeds —
         // `errorMessage` must be cleared so the sheet can dismiss.
         let writer = ToggleWriter()
-        let store = makeStore(cliWriter: writer)
+        let store = try makeStore(cliWriter: writer)
 
         await store.createTask(KanbanCreateDraft(title: "Investigate flake"))
         #expect(store.errorMessage != nil)
@@ -57,23 +57,23 @@ struct AgentsStoreCreateTaskTests {
 
     // MARK: - Edge cases
 
-    @Test func successPopulatesStatusMessageWithCreatedTitle() async {
+    @Test func successPopulatesStatusMessageWithCreatedTitle() async throws {
         // The view surfaces `statusMessage` as confirmation feedback, so the
         // contract is: a successful create publishes a message that names the
         // task that was just created.
-        let store = makeStore(cliWriter: SuccessWriter())
+        let store = try makeStore(cliWriter: SuccessWriter())
 
         await store.createTask(KanbanCreateDraft(title: "Wire dispatcher"))
 
         #expect(store.statusMessage?.contains("Wire dispatcher") == true)
     }
 
-    @Test func duplicateIdFromCLIUpsertsInPlaceWithoutDuplicates() async {
+    @Test func duplicateIdFromCLIUpsertsInPlaceWithoutDuplicates() async throws {
         // Race scenario: a refresh runs concurrently with a create, and the
         // CLI returns a task whose id already exists locally. Upsert must
         // replace the existing entry rather than producing two rows.
         let writer = FixedIdWriter(id: "task-fixed-1")
-        let store = makeStore(cliWriter: writer)
+        let store = try makeStore(cliWriter: writer)
 
         await store.createTask(KanbanCreateDraft(title: "First write"))
         await store.createTask(KanbanCreateDraft(title: "Second write"))
@@ -83,14 +83,14 @@ struct AgentsStoreCreateTaskTests {
         #expect(matching.first?.title == "Second write")
     }
 
-    @Test func sequentialCreatesPreserveNewestFirstOrdering() async {
+    @Test func sequentialCreatesPreserveNewestFirstOrdering() async throws {
         // The kanban board renders tasks newest-first within each column, and
         // the upsert path is responsible for that sort. This guards against a
         // regression where a freshly created task lands below older tasks.
         let writer = SequencedSuccessWriter(
             baseDate: Date(timeIntervalSince1970: 1_700_000_000)
         )
-        let store = makeStore(cliWriter: writer)
+        let store = try makeStore(cliWriter: writer)
 
         await store.createTask(KanbanCreateDraft(title: "Oldest"))
         await store.createTask(KanbanCreateDraft(title: "Middle"))
@@ -101,16 +101,17 @@ struct AgentsStoreCreateTaskTests {
 
     // MARK: - Helpers
 
-    private func makeStore(cliWriter: any KanbanCLIWriting) -> AgentsStore {
+    private func makeStore(cliWriter: any KanbanCLIWriting) throws -> AgentsStore {
         let suffix = UUID().uuidString
         let repo = SettingsRepository(
             suiteName: "AgentsStoreCreateTaskTests-\(suffix)",
             serviceName: "AgentsStoreCreateTaskTests-\(suffix)"
         )
         let settings = SettingsStore(repository: repo)
-        return AgentsStore(
+        return try AgentsStore(
             kanbanData: KanbanDataService(databasePath: "/dev/null"),
             cliWriter: cliWriter,
+            cache: AgentBoardCache(inMemory: true),
             settingsStore: settings
         )
     }

--- a/AgentBoardTests/AgentsStoreMoveTests.swift
+++ b/AgentBoardTests/AgentsStoreMoveTests.swift
@@ -10,9 +10,9 @@ import Testing
 @Suite("AgentsStore.moveTask (issue #143)")
 @MainActor
 struct AgentsStoreMoveTests {
-    @Test func legalPromoteUpdatesStatusAndCallsWriter() async {
+    @Test func legalPromoteUpdatesStatusAndCallsWriter() async throws {
         let writer = RecordingWriter(seedTask: makeTask(id: "t1", status: .todo))
-        let store = await makeStore(cliWriter: writer)
+        let store = try await makeStore(cliWriter: writer)
 
         await store.moveTask(id: "t1", to: .ready)
 
@@ -22,9 +22,9 @@ struct AgentsStoreMoveTests {
         #expect(store.errorMessage == nil)
     }
 
-    @Test func legalBlockUpdatesStatusAndCallsWriterWithReason() async {
+    @Test func legalBlockUpdatesStatusAndCallsWriterWithReason() async throws {
         let writer = RecordingWriter(seedTask: makeTask(id: "t1", status: .ready))
-        let store = await makeStore(cliWriter: writer)
+        let store = try await makeStore(cliWriter: writer)
 
         await store.moveTask(id: "t1", to: .blocked)
 
@@ -33,9 +33,9 @@ struct AgentsStoreMoveTests {
         #expect(calls == [.block(taskID: "t1", reason: "Blocked from board")])
     }
 
-    @Test func legalUnblockUpdatesStatusAndCallsWriter() async {
+    @Test func legalUnblockUpdatesStatusAndCallsWriter() async throws {
         let writer = RecordingWriter(seedTask: makeTask(id: "t1", status: .blocked))
-        let store = await makeStore(cliWriter: writer)
+        let store = try await makeStore(cliWriter: writer)
 
         await store.moveTask(id: "t1", to: .ready)
 
@@ -44,9 +44,9 @@ struct AgentsStoreMoveTests {
         #expect(calls == [.unblock(taskID: "t1")])
     }
 
-    @Test func legalCompleteUpdatesStatusAndCallsWriterWithSummary() async {
+    @Test func legalCompleteUpdatesStatusAndCallsWriterWithSummary() async throws {
         let writer = RecordingWriter(seedTask: makeTask(id: "t1", status: .running))
-        let store = await makeStore(cliWriter: writer)
+        let store = try await makeStore(cliWriter: writer)
 
         await store.moveTask(id: "t1", to: .done)
 
@@ -55,9 +55,9 @@ struct AgentsStoreMoveTests {
         #expect(calls == [.complete(taskID: "t1", summary: "Completed from board")])
     }
 
-    @Test func writerFailureRevertsOptimisticUpdateAndSetsError() async {
+    @Test func writerFailureRevertsOptimisticUpdateAndSetsError() async throws {
         let writer = FailingWriter(seedTask: makeTask(id: "t1", status: .todo), message: "hermes timed out")
-        let store = await makeStore(cliWriter: writer)
+        let store = try await makeStore(cliWriter: writer)
 
         await store.moveTask(id: "t1", to: .ready)
 
@@ -65,9 +65,9 @@ struct AgentsStoreMoveTests {
         #expect(store.errorMessage?.contains("hermes timed out") == true)
     }
 
-    @Test func illegalDropNeverCallsWriterAndSetsRejectionMessage() async {
+    @Test func illegalDropNeverCallsWriterAndSetsRejectionMessage() async throws {
         let writer = RecordingWriter(seedTask: makeTask(id: "t1", status: .todo))
-        let store = await makeStore(cliWriter: writer)
+        let store = try await makeStore(cliWriter: writer)
 
         await store.moveTask(id: "t1", to: .running)
 
@@ -77,9 +77,9 @@ struct AgentsStoreMoveTests {
         #expect(store.statusMessage == "Tasks enter Running when an agent claims them.")
     }
 
-    @Test func illegalSameColumnDropNeverCallsWriter() async {
+    @Test func illegalSameColumnDropNeverCallsWriter() async throws {
         let writer = RecordingWriter(seedTask: makeTask(id: "t1", status: .ready))
-        let store = await makeStore(cliWriter: writer)
+        let store = try await makeStore(cliWriter: writer)
 
         await store.moveTask(id: "t1", to: .ready)
 
@@ -88,9 +88,9 @@ struct AgentsStoreMoveTests {
         #expect(store.statusMessage == "Task is already in Ready.")
     }
 
-    @Test func unknownTaskIdIsANoOp() async {
+    @Test func unknownTaskIdIsANoOp() async throws {
         let writer = RecordingWriter(seedTask: makeTask(id: "t1", status: .todo))
-        let store = await makeStore(cliWriter: writer)
+        let store = try await makeStore(cliWriter: writer)
 
         await store.moveTask(id: "missing", to: .ready)
 
@@ -108,16 +108,17 @@ struct AgentsStoreMoveTests {
     /// Builds a store wired to `cliWriter` and seeds it with the writer's
     /// `create()` response via the public `createTask` API (there is no
     /// internal seam for injecting `tasks` directly).
-    private func makeStore(cliWriter: any KanbanCLIWriting) async -> AgentsStore {
+    private func makeStore(cliWriter: any KanbanCLIWriting) async throws -> AgentsStore {
         let suffix = UUID().uuidString
         let repo = SettingsRepository(
             suiteName: "AgentsStoreMoveTests-\(suffix)",
             serviceName: "AgentsStoreMoveTests-\(suffix)"
         )
         let settings = SettingsStore(repository: repo)
-        let store = AgentsStore(
+        let store = try AgentsStore(
             kanbanData: KanbanDataService(databasePath: "/dev/null"),
             cliWriter: cliWriter,
+            cache: AgentBoardCache(inMemory: true),
             settingsStore: settings
         )
         await store.createTask(KanbanCreateDraft(title: "seed"))

--- a/AgentBoardTests/AgentsStoreSummariesTests.swift
+++ b/AgentBoardTests/AgentsStoreSummariesTests.swift
@@ -5,7 +5,7 @@ import Testing
 @Suite("AgentsStore summary derivation (kanban picker data source)")
 struct AgentsStoreSummariesTests {
     @Test func buildAgentSummariesReturnsEmptyForNoTasks() {
-        let summaries = AgentsStore.buildAgentSummaries(from: [])
+        let summaries = AgentsStore.buildAgentSummaries(from: [], sessionCounts: [:])
         #expect(summaries.isEmpty)
     }
 
@@ -15,7 +15,7 @@ struct AgentsStoreSummariesTests {
             makeTask(id: "2", assignee: "daneel"),
             makeTask(id: "3", assignee: "quentin")
         ]
-        let summaries = AgentsStore.buildAgentSummaries(from: tasks)
+        let summaries = AgentsStore.buildAgentSummaries(from: tasks, sessionCounts: [:])
         let names = summaries.map(\.name)
         #expect(names.count == 2)
         #expect(Set(names) == ["daneel", "quentin"])
@@ -26,7 +26,7 @@ struct AgentsStoreSummariesTests {
             makeTask(id: "1", assignee: "daneel"),
             makeTask(id: "2", assignee: nil)
         ]
-        let summaries = AgentsStore.buildAgentSummaries(from: tasks)
+        let summaries = AgentsStore.buildAgentSummaries(from: tasks, sessionCounts: [:])
         #expect(summaries.map(\.name) == ["daneel"])
     }
 
@@ -39,7 +39,7 @@ struct AgentsStoreSummariesTests {
             makeTask(id: "3", assignee: "   "),
             makeTask(id: "4", assignee: "\t\n")
         ]
-        let summaries = AgentsStore.buildAgentSummaries(from: tasks)
+        let summaries = AgentsStore.buildAgentSummaries(from: tasks, sessionCounts: [:])
         #expect(summaries.map(\.name) == ["daneel"])
     }
 
@@ -49,7 +49,7 @@ struct AgentsStoreSummariesTests {
             makeTask(id: "2", assignee: "alice"),
             makeTask(id: "3", assignee: "Daneel")
         ]
-        let summaries = AgentsStore.buildAgentSummaries(from: tasks)
+        let summaries = AgentsStore.buildAgentSummaries(from: tasks, sessionCounts: [:])
         #expect(summaries.map(\.name) == ["alice", "Daneel", "Quentin"])
     }
 
@@ -57,7 +57,7 @@ struct AgentsStoreSummariesTests {
         let tasks = [
             makeTask(id: "1", assignee: "daneel", status: .running)
         ]
-        let summaries = AgentsStore.buildAgentSummaries(from: tasks)
+        let summaries = AgentsStore.buildAgentSummaries(from: tasks, sessionCounts: [:])
         let summary = summaries.first
         #expect(summary?.health == .online)
         #expect(summary?.activeTaskCount == 1)
@@ -68,7 +68,7 @@ struct AgentsStoreSummariesTests {
             makeTask(id: "1", assignee: "daneel", status: .todo),
             makeTask(id: "2", assignee: "daneel", status: .done)
         ]
-        let summaries = AgentsStore.buildAgentSummaries(from: tasks)
+        let summaries = AgentsStore.buildAgentSummaries(from: tasks, sessionCounts: [:])
         let summary = summaries.first
         #expect(summary?.health == .idle)
         #expect(summary?.activeTaskCount == 0)
@@ -87,7 +87,7 @@ struct AgentsStoreSummariesTests {
             makeTask(id: "2", assignee: "daneel", status: .todo),
             makeTask(id: "3", assignee: "\tdaneel\n", status: .done)
         ]
-        let summaries = AgentsStore.buildAgentSummaries(from: tasks)
+        let summaries = AgentsStore.buildAgentSummaries(from: tasks, sessionCounts: [:])
         let summary = summaries.first
         #expect(summaries.count == 1)
         #expect(summary?.name == "daneel")
@@ -114,7 +114,7 @@ struct AgentsStoreSummariesTests {
                 createdAt: recentDate
             )
         ]
-        let summaries = AgentsStore.buildAgentSummaries(from: tasks)
+        let summaries = AgentsStore.buildAgentSummaries(from: tasks, sessionCounts: [:])
         #expect(summaries.first?.recentActivity == "newer")
     }
 
@@ -125,8 +125,30 @@ struct AgentsStoreSummariesTests {
             makeTask(id: "1", assignee: "  Claude  "),
             makeTask(id: "2", assignee: "claude")
         ]
-        let summaries = AgentsStore.buildAgentSummaries(from: tasks)
+        let summaries = AgentsStore.buildAgentSummaries(from: tasks, sessionCounts: [:])
         #expect(Set(summaries.map(\.name)) == ["Claude", "claude"])
+    }
+
+    // MARK: - Session counts (issue #144)
+
+    @Test func buildAgentSummariesReflectsInjectedSessionCount() {
+        let tasks = [makeTask(id: "1", assignee: "daneel")]
+        let summaries = AgentsStore.buildAgentSummaries(from: tasks, sessionCounts: ["daneel": 3])
+        #expect(summaries.first?.activeSessionCount == 3)
+    }
+
+    @Test func buildAgentSummariesDefaultsToZeroForUnknownAssignee() {
+        let tasks = [makeTask(id: "1", assignee: "daneel")]
+        let summaries = AgentsStore.buildAgentSummaries(from: tasks, sessionCounts: ["quentin": 5])
+        #expect(summaries.first?.activeSessionCount == 0)
+    }
+
+    @Test func buildAgentSummariesSessionCountLookupUsesTrimmedAssignee() {
+        // sessionCounts is keyed by the same trimmed-assignee string the
+        // per-summary task filter uses, so padded assignees still resolve.
+        let tasks = [makeTask(id: "1", assignee: "  daneel  ")]
+        let summaries = AgentsStore.buildAgentSummaries(from: tasks, sessionCounts: ["daneel": 2])
+        #expect(summaries.first?.activeSessionCount == 2)
     }
 
     // MARK: - Helpers

--- a/AgentBoardTests/NoopAgentBoardCacheTests.swift
+++ b/AgentBoardTests/NoopAgentBoardCacheTests.swift
@@ -13,10 +13,12 @@ struct NoopAgentBoardCacheTests {
         #expect(try cache.loadWorkItems().isEmpty)
         #expect(try cache.loadSessions().isEmpty)
         #expect(try cache.loadAgentSummaries().isEmpty)
+        #expect(try cache.loadKanbanTasks().isEmpty)
 
         try cache.replaceWorkItems([])
         try cache.replaceSessions([])
         try cache.replaceAgentSummaries([])
+        try cache.replaceKanbanTasks([])
         try cache.deleteConversation(id: UUID())
     }
 }


### PR DESCRIPTION
Phase 2 PR F of `docs/superpowers/plans/2026-07-17-phase2-agent-kanban.md`. **Stacked on #154** (which needs #153 first) — merge in order; GitHub retargets.

- Kanban tasks now cached via `AgentBoardCacheProtocol` (`CachedKanbanTaskRecord`, full-fidelity round-trip tested field-by-field): the board renders instantly from cache on launch and stays visible with a "Showing cached tasks" notice when `~/.hermes/kanban.db` is unreachable
- Agent rail `activeSessionCount` is no longer hard-coded 0: derived by joining `AgentSession.linkedTaskID → KanbanTask.assignee`, recomputed after every session refresh/companion event
- 471/471 tests (+19); all three schemes build; SwiftLint strict clean. Implemented by a Sonnet subagent, reviewed + verified here.

Caveat (follow-up filed): the companion doesn't populate `linkedTaskID` yet, so live counts read 0 until it does — the join is correct and tested.

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)