### PR TITLE
fix: main broken again by Copilot Autofix commit — restore KanbanBoardMove

### DIFF
--- a/AgentBoardCore/Models/KanbanBoardMove.swift
+++ b/AgentBoardCore/Models/KanbanBoardMove.swift
@@ -32,21 +32,20 @@ public enum KanbanBoardMove: Equatable, Sendable {
     }
 
     /// Human explanation for a rejected drop.
-public static func rejectionMessage(from: KanbanStatus, to: KanbanStatus) -> String {
-    if from == .done {
-        return "Completed tasks can't be moved."
-    }
-
-    if from == to {
-        return "Task is already in \(to.title)."
-    }
-
-    switch to {
-    case .running:
-        return "Tasks enter Running when an agent claims them."
-    case .triage, .todo, .archived:
-        return "Tasks can't be dragged to \(to.title)."
-    default:
-        return "That move isn't supported."
+    public static func rejectionMessage(from: KanbanStatus, to: KanbanStatus) -> String {
+        switch to {
+        case .running:
+            return "Tasks enter Running when an agent claims them."
+        case .triage, .todo, .archived:
+            return "Tasks can't be dragged to \(to.title)."
+        default:
+            if from == to {
+                return "Task is already in \(to.title)."
+            }
+            if from == .done {
+                return "Completed tasks can't be moved."
+            }
+            return "That move isn't supported."
+        }
     }
 }


### PR DESCRIPTION
**Merge first — main does not compile** (second occurrence). The Copilot Autofix commit `73173ca` that landed with the #154 merge rewrote `KanbanBoardMove.rejectionMessage` with mismatched braces, leaving the enum unclosed. This restores the reviewed version from PR #154; 471/471 tests pass.

**Strong recommendation:** stop applying Copilot Autofix suggestions directly at merge time — this is the second broken-main in two merges (#151's broke `VoicePlaybackView`, fixed in #153). If you want them, apply as review comments and let the branch's tests run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)