### PR TITLE
feat: three-column work board — To Do / In Progress / Resolved (#145)

### DIFF
--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		2EFC8887C151538585798677 /* SessionDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05A145F7A1A70B53DF066DBD /* SessionDetailSheet.swift */; };
 		30B2D9B7D1BFC77B6964A96C /* AgentBoardDesignTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4542E208AACDF95595A0B0D4 /* AgentBoardDesignTheme.swift */; };
 		31F4BD470BD142ABB72D00E8 /* AgentsStoreCreateTaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C500C7AF3B484DBB847E3A /* AgentsStoreCreateTaskTests.swift */; };
+		329205BFE190D828D883FF89 /* WorkBoardColumnTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F00F0612428FF4A1858440A /* WorkBoardColumnTests.swift */; };
 		34C9CEDCDFB2E84348A0EDB4 /* ChatEndpointValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FC87E1E7EE82E2FE4C749F /* ChatEndpointValidatorTests.swift */; };
 		37F82839F098968527158CC9 /* EmbeddedTerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A978B41E9572538A1E74E5C /* EmbeddedTerminalView.swift */; };
 		38E1089316EEC57E444A6FB1 /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957114148477B05585A13D7C /* MockURLProtocol.swift */; };
@@ -110,6 +111,7 @@
 		9781E0240F8A4C6FC3DC30B7 /* NativeSwiftUIInterfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5CC5206E88A59FBD80A856 /* NativeSwiftUIInterfaceTests.swift */; };
 		97BD3D8CCE198A034A5E0C2F /* AttachmentPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E3C09A95E37674D30B6072F /* AttachmentPicker.swift */; };
 		9A90C5EF45CA6630C7EA64CD /* SessionLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B1DC901AD1D60B3855D38 /* SessionLauncherTests.swift */; };
+		9A97D7081D317A037684C058 /* WorkBoardColumn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09451390C71FFAD903439B0F /* WorkBoardColumn.swift */; };
 		9D005EDAE8079475FA09FE67 /* AgentBoardAppModelActiveSessionCountsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E105E4FF286F13A9AB9E6E /* AgentBoardAppModelActiveSessionCountsTests.swift */; };
 		9EAAAF4FFBF10F8A576AF5BD /* SessionLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B7CE4C138A75D87781C1DB /* SessionLauncher.swift */; };
 		9EAC1A69746A2ABCB376F952 /* KanbanBoardMoveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3540D69FA92919FFD0494695 /* KanbanBoardMoveTests.swift */; };
@@ -271,10 +273,12 @@
 		08B7CE4C138A75D87781C1DB /* SessionLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLauncher.swift; sourceTree = "<group>"; };
 		08C9688956A467F60F3B9B34 /* KanbanDataReading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanDataReading.swift; sourceTree = "<group>"; };
 		08FC87E1E7EE82E2FE4C749F /* ChatEndpointValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatEndpointValidatorTests.swift; sourceTree = "<group>"; };
+		09451390C71FFAD903439B0F /* WorkBoardColumn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkBoardColumn.swift; sourceTree = "<group>"; };
 		0A55930915B4E8B29ECFC5DD /* KanbanModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanModels.swift; sourceTree = "<group>"; };
 		0B023A92D06AE2F3272FC200 /* NoopAgentBoardCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoopAgentBoardCacheTests.swift; sourceTree = "<group>"; };
 		0B7442B7AA1CFE33776582C1 /* AgentBoardMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBoardMobileApp.swift; sourceTree = "<group>"; };
 		0D0FBEDFA7766F71A98B48E3 /* SlashCommandHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandHandler.swift; sourceTree = "<group>"; };
+		0F00F0612428FF4A1858440A /* WorkBoardColumnTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkBoardColumnTests.swift; sourceTree = "<group>"; };
 		101D840E678502545284009E /* ChatStoreCapabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStoreCapabilityTests.swift; sourceTree = "<group>"; };
 		132785F0427381E3DB05BD8E /* ChatEndpointValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatEndpointValidator.swift; sourceTree = "<group>"; };
 		17F872D9728B5938D841130C /* ChatMessageList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageList.swift; sourceTree = "<group>"; };
@@ -488,6 +492,7 @@
 				92E0CE9F3A8E9CA87A6C3B95 /* SessionsStoreTests.swift */,
 				B4813FBD80F9AC10D1A51841 /* SettingsStoreTests.swift */,
 				EA26177C115F337F0AC82395 /* SlashCommandHandlerTests.swift */,
+				0F00F0612428FF4A1858440A /* WorkBoardColumnTests.swift */,
 				7863E93C0B04059321066BCD /* WorkStoreCRUDTests.swift */,
 				BB9701D71214407E75807732 /* WorkStoreTests.swift */,
 			);
@@ -506,6 +511,7 @@
 				275D2D504EF7D2F320157884 /* KanbanBoardMove.swift */,
 				0A55930915B4E8B29ECFC5DD /* KanbanModels.swift */,
 				AE2A97A08B0556443C6746EC /* LabelSchema.swift */,
+				09451390C71FFAD903439B0F /* WorkBoardColumn.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1038,6 +1044,7 @@
 				F18232EF1BD587C14FCCD06F /* SessionsStoreTests.swift in Sources */,
 				D4674853A5F6064FC3E65542 /* SettingsStoreTests.swift in Sources */,
 				2525C93CDB9C86D825831FC9 /* SlashCommandHandlerTests.swift in Sources */,
+				329205BFE190D828D883FF89 /* WorkBoardColumnTests.swift in Sources */,
 				293FC2DA4D1A99F6056A3C91 /* WorkStoreCRUDTests.swift in Sources */,
 				6F28FCEEB172015EFF5AFC70 /* WorkStoreTests.swift in Sources */,
 			);
@@ -1090,6 +1097,7 @@
 				4D05F9AAB6DA0E2642F377F4 /* ShellEnvironment.swift in Sources */,
 				C993681ECCC427965F61D4E6 /* SlashCommandHandler.swift in Sources */,
 				18479A684D668F5C137C5C86 /* TmuxController.swift in Sources */,
+				9A97D7081D317A037684C058 /* WorkBoardColumn.swift in Sources */,
 				1C711E565B9941FC998F8265 /* WorkStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AgentBoardCore/Models/WorkBoardColumn.swift
+++ b/AgentBoardCore/Models/WorkBoardColumn.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Presentation-only grouping of `WorkState` into the three columns shown on the
+/// Work board. `WorkState` (and the `status:*` label schema) remains the domain
+/// truth; this enum exists purely to simplify the board from five states to three
+/// columns without touching labels, CLI workflows, or agent tooling.
+public enum WorkBoardColumn: String, CaseIterable, Identifiable, Sendable {
+    case todo
+    case inProgress
+    case resolved
+
+    public var id: String {
+        rawValue
+    }
+
+    public var title: String {
+        switch self {
+        case .todo: "To Do"
+        case .inProgress: "In Progress"
+        case .resolved: "Resolved"
+        }
+    }
+
+    /// Which column a card renders in for a given `WorkState`.
+    public static func column(for state: WorkState) -> WorkBoardColumn {
+        switch state {
+        case .ready: .todo
+        case .inProgress, .review, .blocked: .inProgress
+        case .done: .resolved
+        }
+    }
+
+    /// The `WorkState` a drop onto this column requests via `WorkStore.updateStatus`.
+    public var dropTargetState: WorkState {
+        switch self {
+        case .todo: .ready
+        case .inProgress: .inProgress
+        case .resolved: .done
+        }
+    }
+}

--- a/AgentBoardTests/AccessibilityIdentifierTests.swift
+++ b/AgentBoardTests/AccessibilityIdentifierTests.swift
@@ -203,7 +203,7 @@ struct AccessibilityIdentifierTests {
             "work_picker_repository"
         ]
         assertIdentifiers(required, in: source)
-        #expect(source.contains(#"work_column_\(column.state.rawValue)"#))
+        #expect(source.contains(#"work_column_\(column.column.rawValue)"#))
     }
 
     @Test("Create issue sheet exposes identifiers for every interactive control")

--- a/AgentBoardTests/WorkBoardColumnTests.swift
+++ b/AgentBoardTests/WorkBoardColumnTests.swift
@@ -1,0 +1,44 @@
+import AgentBoardCore
+import Testing
+
+@Suite("WorkBoardColumn")
+struct WorkBoardColumnTests {
+    @Test func readyMapsToTodo() {
+        #expect(WorkBoardColumn.column(for: .ready) == .todo)
+    }
+
+    @Test func inProgressReviewAndBlockedMapToInProgress() {
+        #expect(WorkBoardColumn.column(for: .inProgress) == .inProgress)
+        #expect(WorkBoardColumn.column(for: .review) == .inProgress)
+        #expect(WorkBoardColumn.column(for: .blocked) == .inProgress)
+    }
+
+    @Test func doneMapsToResolved() {
+        #expect(WorkBoardColumn.column(for: .done) == .resolved)
+    }
+
+    @Test func everyWorkStateMapsToExactlyOneColumn() {
+        for state in WorkState.allCases {
+            let column = WorkBoardColumn.column(for: state)
+            #expect(WorkBoardColumn.allCases.contains(column))
+        }
+    }
+
+    @Test func dropTargetStatesMatchColumnMapping() {
+        #expect(WorkBoardColumn.todo.dropTargetState == .ready)
+        #expect(WorkBoardColumn.inProgress.dropTargetState == .inProgress)
+        #expect(WorkBoardColumn.resolved.dropTargetState == .done)
+    }
+
+    @Test func dropTargetStateAlwaysMapsBackToItsOwnColumn() {
+        for column in WorkBoardColumn.allCases {
+            #expect(WorkBoardColumn.column(for: column.dropTargetState) == column)
+        }
+    }
+
+    @Test func titlesMatchThreeColumnSpec() {
+        #expect(WorkBoardColumn.todo.title == "To Do")
+        #expect(WorkBoardColumn.inProgress.title == "In Progress")
+        #expect(WorkBoardColumn.resolved.title == "Resolved")
+    }
+}

--- a/AgentBoardTests/WorkStoreTests.swift
+++ b/AgentBoardTests/WorkStoreTests.swift
@@ -624,6 +624,133 @@ struct WorkStoreTests {
         #expect(store.items.first?.status == .ready)
     }
 
+    // MARK: - Three-column board drop transitions (WorkBoardColumn)
+
+    /// Dropping a card onto the Resolved column must close the GitHub issue.
+    @Test func dropOnResolvedColumnClosesIssue() async throws {
+        final class Capture: @unchecked Sendable { var state: String? }
+        let captured = Capture()
+        let listPayload = "[" + issueJSON(
+            number: 40,
+            title: "Ship it",
+            body: "",
+            labels: ["status:in-progress"]
+        ) + "]"
+        let updatedPayload = makeClosedIssueJSON(number: 40, title: "Ship it", labels: ["status:done"])
+
+        let (store, _) = try makeStore(mockHandler: { request in
+            if request.httpMethod == "PATCH",
+               let body = request.httpBody ?? request.bodyStreamData(),
+               let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any] {
+                captured.state = json["state"] as? String
+            }
+            let body = (request.httpMethod == "PATCH")
+                ? Data(updatedPayload.utf8)
+                : Data(listPayload.utf8)
+            let response = try HTTPURLResponse(
+                url: request.url ?? URL(string: "http://api.github.com")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, body)
+        })
+        await store.refresh()
+        let item = try #require(store.items.first)
+
+        await store.updateStatus(for: item, to: WorkBoardColumn.resolved.dropTargetState)
+
+        #expect(captured.state == "closed")
+        #expect(store.items.first?.status == .done)
+    }
+
+    /// Dragging a Resolved (done) card out to the To Do column must reopen the issue.
+    @Test func dragOutOfResolvedColumnReopensIssue() async throws {
+        final class Capture: @unchecked Sendable { var state: String? }
+        let captured = Capture()
+        let listPayload = "[" + makeClosedIssueJSON(
+            number: 41,
+            title: "Reopen via board",
+            labels: ["status:done"]
+        ) + "]"
+        let updatedPayload = issueJSON(
+            number: 41,
+            title: "Reopen via board",
+            body: "",
+            labels: ["status:ready"]
+        )
+
+        let (store, _) = try makeStore(mockHandler: { request in
+            if request.httpMethod == "PATCH",
+               let body = request.httpBody ?? request.bodyStreamData(),
+               let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any] {
+                captured.state = json["state"] as? String
+            }
+            let body = (request.httpMethod == "PATCH")
+                ? Data(updatedPayload.utf8)
+                : Data(listPayload.utf8)
+            let response = try HTTPURLResponse(
+                url: request.url ?? URL(string: "http://api.github.com")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, body)
+        })
+        await store.refresh()
+        let item = try #require(store.items.first)
+        #expect(WorkBoardColumn.column(for: item.status) == .resolved)
+
+        await store.updateStatus(for: item, to: WorkBoardColumn.todo.dropTargetState)
+
+        #expect(captured.state == "open")
+        #expect(store.items.first?.status == .ready)
+    }
+
+    /// A same-column, different-state drop (Review card dropped within the In Progress
+    /// column) must still normalize the label to `status:in-progress` rather than no-op —
+    /// only an exact-state match is skipped.
+    @Test func dropWithinInProgressColumnNormalizesReviewToInProgress() async throws {
+        final class Counter: @unchecked Sendable { var patches = 0 }
+        let counter = Counter()
+        let listPayload = "[" + issueJSON(
+            number: 42,
+            title: "In review",
+            body: "",
+            labels: ["status:review"]
+        ) + "]"
+        let updatedPayload = issueJSON(
+            number: 42,
+            title: "In review",
+            body: "",
+            labels: ["status:in-progress"]
+        )
+
+        let (store, _) = try makeStore(mockHandler: { request in
+            if request.httpMethod == "PATCH" {
+                counter.patches += 1
+            }
+            let body = (request.httpMethod == "PATCH")
+                ? Data(updatedPayload.utf8)
+                : Data(listPayload.utf8)
+            let response = try HTTPURLResponse(
+                url: request.url ?? URL(string: "http://api.github.com")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, body)
+        })
+        await store.refresh()
+        let item = try #require(store.items.first)
+        #expect(WorkBoardColumn.column(for: item.status) == .inProgress)
+
+        await store.updateStatus(for: item, to: WorkBoardColumn.inProgress.dropTargetState)
+
+        #expect(counter.patches == 1)
+        #expect(store.items.first?.status == .inProgress)
+    }
+
     private func makeClosedIssueJSON(number: Int, title: String, labels: [String]) -> String {
         let labelsJSON = labels.map { #"{"name": "\#($0)"}"# }.joined(separator: ", ")
         return """

--- a/AgentBoardUI/Screens/WorkScreen.swift
+++ b/AgentBoardUI/Screens/WorkScreen.swift
@@ -108,10 +108,9 @@ struct WorkScreen: View {
         return appModel.settingsStore.repositories.first { $0.fullName == selectedRepo }
     }
 
-    private var groupedFilteredItems: [(state: WorkState, items: [WorkItem])] {
-        // Show Ready, In Progress, Review, Done columns (skip Blocked)
-        [.ready, .inProgress, .review, .done].map { state in
-            (state, filteredItems.filter { $0.status == state })
+    private var groupedFilteredItems: [(column: WorkBoardColumn, items: [WorkItem])] {
+        WorkBoardColumn.allCases.map { column in
+            (column, filteredItems.filter { WorkBoardColumn.column(for: $0.status) == column })
         }
     }
 
@@ -241,14 +240,14 @@ struct WorkScreen: View {
             let columnWidth: CGFloat = 170
             ScrollView(.horizontal, showsIndicators: true) {
                 HStack(alignment: .top, spacing: 16) {
-                    ForEach(groupedFilteredItems, id: \.state) { column in
+                    ForEach(groupedFilteredItems, id: \.column) { column in
                         VStack(alignment: .leading, spacing: 10) {
                             HStack(spacing: 8) {
                                 Circle()
-                                    .fill(workStateColor(column.state))
+                                    .fill(workBoardColumnColor(column.column))
                                     .frame(width: 7, height: 7)
-                                    .shadow(color: workStateColor(column.state).opacity(0.6), radius: 8)
-                                Text(column.state.designColumnTitle)
+                                    .shadow(color: workBoardColumnColor(column.column).opacity(0.6), radius: 8)
+                                Text(column.column.title.uppercased())
                                     .font(.system(size: 11, weight: .semibold, design: .monospaced))
                                     .tracking(1.2)
                                     .foregroundStyle(NeuPalette.textPrimary)
@@ -290,7 +289,7 @@ struct WorkScreen: View {
         }
     }
 
-    private func boardColumnContent(for column: (state: WorkState, items: [WorkItem])) -> some View {
+    private func boardColumnContent(for column: (column: WorkBoardColumn, items: [WorkItem])) -> some View {
         VStack(spacing: 8) {
             if column.items.isEmpty {
                 Spacer()
@@ -311,7 +310,7 @@ struct WorkScreen: View {
                 }
             }
         }
-        .accessibilityIdentifier("work_column_\(column.state.rawValue)")
+        .accessibilityIdentifier("work_column_\(column.column.rawValue)")
         .dropDestination(for: WorkItemID.self) { ids, _ in
             guard let id = ids.first?.rawValue,
                   let item = filteredItems.first(where: { $0.id == id }) else {
@@ -319,7 +318,7 @@ struct WorkScreen: View {
             }
 
             Task { @MainActor in
-                await appModel.workStore.updateStatus(for: item, to: column.state)
+                await appModel.workStore.updateStatus(for: item, to: column.column.dropTargetState)
             }
             return true
         }
@@ -363,6 +362,16 @@ private struct WorkCardNeu: View {
                     Spacer(minLength: 8)
 
                     HStack(spacing: 6) {
+                        if item.status == .blocked {
+                            Text("Blocked")
+                                .font(.system(size: 9, weight: .bold))
+                                .foregroundStyle(NeuPalette.accentCoral)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(NeuPalette.accentCoral.opacity(0.15))
+                                .clipShape(Capsule())
+                                .accessibilityIdentifier("work_badge_blocked_\(item.id)")
+                        }
                         WorkStatusNeu(state: item.status)
                         PriorityNeu(priority: item.priority)
                     }
@@ -445,6 +454,15 @@ private func workStateColor(_ state: WorkState) -> Color {
     case .blocked: NeuPalette.accentCoral
     case .review: .purple
     case .done: NeuPalette.accentGreen
+    }
+}
+
+@MainActor
+private func workBoardColumnColor(_ column: WorkBoardColumn) -> Color {
+    switch column {
+    case .todo: NeuPalette.statusBlue
+    case .inProgress: NeuPalette.accentOrange
+    case .resolved: NeuPalette.accentGreen
     }
 }
 

--- a/AgentBoardUI/Screens/WorkScreen.swift
+++ b/AgentBoardUI/Screens/WorkScreen.swift
@@ -116,11 +116,10 @@ struct WorkScreen: View {
 
     private var statusCounts: (open: Int, inProgress: Int, done: Int) {
         filteredItems.reduce(into: (open: 0, inProgress: 0, done: 0)) { counts, item in
-            switch item.status {
-            case .ready: counts.open += 1
-            case .inProgress, .review: counts.inProgress += 1
-            case .done: counts.done += 1
-            default: break
+            switch WorkBoardColumn.column(for: item.status) {
+            case .todo: counts.open += 1
+            case .inProgress: counts.inProgress += 1
+            case .resolved: counts.done += 1
             }
         }
     }

--- a/docs/superpowers/plans/2026-07-17-phase3-issues-board.md
+++ b/docs/superpowers/plans/2026-07-17-phase3-issues-board.md
@@ -1,0 +1,55 @@
+# Phase 3 — Three-Column Issues Board Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Simplify the GitHub issues Work board from four columns (Ready / In Progress / Review / Done) to three (To Do / In Progress / Resolved) as a presentation-side remap — `status:*` labels are never renamed or removed, so CLI/agent workflows keep working (issue #145).
+
+**Architecture:** One PR. `WorkState` (label-derived, five cases) stays untouched as the domain truth. A new presentation enum `WorkBoardColumn` groups states into three columns and defines drop transitions. `WorkScreen` renders columns from the new enum; drops map a column to a target `WorkState` and reuse the existing `WorkStore.updateStatus` (which already swaps labels and opens/closes issues).
+
+**Tech Stack / Global Constraints:** identical to Phase 2 plan (`2026-07-17-phase2-agent-kanban.md`).
+
+## Column mapping (spec, decided 2026-07-16)
+
+| Column | Contains (WorkState) | Notes |
+|---|---|---|
+| To Do | `.ready` | open issues with `status:ready` or no status label (existing derivation already maps unlabeled-open → ready) |
+| In Progress | `.inProgress`, `.review`, `.blocked` | blocked cards get a visible "Blocked" badge |
+| Resolved | `.done` | closed issues |
+
+Drop transitions: To Do → `updateStatus(.ready)`; In Progress → `updateStatus(.inProgress)` (review/blocked states are reachable only via labels/detail sheet, not drops); Resolved → `updateStatus(.done)` (closes the issue). Dragging out of Resolved reopens + sets the target label (updateStatus already handles reopen — verify in `WorkStore.swift:218` region and `GitHubWorkService` PATCH logic).
+
+## Task G1: WorkBoardColumn (Core, pure)
+
+**Files:** Create `AgentBoardCore/Models/WorkBoardColumn.swift`; test `AgentBoardTests/WorkBoardColumnTests.swift` (new).
+
+```swift
+public enum WorkBoardColumn: String, CaseIterable, Identifiable, Sendable {
+    case todo, inProgress, resolved
+    public var id: String { rawValue }
+    public var title: String            // "To Do", "In Progress", "Resolved"
+    public static func column(for state: WorkState) -> WorkBoardColumn
+    public var dropTargetState: WorkState   // .ready / .inProgress / .done
+}
+```
+Tests: every `WorkState` maps to exactly one column per the table; drop targets are `.ready`/`.inProgress`/`.done`; titles.
+
+## Task G2: WorkScreen renders three columns
+
+**Files:** Modify `AgentBoardUI/Screens/WorkScreen.swift`; extend `AgentBoardTests` only where source-text tests pin identifiers (check `AccessibilityIdentifierTests` / `NativeSwiftUIInterfaceTests` for pinned WorkScreen strings that need updating).
+
+- Board layout iterates `WorkBoardColumn.allCases` instead of the current four-state array (~WorkScreen.swift:111-116); each column's items = `filteredItems.filter { WorkBoardColumn.column(for: $0.status) == column }`, preserving current in-column sort.
+- `.dropDestination` per column calls `WorkStore.updateStatus(for:to: column.dropTargetState)` — skip the call when the item is already in that column (same-column drop no-op; updateStatus already early-returns on same state, but same-COLUMN with different state, e.g. review → In Progress drop, SHOULD call updateStatus(.inProgress) — implement that nuance: only skip when `column(for: item.status) == targetColumn && item.status == column.dropTargetState`).
+- Blocked badge: cards whose `status == .blocked` show a small "Blocked" capsule (existing palette; `.accessibilityIdentifier("work_badge_blocked_\(item.id)")`). Review-state cards may keep their existing status pill if one exists — inspect the card view first and keep changes minimal.
+- List layout (non-board) untouched. Column headers get/keep accessibility identifiers per existing convention.
+
+## Task G3: Store/service verification pass
+
+**Files:** `AgentBoardCore/Stores/WorkStore.swift`, `AgentBoardTests/WorkStoreTests.swift` / `WorkStoreCRUDTests.swift` (extend).
+
+- Verify (and add tests for) the two board-critical flows: drop → Resolved closes the issue (state PATCH closed + `status:done` label swap per existing behavior), and drag out of Resolved reopens (PATCH open + target label). These flows exist — the deliverable is TESTS proving them under the new 3-column mapping, plus any small fix if reopen doesn't actually happen (read `updateStatus` and `GitHubWorkService.update` carefully first).
+
+Gate: full suite green (baseline 471), three schemes build, SwiftLint strict clean, `xcodegen generate` for new files. Branch `feat/issue-145-three-column-board`. Commits: `feat: three-column work board mapping (#145)` (G1), `feat: render To Do / In Progress / Resolved on the work board (#145)` (G2+G3).
+
+## Self-review notes
+- Same-column-different-state drops (review → In Progress) intentionally normalize the label to `status:in-progress`; that's the simplification's point, and labels remain the source of truth.
+- No changes to `WorkState`, `derivedStatus`, label schema, or the list layout — presentation + transition only.


### PR DESCRIPTION
Phase 3 PR G of `docs/superpowers/plans/2026-07-17-phase3-issues-board.md`. Presentation-only remap — `WorkState` and the `status:*` label schema are untouched, so CLI/agent workflows keep working.

- New pure `WorkBoardColumn` enum: To Do (`ready`/unlabeled-open), In Progress (`in-progress`/`review`/`blocked` with a Blocked badge), Resolved (closed)
- Board renders three columns; drop → Resolved closes the issue (wire-level PATCH asserted in tests), drag out of Resolved reopens; same-column drops normalize review/blocked to `status:in-progress`
- Header stat chips now bucket identically to the columns (added in review — the chip named In Progress previously excluded blocked)
- 481/481 tests (+10); all three schemes build; SwiftLint strict clean. Implemented by a Sonnet subagent, reviewed + verified here.

Note: this branch includes the #158 hotfix commit (already merged — deduplicates on merge).

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)