### PR TITLE
feat: dashboard home screen (#146)

### DIFF
--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		6DC087141B5B07B4F293045F /* VoiceViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEBA7BFDBBBF6316B340FAA /* VoiceViews.swift */; };
 		6EE512882ACF48B1A60F1603 /* DomainModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043C2F07C2F7E6DFBC165E9A /* DomainModels.swift */; };
 		6F28FCEEB172015EFF5AFC70 /* WorkStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9701D71214407E75807732 /* WorkStoreTests.swift */; };
+		702061D27F0B36AA2C2B0FB6 /* DashboardSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F805B62EF3A45AAE4426A3AA /* DashboardSnapshotTests.swift */; };
 		709B1495522FEA1AABEDEC6A /* BoardChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D736CF52ACD4E2BD9D3ADC /* BoardChrome.swift */; };
 		735B9E32C6B9218218F1CB8D /* AttachmentPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E3C09A95E37674D30B6072F /* AttachmentPicker.swift */; };
 		736771D2489A4C0C6FBB4A83 /* KeyboardDismissal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196C90FC0E35E33601741243 /* KeyboardDismissal.swift */; };
@@ -169,6 +170,7 @@
 		F3D458595223FE83DD26EDC5 /* NukeUI in Frameworks */ = {isa = PBXBuildFile; productRef = AA403A62FC0CC3B341A2D00B /* NukeUI */; };
 		F48A4EE8A94BD511FD764029 /* AgentsStoreMoveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0419C766B0215E27D4A7FD5B /* AgentsStoreMoveTests.swift */; };
 		F595A9354548F0B6A8A8F2E3 /* AgentBoardCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; };
+		F6BC6F7575EEA3C8449D315C /* DashboardSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F09EF2B1D929363AF662D5F /* DashboardSnapshot.swift */; };
 		F78742DD742A458919E091C0 /* AgentBoardCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		FD03671AAB65C52CE827D3DA /* AgentBoardCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; };
 		FD05A98C162D7CC536D93096 /* AgentBoardApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC92FF930020DC82D470A002 /* AgentBoardApp.swift */; };
@@ -279,6 +281,7 @@
 		0B7442B7AA1CFE33776582C1 /* AgentBoardMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBoardMobileApp.swift; sourceTree = "<group>"; };
 		0D0FBEDFA7766F71A98B48E3 /* SlashCommandHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandHandler.swift; sourceTree = "<group>"; };
 		0F00F0612428FF4A1858440A /* WorkBoardColumnTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkBoardColumnTests.swift; sourceTree = "<group>"; };
+		0F09EF2B1D929363AF662D5F /* DashboardSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardSnapshot.swift; sourceTree = "<group>"; };
 		101D840E678502545284009E /* ChatStoreCapabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStoreCapabilityTests.swift; sourceTree = "<group>"; };
 		132785F0427381E3DB05BD8E /* ChatEndpointValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatEndpointValidator.swift; sourceTree = "<group>"; };
 		17F872D9728B5938D841130C /* ChatMessageList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageList.swift; sourceTree = "<group>"; };
@@ -388,6 +391,7 @@
 		F31C11E46072F7E4A9FFADDB /* AttachmentInteractions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentInteractions.swift; sourceTree = "<group>"; };
 		F5C500C7AF3B484DBB847E3A /* AgentsStoreCreateTaskTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsStoreCreateTaskTests.swift; sourceTree = "<group>"; };
 		F6FDDFF5030B377E6973E969 /* ChatScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScreen.swift; sourceTree = "<group>"; };
+		F805B62EF3A45AAE4426A3AA /* DashboardSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardSnapshotTests.swift; sourceTree = "<group>"; };
 		F876603AEC9BE7B94289CA01 /* SettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStore.swift; sourceTree = "<group>"; };
 		FA4BD1071B801A6A1C9E1CEF /* NeumorphicTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeumorphicTheme.swift; sourceTree = "<group>"; };
 		FFA60A5A5B633630F99A562B /* GitHubWorkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubWorkService.swift; sourceTree = "<group>"; };
@@ -474,6 +478,7 @@
 				D165293786CA5ACAB31F2F12 /* CompanionClientEventsTests.swift */,
 				B56A44BC3ACA67014432FDD4 /* CompanionSQLiteStoreTests.swift */,
 				E15329720160FF009D5B1535 /* ConfigBackupServiceTests.swift */,
+				F805B62EF3A45AAE4426A3AA /* DashboardSnapshotTests.swift */,
 				19CE389F4A620817A309F601 /* DesignSemanticsTests.swift */,
 				C233996F081109570393D6FA /* DomainModelsTests.swift */,
 				3B9B576059ADDC3B5D219868 /* FoundationExtrasTests.swift */,
@@ -506,6 +511,7 @@
 				78ED2576E35E0964839427AD /* AppDestination.swift */,
 				C9D42E5CA1B251EA0284E8C6 /* AttachmentModels.swift */,
 				A062681C1E251F786843C99C /* ChatCapability.swift */,
+				0F09EF2B1D929363AF662D5F /* DashboardSnapshot.swift */,
 				E20006E3DE0937110157F9D1 /* DemoFixtures.swift */,
 				043C2F07C2F7E6DFBC165E9A /* DomainModels.swift */,
 				275D2D504EF7D2F320157884 /* KanbanBoardMove.swift */,
@@ -1026,6 +1032,7 @@
 				44DFBA6A0CA31D48DE0A0961 /* CompanionClientEventsTests.swift in Sources */,
 				58446795E6F62924439AD001 /* CompanionSQLiteStoreTests.swift in Sources */,
 				AC9718464408D550B64EFB4E /* ConfigBackupServiceTests.swift in Sources */,
+				702061D27F0B36AA2C2B0FB6 /* DashboardSnapshotTests.swift in Sources */,
 				10A2BF960BB432E046A8392E /* DesignSemanticsTests.swift in Sources */,
 				69807B75BA17F5A303D50067 /* DomainModelsTests.swift in Sources */,
 				E069DEDCB71500BCB3DA43A4 /* FoundationExtrasTests.swift in Sources */,
@@ -1074,6 +1081,7 @@
 				680A624F6E9ED591E1F63DA2 /* ChatStreamCoordinator.swift in Sources */,
 				81CAC6C9E0241A2ADE971ADC /* CompanionClient.swift in Sources */,
 				3FDBA88CC8E8D63388C757C6 /* ConfigBackupService.swift in Sources */,
+				F6BC6F7575EEA3C8449D315C /* DashboardSnapshot.swift in Sources */,
 				87A19AEDBCBE0206D4D71EFE /* DemoFixtures.swift in Sources */,
 				6EE512882ACF48B1A60F1603 /* DomainModels.swift in Sources */,
 				C6F5E2BE0559A438785BBCF8 /* FoundationExtras.swift in Sources */,

--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		1C711E565B9941FC998F8265 /* WorkStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A06C1DAB866C77FF3A634D71 /* WorkStore.swift */; };
 		1C7E32DFC4B2295F98363820 /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F876603AEC9BE7B94289CA01 /* SettingsStore.swift */; };
 		1DBE4EB751A629F1664040D8 /* IssueDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A31E0F643092B573A4DB9D /* IssueDetailSheet.swift */; };
+		1EFEE60391B527598A83613A /* DashboardScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1FF2AE621C085664C1C791 /* DashboardScreen.swift */; };
 		1F824DF6C0CFA67F11902759 /* CompanionLocalProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA51DADAAAAFFE9B833D35E9 /* CompanionLocalProbe.swift */; };
 		1F9726A41234F9B401F973B1 /* AgentBoardCompanionKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DB3E71CE348AC298EB4048DE /* AgentBoardCompanionKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		21BD68D1C8793B9DA7441B08 /* AgentsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE362DDE00559E2C84434C13 /* AgentsScreen.swift */; };
@@ -88,6 +89,7 @@
 		736771D2489A4C0C6FBB4A83 /* KeyboardDismissal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196C90FC0E35E33601741243 /* KeyboardDismissal.swift */; };
 		73D0983941C6808FB4A17E35 /* ChatCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = A062681C1E251F786843C99C /* ChatCapability.swift */; };
 		73E3E44246ACF7764C2B96D9 /* AgentBoardCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; };
+		745D4F6C8C8317CA446F822D /* DashboardScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1FF2AE621C085664C1C791 /* DashboardScreen.swift */; };
 		77E2DDC0D4C0CA009FD508F0 /* EmbeddedTerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A978B41E9572538A1E74E5C /* EmbeddedTerminalView.swift */; };
 		7AC30545E6D54E227C8831BA /* AgentBoardCompanionKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB3E71CE348AC298EB4048DE /* AgentBoardCompanionKit.framework */; };
 		7DE9CA2273E136476F38D922 /* TaskDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651B64AF0921713BAE550D2D /* TaskDetailSheet.swift */; };
@@ -340,6 +342,7 @@
 		82BF95164B1DFE66D15CB770 /* ChatHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHeader.swift; sourceTree = "<group>"; };
 		8562113DB3BC11316C4B4A50 /* LabelSchemaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelSchemaTests.swift; sourceTree = "<group>"; };
 		877DCCB45A0AFBD92AFAB650 /* AudioPlaybackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlaybackService.swift; sourceTree = "<group>"; };
+		8D1FF2AE621C085664C1C791 /* DashboardScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardScreen.swift; sourceTree = "<group>"; };
 		92E0CE9F3A8E9CA87A6C3B95 /* SessionsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionsStoreTests.swift; sourceTree = "<group>"; };
 		9503F3F8C1E54BE6D35A3641 /* PRDComposerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRDComposerTests.swift; sourceTree = "<group>"; };
 		957114148477B05585A13D7C /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
@@ -610,6 +613,7 @@
 				17F872D9728B5938D841130C /* ChatMessageList.swift */,
 				F6FDDFF5030B377E6973E969 /* ChatScreen.swift */,
 				702A0D71A27F07711AF96C4A /* CreateIssueSheet.swift */,
+				8D1FF2AE621C085664C1C791 /* DashboardScreen.swift */,
 				26A31E0F643092B573A4DB9D /* IssueDetailSheet.swift */,
 				03AD61915721952F19190205 /* LaunchSessionSheet.swift */,
 				1FFDF3222AEE5530E6C58DFC /* QuickLaunchSheet.swift */,
@@ -979,6 +983,7 @@
 				44025BC27B4AC9D5100A392F /* ChatMessageList.swift in Sources */,
 				41487A7506D835D9946C1B9E /* ChatScreen.swift in Sources */,
 				B32E7225FAA8967B580A58A1 /* CreateIssueSheet.swift in Sources */,
+				1EFEE60391B527598A83613A /* DashboardScreen.swift in Sources */,
 				ABB3B9109C6F6749E7933CF2 /* DesktopRootView.swift in Sources */,
 				8304F715858D01DEFB812754 /* DesktopSidebar.swift in Sources */,
 				18513E9340A65D8111F82D18 /* DomainPills.swift in Sources */,
@@ -1127,6 +1132,7 @@
 				C94A55ED7CCDD9540A5BF068 /* ChatMessageList.swift in Sources */,
 				6AD44EB0146CC268B39C27E1 /* ChatScreen.swift in Sources */,
 				06B09775C2F43ADB9D2A7DDB /* CreateIssueSheet.swift in Sources */,
+				745D4F6C8C8317CA446F822D /* DashboardScreen.swift in Sources */,
 				D5FE06BE70E2B8AFB20C40B5 /* DesktopSidebar.swift in Sources */,
 				BC1CCDB452C13C403BFA1460 /* DomainPills.swift in Sources */,
 				77E2DDC0D4C0CA009FD508F0 /* EmbeddedTerminalView.swift in Sources */,

--- a/AgentBoard/DesktopRootView.swift
+++ b/AgentBoard/DesktopRootView.swift
@@ -102,6 +102,8 @@ struct DesktopRootView: View {
             }
         } else {
             switch desktopDestination(for: appModel.selectedDestination) {
+            case .dashboard:
+                WorkScreen()
             case .work:
                 WorkScreen()
             case .agents:

--- a/AgentBoard/DesktopRootView.swift
+++ b/AgentBoard/DesktopRootView.swift
@@ -103,7 +103,7 @@ struct DesktopRootView: View {
         } else {
             switch desktopDestination(for: appModel.selectedDestination) {
             case .dashboard:
-                WorkScreen()
+                DashboardScreen(onOpenChat: { isChatInspectorPresented = true })
             case .work:
                 WorkScreen()
             case .agents:

--- a/AgentBoardCore/Models/AppDestination.swift
+++ b/AgentBoardCore/Models/AppDestination.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public enum AppDestination: String, CaseIterable, Identifiable, Sendable {
+    case dashboard
     case chat
     case work
     case agents
@@ -13,6 +14,7 @@ public enum AppDestination: String, CaseIterable, Identifiable, Sendable {
 
     public var title: String {
         switch self {
+        case .dashboard: "Dashboard"
         case .chat: "Chat"
         case .work: "Work"
         case .agents: "Agents"
@@ -23,6 +25,7 @@ public enum AppDestination: String, CaseIterable, Identifiable, Sendable {
 
     public var systemImage: String {
         switch self {
+        case .dashboard: "speedometer"
         case .chat: "bubble.left.and.bubble.right"
         case .work: "square.grid.2x2"
         case .agents: "person.3.sequence"
@@ -32,6 +35,6 @@ public enum AppDestination: String, CaseIterable, Identifiable, Sendable {
     }
 
     public static var desktopTabs: [AppDestination] {
-        [.work, .agents, .sessions, .settings]
+        [.dashboard, .work, .agents, .sessions, .settings]
     }
 }

--- a/AgentBoardCore/Models/DashboardSnapshot.swift
+++ b/AgentBoardCore/Models/DashboardSnapshot.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// Pure aggregation of the app's existing stores into the numbers the
+/// Dashboard home screen renders. Holds no state of its own — callers
+/// rebuild it from current store contents whenever they need a snapshot.
+public struct DashboardSnapshot: Equatable, Sendable {
+    public struct KanbanSummary: Equatable, Sendable {
+        public let running: Int
+        public let ready: Int
+        public let blocked: Int
+        public let done: Int
+        public let total: Int
+
+        public init(running: Int, ready: Int, blocked: Int, done: Int, total: Int) {
+            self.running = running
+            self.ready = ready
+            self.blocked = blocked
+            self.done = done
+            self.total = total
+        }
+    }
+
+    public struct WorkSummary: Equatable, Sendable {
+        public let todo: Int
+        public let inProgress: Int
+        public let resolved: Int
+
+        public init(todo: Int, inProgress: Int, resolved: Int) {
+            self.todo = todo
+            self.inProgress = inProgress
+            self.resolved = resolved
+        }
+    }
+
+    public struct SessionsSummary: Equatable, Sendable {
+        public let active: Int
+        public let total: Int
+        public let syncStatus: SessionsSyncStatus
+
+        public init(active: Int, total: Int, syncStatus: SessionsSyncStatus) {
+            self.active = active
+            self.total = total
+            self.syncStatus = syncStatus
+        }
+    }
+
+    public let kanban: KanbanSummary
+    public let work: WorkSummary
+    public let sessions: SessionsSummary
+    public let runningTaskTitles: [String]
+    public let recentConversations: [ChatConversation]
+    public let chatConnection: ChatConnectionState
+
+    public static func build(
+        kanbanTasks: [KanbanTask],
+        workItems: [WorkItem],
+        sessions: [AgentSession],
+        conversations: [ChatConversation],
+        chatConnection: ChatConnectionState,
+        syncStatus: SessionsSyncStatus = .offline
+    ) -> DashboardSnapshot {
+        let kanbanSummary = KanbanSummary(
+            running: kanbanTasks.count { $0.status == .running },
+            ready: kanbanTasks.count { $0.status == .ready },
+            blocked: kanbanTasks.count { $0.status == .blocked },
+            done: kanbanTasks.count { $0.status == .done },
+            total: kanbanTasks.count
+        )
+
+        let workSummary = workItems.reduce(into: (todo: 0, inProgress: 0, resolved: 0)) { counts, item in
+            switch WorkBoardColumn.column(for: item.status) {
+            case .todo: counts.todo += 1
+            case .inProgress: counts.inProgress += 1
+            case .resolved: counts.resolved += 1
+            }
+        }
+
+        let sessionsSummary = SessionsSummary(
+            active: sessions.count { $0.status == .running },
+            total: sessions.count,
+            syncStatus: syncStatus
+        )
+
+        let runningTaskTitles = kanbanTasks
+            .filter { $0.status == .running }
+            .prefix(3)
+            .map(\.title)
+
+        let recentConversations = conversations
+            .sorted { $0.updatedAt > $1.updatedAt }
+            .prefix(3)
+
+        return DashboardSnapshot(
+            kanban: kanbanSummary,
+            work: WorkSummary(
+                todo: workSummary.todo,
+                inProgress: workSummary.inProgress,
+                resolved: workSummary.resolved
+            ),
+            sessions: sessionsSummary,
+            runningTaskTitles: Array(runningTaskTitles),
+            recentConversations: Array(recentConversations),
+            chatConnection: chatConnection
+        )
+    }
+}

--- a/AgentBoardCore/Stores/AgentBoardAppModel.swift
+++ b/AgentBoardCore/Stores/AgentBoardAppModel.swift
@@ -16,7 +16,7 @@ public final class AgentBoardAppModel {
     public let sessionsStore: SessionsStore
     public let sessionLauncher: SessionLauncher
 
-    public var selectedDestination: AppDestination = .chat
+    public var selectedDestination: AppDestination = .dashboard
     public private(set) var isBootstrapping = false
     public private(set) var didBootstrap = false
     public var statusMessage: String?

--- a/AgentBoardMobile/MobileRootView.swift
+++ b/AgentBoardMobile/MobileRootView.swift
@@ -2,10 +2,22 @@ import AgentBoardCore
 import SwiftUI
 
 struct MobileRootView: View {
-    @State private var selectedDestination: AppDestination = .chat
+    @Environment(AgentBoardAppModel.self) private var appModel
 
     var body: some View {
-        TabView(selection: $selectedDestination) {
+        @Bindable var appModel = appModel
+
+        TabView(selection: $appModel.selectedDestination) {
+            Tab(value: AppDestination.dashboard) {
+                NavigationStack {
+                    WorkScreen()
+                        .navigationTitle(AppDestination.dashboard.title)
+                }
+                .accessibilityIdentifier("mobile_tab_dashboard")
+            } label: {
+                Label(AppDestination.dashboard.title, systemImage: AppDestination.dashboard.systemImage)
+            }
+
             Tab(value: AppDestination.chat) {
                 NavigationStack {
                     ChatScreen()

--- a/AgentBoardMobile/MobileRootView.swift
+++ b/AgentBoardMobile/MobileRootView.swift
@@ -10,7 +10,7 @@ struct MobileRootView: View {
         TabView(selection: $appModel.selectedDestination) {
             Tab(value: AppDestination.dashboard) {
                 NavigationStack {
-                    WorkScreen()
+                    DashboardScreen()
                         .navigationTitle(AppDestination.dashboard.title)
                 }
                 .accessibilityIdentifier("mobile_tab_dashboard")

--- a/AgentBoardTests/AccessibilityIdentifierTests.swift
+++ b/AgentBoardTests/AccessibilityIdentifierTests.swift
@@ -101,6 +101,20 @@ struct AccessibilityIdentifierTests {
         assertIdentifiers(required, in: source)
     }
 
+    @Test("Dashboard screen exposes identifiers for every tile and the refresh control")
+    func dashboardScreenIdentifiers() throws {
+        let source = try readUISource("Screens/DashboardScreen.swift")
+        let required = [
+            "screen_dashboard",
+            "dashboard_tile_agents",
+            "dashboard_tile_work",
+            "dashboard_tile_sessions",
+            "dashboard_tile_chat",
+            "dashboard_button_refresh"
+        ]
+        assertIdentifiers(required, in: source)
+    }
+
     @Test("Sessions screen exposes identifiers for refresh + per-row taps")
     func sessionsScreenIdentifiers() throws {
         let source = try readUISource("Screens/SessionsScreen.swift")

--- a/AgentBoardTests/AppDestinationTests.swift
+++ b/AgentBoardTests/AppDestinationTests.swift
@@ -5,7 +5,7 @@ import Testing
 struct AppDestinationTests {
     @Test func appDestinationAllCasesAreStable() {
         // Ordering matters because navigation rails iterate `.allCases` directly.
-        #expect(AppDestination.allCases == [.chat, .work, .agents, .sessions, .settings])
+        #expect(AppDestination.allCases == [.dashboard, .chat, .work, .agents, .sessions, .settings])
     }
 
     @Test func appDestinationIDMatchesRawValue() {
@@ -15,6 +15,7 @@ struct AppDestinationTests {
     }
 
     @Test func appDestinationTitleIsUserFacing() {
+        #expect(AppDestination.dashboard.title == "Dashboard")
         #expect(AppDestination.chat.title == "Chat")
         #expect(AppDestination.work.title == "Work")
         #expect(AppDestination.agents.title == "Agents")

--- a/AgentBoardTests/DashboardSnapshotTests.swift
+++ b/AgentBoardTests/DashboardSnapshotTests.swift
@@ -1,0 +1,154 @@
+import AgentBoardCore
+import Foundation
+import Testing
+
+@Suite("DashboardSnapshot")
+struct DashboardSnapshotTests {
+    @Test func emptyInputsProduceAllZeroCounts() {
+        let snapshot = DashboardSnapshot.build(
+            kanbanTasks: [],
+            workItems: [],
+            sessions: [],
+            conversations: [],
+            chatConnection: .disconnected
+        )
+
+        #expect(snapshot.kanban == DashboardSnapshot.KanbanSummary(running: 0, ready: 0, blocked: 0, done: 0, total: 0))
+        #expect(snapshot.work == DashboardSnapshot.WorkSummary(todo: 0, inProgress: 0, resolved: 0))
+        #expect(snapshot.sessions == DashboardSnapshot.SessionsSummary(active: 0, total: 0, syncStatus: .offline))
+        #expect(snapshot.runningTaskTitles.isEmpty)
+        #expect(snapshot.recentConversations.isEmpty)
+        #expect(snapshot.chatConnection == .disconnected)
+    }
+
+    @Test func kanbanCountsBucketByStatus() {
+        let tasks = [
+            makeTask(id: "1", status: .running),
+            makeTask(id: "2", status: .running),
+            makeTask(id: "3", status: .ready),
+            makeTask(id: "4", status: .blocked),
+            makeTask(id: "5", status: .done),
+            makeTask(id: "6", status: .triage),
+            makeTask(id: "7", status: .todo),
+            makeTask(id: "8", status: .archived)
+        ]
+
+        let snapshot = DashboardSnapshot.build(
+            kanbanTasks: tasks,
+            workItems: [],
+            sessions: [],
+            conversations: [],
+            chatConnection: .disconnected
+        )
+
+        #expect(snapshot.kanban == DashboardSnapshot.KanbanSummary(running: 2, ready: 1, blocked: 1, done: 1, total: 8))
+    }
+
+    @Test func workCountsBucketByBoardColumn() {
+        let items = [
+            makeWorkItem(number: 1, status: .ready),
+            makeWorkItem(number: 2, status: .inProgress),
+            makeWorkItem(number: 3, status: .review),
+            makeWorkItem(number: 4, status: .blocked),
+            makeWorkItem(number: 5, status: .done)
+        ]
+
+        let snapshot = DashboardSnapshot.build(
+            kanbanTasks: [],
+            workItems: items,
+            sessions: [],
+            conversations: [],
+            chatConnection: .disconnected
+        )
+
+        #expect(snapshot.work == DashboardSnapshot.WorkSummary(todo: 1, inProgress: 3, resolved: 1))
+    }
+
+    @Test func sessionCountsTreatRunningAsActive() {
+        let sessions = [
+            makeSession(id: "a", status: .running),
+            makeSession(id: "b", status: .running),
+            makeSession(id: "c", status: .idle),
+            makeSession(id: "d", status: .stopped)
+        ]
+
+        let snapshot = DashboardSnapshot.build(
+            kanbanTasks: [],
+            workItems: [],
+            sessions: sessions,
+            conversations: [],
+            chatConnection: .connected
+        )
+
+        #expect(snapshot.sessions == DashboardSnapshot.SessionsSummary(active: 2, total: 4, syncStatus: .offline))
+        #expect(snapshot.chatConnection == .connected)
+    }
+
+    @Test func runningTaskTitlesCapAtThreeAndPreserveOrder() {
+        let tasks = [
+            makeTask(id: "1", title: "First", status: .running),
+            makeTask(id: "2", title: "Second", status: .running),
+            makeTask(id: "3", title: "Third", status: .running),
+            makeTask(id: "4", title: "Fourth", status: .running),
+            makeTask(id: "5", title: "Ready one", status: .ready)
+        ]
+
+        let snapshot = DashboardSnapshot.build(
+            kanbanTasks: tasks,
+            workItems: [],
+            sessions: [],
+            conversations: [],
+            chatConnection: .disconnected
+        )
+
+        #expect(snapshot.runningTaskTitles == ["First", "Second", "Third"])
+    }
+
+    @Test func recentConversationsAreSortedByUpdatedAtDescendingAndCappedAtThree() {
+        let now = Date.now
+        let conversations = [
+            ChatConversation(title: "Oldest", updatedAt: now.addingTimeInterval(-300)),
+            ChatConversation(title: "Newest", updatedAt: now),
+            ChatConversation(title: "Middle", updatedAt: now.addingTimeInterval(-100)),
+            ChatConversation(title: "Fourth", updatedAt: now.addingTimeInterval(-200))
+        ]
+
+        let snapshot = DashboardSnapshot.build(
+            kanbanTasks: [],
+            workItems: [],
+            sessions: [],
+            conversations: conversations,
+            chatConnection: .disconnected
+        )
+
+        #expect(snapshot.recentConversations.map(\.title) == ["Newest", "Middle", "Fourth"])
+    }
+
+    // MARK: - Fixtures
+
+    private func makeTask(id: String, title: String = "Task", status: KanbanStatus) -> KanbanTask {
+        KanbanTask(id: id, title: title, status: status)
+    }
+
+    private func makeWorkItem(number: Int, status: WorkState) -> WorkItem {
+        WorkItem(
+            repository: ConfiguredRepository(owner: "jbcrane13", name: "AgentBoard"),
+            issueNumber: number,
+            title: "Item \(number)",
+            bodySummary: "",
+            isClosed: status.isTerminal,
+            assignees: [],
+            milestone: nil,
+            labels: [],
+            status: status,
+            priority: .p2,
+            agentHint: nil,
+            createdAt: .now,
+            updatedAt: .now
+        )
+    }
+
+    private func makeSession(id: String, status: AgentSessionStatus) -> AgentSession {
+        AgentSession(id: id, source: "test", status: status)
+    }
+}

--- a/AgentBoardUI/Components/DesktopSidebar.swift
+++ b/AgentBoardUI/Components/DesktopSidebar.swift
@@ -162,7 +162,7 @@ struct DesktopSidebar: View {
         case .work: appModel.workStore.items.count
         case .agents: appModel.agentsStore.summaries.count
         case .sessions: appModel.sessionsStore.sessions.count
-        case .chat, .settings: nil
+        case .dashboard, .chat, .settings: nil
         }
     }
 

--- a/AgentBoardUI/Screens/DashboardScreen.swift
+++ b/AgentBoardUI/Screens/DashboardScreen.swift
@@ -1,0 +1,229 @@
+import AgentBoardCore
+import SwiftUI
+
+struct DashboardScreen: View {
+    @Environment(AgentBoardAppModel.self) private var appModel
+    @Environment(\.horizontalSizeClass) private var hSizeClass
+    var onOpenChat: (() -> Void)?
+
+    private var isCompact: Bool {
+        hSizeClass == .compact
+    }
+
+    private var columns: [GridItem] {
+        Array(repeating: GridItem(.flexible(), spacing: 20), count: isCompact ? 2 : 3)
+    }
+
+    private var snapshot: DashboardSnapshot {
+        DashboardSnapshot.build(
+            kanbanTasks: appModel.agentsStore.tasks,
+            workItems: appModel.workStore.items,
+            sessions: appModel.sessionsStore.sessions,
+            conversations: appModel.chatStore.conversations,
+            chatConnection: appModel.chatStore.connectionState,
+            syncStatus: appModel.sessionsStore.syncStatus
+        )
+    }
+
+    var body: some View {
+        ZStack {
+            NeuBackground()
+
+            VStack(spacing: 0) {
+                header
+                    .padding(isCompact ? 16 : 24)
+                    .padding(.bottom, 8)
+
+                ScrollView(showsIndicators: false) {
+                    LazyVGrid(columns: columns, spacing: 20) {
+                        agentTasksTile
+                        workItemsTile
+                        sessionsTile
+                        chatTile
+                    }
+                    .padding(isCompact ? 16 : 24)
+                }
+            }
+        }
+        .agentBoardNavigationBarHidden(true)
+        .refreshable {
+            await appModel.refreshAll()
+        }
+        .accessibilityIdentifier("screen_dashboard")
+    }
+
+    private var header: some View {
+        HStack(alignment: .bottom) {
+            VStack(alignment: .leading, spacing: 6) {
+                AgentBoardEyebrow(text: "DASHBOARD")
+                Text("Home")
+                    .font(.system(size: isCompact ? 34 : 30, weight: .bold))
+                    .foregroundStyle(NeuPalette.textPrimary)
+                    .tracking(-0.8)
+            }
+            Spacer()
+            Button {
+                Task { await appModel.refreshAll() }
+            } label: {
+                Image(systemName: "arrow.clockwise")
+            }
+            .buttonStyle(NeuButtonTarget(isAccent: false))
+            .accessibilityIdentifier("dashboard_button_refresh")
+        }
+    }
+
+    private var agentTasksTile: some View {
+        DashboardTile(
+            title: "Agent Tasks",
+            systemImage: AppDestination.agents.systemImage,
+            accentColor: NeuPalette.accentCyan
+        ) {
+            appModel.selectedDestination = .agents
+        } content: {
+            HStack(spacing: 14) {
+                statPill(label: "Running", count: snapshot.kanban.running, color: NeuPalette.statusSuccess)
+                statPill(label: "Ready", count: snapshot.kanban.ready, color: NeuPalette.accentCyan)
+                statPill(label: "Blocked", count: snapshot.kanban.blocked, color: NeuPalette.accentOrange)
+            }
+            previewList(snapshot.runningTaskTitles, emptyText: "No tasks running")
+        }
+        .accessibilityIdentifier("dashboard_tile_agents")
+    }
+
+    private var workItemsTile: some View {
+        DashboardTile(
+            title: "Work Items",
+            systemImage: AppDestination.work.systemImage,
+            accentColor: NeuPalette.statusBlue
+        ) {
+            appModel.selectedDestination = .work
+        } content: {
+            HStack(spacing: 14) {
+                statPill(label: "To Do", count: snapshot.work.todo, color: NeuPalette.statusBlue)
+                statPill(label: "In Progress", count: snapshot.work.inProgress, color: NeuPalette.accentOrange)
+                statPill(label: "Resolved", count: snapshot.work.resolved, color: NeuPalette.accentGreen)
+            }
+        }
+        .accessibilityIdentifier("dashboard_tile_work")
+    }
+
+    private var sessionsTile: some View {
+        DashboardTile(
+            title: "Sessions",
+            systemImage: AppDestination.sessions.systemImage,
+            accentColor: NeuPalette.statusIdle
+        ) {
+            appModel.selectedDestination = .sessions
+        } content: {
+            HStack(spacing: 14) {
+                statPill(label: "Active", count: snapshot.sessions.active, color: NeuPalette.statusSuccess)
+                statPill(label: "Total", count: snapshot.sessions.total, color: NeuPalette.textSecondary)
+            }
+            Text(snapshot.sessions.syncStatus.title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(NeuPalette.textSecondary)
+        }
+        .accessibilityIdentifier("dashboard_tile_sessions")
+    }
+
+    private var chatTile: some View {
+        DashboardTile(
+            title: "Chat",
+            systemImage: AppDestination.chat.systemImage,
+            accentColor: NeuPalette.accentPurple
+        ) {
+            if let onOpenChat {
+                onOpenChat()
+            } else {
+                appModel.selectedDestination = .chat
+            }
+        } content: {
+            Text(snapshot.chatConnection.title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(NeuPalette.textSecondary)
+            previewList(
+                snapshot.recentConversations.map(\.title),
+                emptyText: "No conversations yet"
+            )
+        }
+        .accessibilityIdentifier("dashboard_tile_chat")
+    }
+
+    private func statPill(label: String, count: Int, color: Color) -> some View {
+        HStack(spacing: 5) {
+            Circle()
+                .fill(color)
+                .frame(width: 7, height: 7)
+                .shadow(color: color.opacity(0.6), radius: 4)
+            Text("\(count)")
+                .font(.system(.subheadline, design: .rounded, weight: .bold))
+                .monospacedDigit()
+                .foregroundStyle(NeuPalette.textPrimary)
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(NeuPalette.textSecondary)
+        }
+    }
+
+    private func previewList(_ lines: [String], emptyText: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if lines.isEmpty {
+                Text(emptyText)
+                    .font(.caption)
+                    .foregroundStyle(NeuPalette.textTertiary)
+            } else {
+                ForEach(lines, id: \.self) { line in
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(NeuPalette.textTertiary)
+                            .frame(width: 4, height: 4)
+                        Text(line)
+                            .font(.caption)
+                            .foregroundStyle(NeuPalette.textSecondary)
+                            .lineLimit(1)
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct DashboardTile<Content: View>: View {
+    let title: String
+    let systemImage: String
+    let accentColor: Color
+    let action: () -> Void
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 16) {
+                HStack(spacing: 10) {
+                    Image(systemName: systemImage)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(accentColor)
+                        .frame(width: 30, height: 30)
+                        .background(accentColor.opacity(0.12))
+                        .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
+
+                    Text(title)
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundStyle(NeuPalette.textPrimary)
+
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(NeuPalette.textTertiary)
+                }
+
+                content
+            }
+            .padding(18)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .neuExtruded(cornerRadius: 22, elevation: 8)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/docs/superpowers/plans/2026-07-17-phase4-dashboard.md
+++ b/docs/superpowers/plans/2026-07-17-phase4-dashboard.md
@@ -1,0 +1,65 @@
+# Phase 4 — Dashboard Home Screen Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A new Dashboard home screen — first destination on both platforms — summarizing app state from existing stores, with every tile navigating to its screen (issue #146).
+
+**Architecture:** One PR. New `.dashboard` case in `AppDestination` (first tab on iOS, first sidebar entry on macOS). A `DashboardScreen` (AgentBoardUI) reads directly from `AgentBoardAppModel`'s existing stores — no new services, no new stores. A small pure `DashboardSnapshot` model in Core aggregates the numbers so the tile math is unit-testable. Visual design follows the app's existing neumorphic system (`NeuPalette` / `NeumorphicTheme`, `BoardChrome` patterns) — consistency with the app IS the design direction; no new visual language.
+
+**Tech Stack / Global Constraints:** identical to Phase 2/3 plans. Every interactive element gets `dashboard_*` accessibility identifiers.
+
+## Verified navigation facts
+- `AppDestination` (AgentBoardCore/Models/AppDestination.swift): 5 cases with `title`/`systemImage`; `desktopTabs = [.work, .agents, .sessions, .settings]` (chat is a trailing inspector on desktop, first tab on mobile).
+- `DesktopRootView.swift`: sidebar drives `appModel.selectedDestination`; detail `switch` at ~line 104 maps destinations to screens; `.chat` currently falls through to `WorkScreen()`.
+- `MobileRootView.swift`: `TabView(selection:)` with `Tab(value:)` per destination, chat first.
+
+## Task H1: DashboardSnapshot (Core, pure + testable)
+
+**Files:** Create `AgentBoardCore/Models/DashboardSnapshot.swift`; test `AgentBoardTests/DashboardSnapshotTests.swift` (new).
+
+```swift
+public struct DashboardSnapshot: Equatable, Sendable {
+    public struct KanbanSummary: Equatable, Sendable { public let running: Int; public let ready: Int; public let blocked: Int; public let done: Int; public let total: Int }
+    public struct WorkSummary: Equatable, Sendable { public let todo: Int; public let inProgress: Int; public let resolved: Int }   // uses WorkBoardColumn.column(for:)
+    public struct SessionsSummary: Equatable, Sendable { public let active: Int; public let total: Int; public let syncStatus: SessionsSyncStatus }
+    public let kanban: KanbanSummary
+    public let work: WorkSummary
+    public let sessions: SessionsSummary
+    public let runningTaskTitles: [String]          // up to 3, KanbanStatus.running
+    public let recentConversations: [ChatConversation]  // up to 3 by updatedAt desc
+    public let chatConnection: ChatConnectionState
+
+    public static func build(
+        kanbanTasks: [KanbanTask],
+        workItems: [WorkItem],
+        sessions: [AgentSession],
+        conversations: [ChatConversation],
+        chatConnection: ChatConnectionState
+    ) -> DashboardSnapshot
+}
+```
+Inspect `AgentSession` for the correct "active" predicate (reuse whatever SessionsScreen/AgentBoardAppModel.activeSessionCounts treats as active). Tests: counts per bucket from fixture arrays; running titles capped at 3; recent conversations sorted/capped; empty inputs → all zeros.
+
+## Task H2: `.dashboard` destination + routing
+
+**Files:** Modify `AgentBoardCore/Models/AppDestination.swift` (new first case `dashboard`, title "Dashboard", systemImage "gauge.with.dots.needle.50percent" or similar SF Symbol that exists on macOS 26/iOS 26; `desktopTabs` becomes `[.dashboard, .work, .agents, .sessions, .settings]`), `AgentBoard/DesktopRootView.swift` (detail switch gains `.dashboard: DashboardScreen()`; check `desktopDestination(for:)` fallback logic and the default `selectedDestination`), `AgentBoardMobile/MobileRootView.swift` (Dashboard tab FIRST, before chat), `AgentBoardCore/Stores/AgentBoardAppModel.swift` (`selectedDestination` default becomes `.dashboard`). Check `AppDestinationTests.swift` and any pinned source-text tests for tab lists and update them deliberately.
+
+## Task H3: DashboardScreen
+
+**Files:** Create `AgentBoardUI/Screens/DashboardScreen.swift`; extend `AgentBoardTests/AccessibilityIdentifierTests.swift` if it pins per-screen coverage (follow its pattern).
+
+- Layout: scrollable grid of tiles (adaptive columns — 2-up compact, 3-up regular) using the existing neumorphic card styling (mirror how `AgentsScreen`/`WorkScreen` build cards with NeuPalette; reuse `BoardChrome` components where they fit). Screen root gets `.accessibilityIdentifier("screen_dashboard")`.
+- Tiles (each a `Button` navigating via `appModel.selectedDestination = ...`, accessibility id `dashboard_tile_<name>`):
+  1. **Agent tasks** → `.agents`: running/ready/blocked counts + up to 3 running task titles.
+  2. **Work items** → `.work`: To Do / In Progress / Resolved counts (via `WorkBoardColumn`).
+  3. **Sessions** → `.sessions`: active/total + sync status line.
+  4. **Chat** → `.chat` (on desktop: opens the chat inspector — check how the inspector is toggled in DesktopRootView and do the equivalent; on mobile selects the chat tab): connection state + up to 3 recent conversation titles.
+- Data: compute `DashboardSnapshot.build(...)` from `appModel`'s stores in the view body (stores are @Observable — recomputation is automatic). A refresh toolbar button calls `appModel.refreshAll()` (id `dashboard_button_refresh`).
+- Empty states: tiles render zeros gracefully (no blank tiles).
+- Design: match the app's existing visual system exactly — typography, palette, corner radii, and shadows from NeumorphicTheme. No new colors or fonts.
+
+Gate: full suite green, three schemes build, SwiftLint strict clean, `xcodegen generate` for new files. Branch `feat/issue-146-dashboard`. Commits: `feat: DashboardSnapshot aggregation model (#146)`, `feat: dashboard destination and routing (#146)`, `feat: dashboard home screen (#146)`.
+
+## Self-review notes
+- Desktop default destination changes from `.chat` (which renders WorkScreen anyway) to `.dashboard` — strictly an improvement; verify no test pins the old default.
+- The chat tile's desktop behavior depends on how the inspector toggle works — the implementer must read DesktopRootView first and match the existing mechanism rather than invent one.


### PR DESCRIPTION
Phase 4 PR H of `docs/superpowers/plans/2026-07-17-phase4-dashboard.md` — the final slice of the feature-complete roadmap. Stacked on #159 (already merged).

- New pure `DashboardSnapshot` aggregation model (unit-tested) — no new services or stores
- `.dashboard` is the first destination on both platforms; desktop detail + sidebar wired, default destination is now Dashboard
- Four navigating tiles (agent tasks, work items via the new 3-column buckets, sessions + sync status, chat with recent conversations) in the app's existing neumorphic styling; refresh header button + pull-to-refresh; `dashboard_*` accessibility ids pinned in tests
- **Bug fixed en route:** `MobileRootView`'s tab selection was bound to a private local `@State`, decoupled from `appModel.selectedDestination` — programmatic navigation on iOS was a silent no-op; now bound via `@Bindable` to the app model
- 488/488 tests (+7); all three schemes build; SwiftLint strict clean. Implemented by a Sonnet subagent, reviewed + verified here.

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)