### PR TITLE
fix: companion conversations carry hermesSessionID (#152)

### DIFF
--- a/AgentBoardCompanionKit/CompanionSQLiteStore.swift
+++ b/AgentBoardCompanionKit/CompanionSQLiteStore.swift
@@ -97,7 +97,8 @@ public actor CompanionSQLiteStore {
                 id TEXT PRIMARY KEY NOT NULL,
                 title TEXT NOT NULL,
                 model_id TEXT,
-                updated_at REAL NOT NULL
+                updated_at REAL NOT NULL,
+                hermes_session_id TEXT
             );
             """
         )
@@ -137,6 +138,11 @@ public actor CompanionSQLiteStore {
         if let messageColumns = try? existingColumns(table: "conversation_messages"),
            !messageColumns.contains("attachments_json") {
             try? execute("ALTER TABLE conversation_messages ADD COLUMN attachments_json TEXT;")
+        }
+
+        if let conversationColumns = try? existingColumns(table: "conversations"),
+           !conversationColumns.contains("hermes_session_id") {
+            try? execute("ALTER TABLE conversations ADD COLUMN hermes_session_id TEXT;")
         }
     }
 
@@ -313,8 +319,8 @@ public actor CompanionSQLiteStore {
         for conversation in conversations {
             let statement = try prepare(
                 """
-                INSERT INTO conversations (id, title, model_id, updated_at)
-                VALUES (?, ?, ?, ?);
+                INSERT INTO conversations (id, title, model_id, updated_at, hermes_session_id)
+                VALUES (?, ?, ?, ?, ?);
                 """
             )
             defer { sqlite3_finalize(statement) }
@@ -323,6 +329,7 @@ public actor CompanionSQLiteStore {
             bind(conversation.title, to: 2, in: statement)
             bind(conversation.modelID, to: 3, in: statement)
             sqlite3_bind_double(statement, 4, conversation.updatedAt.timeIntervalSince1970)
+            bind(conversation.hermesSessionID, to: 5, in: statement)
 
             guard sqlite3_step(statement) == SQLITE_DONE else {
                 throw StoreError.stepFailed(Self.sqliteMessage(handle.raw))
@@ -333,7 +340,7 @@ public actor CompanionSQLiteStore {
     public func listConversations() throws -> [ChatConversation] {
         let statement = try prepare(
             """
-            SELECT id, title, model_id, updated_at
+            SELECT id, title, model_id, updated_at, hermes_session_id
             FROM conversations
             ORDER BY updated_at DESC;
             """
@@ -348,7 +355,8 @@ public actor CompanionSQLiteStore {
                     id: id,
                     title: string(statement, index: 1),
                     modelID: nullableString(statement, index: 2),
-                    updatedAt: date(statement, index: 3)
+                    updatedAt: date(statement, index: 3),
+                    hermesSessionID: nullableString(statement, index: 4)
                 )
             )
         }
@@ -373,8 +381,8 @@ public actor CompanionSQLiteStore {
 
         let insertConv = try prepare(
             """
-            INSERT INTO conversations (id, title, model_id, updated_at)
-            VALUES (?, ?, ?, ?);
+            INSERT INTO conversations (id, title, model_id, updated_at, hermes_session_id)
+            VALUES (?, ?, ?, ?, ?);
             """
         )
         defer { sqlite3_finalize(insertConv) }
@@ -383,6 +391,7 @@ public actor CompanionSQLiteStore {
         bind(conversation.title, to: 2, in: insertConv)
         bind(conversation.modelID, to: 3, in: insertConv)
         sqlite3_bind_double(insertConv, 4, conversation.updatedAt.timeIntervalSince1970)
+        bind(conversation.hermesSessionID, to: 5, in: insertConv)
 
         guard sqlite3_step(insertConv) == SQLITE_DONE else {
             throw StoreError.stepFailed(Self.sqliteMessage(handle.raw))

--- a/AgentBoardTests/CompanionSQLiteStoreTests.swift
+++ b/AgentBoardTests/CompanionSQLiteStoreTests.swift
@@ -1,7 +1,11 @@
 @testable import AgentBoardCompanionKit
 import AgentBoardCore
 import Foundation
+import SQLite3
 import Testing
+
+// swiftformat:disable:next modifierOrder
+nonisolated private let testSqliteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 
 struct CompanionSQLiteStoreTests {
     @Test
@@ -143,6 +147,109 @@ struct CompanionSQLiteStoreTests {
     }
 
     @Test
+    func replaceConversationsRoundTripsHermesSessionIDWithAndWithoutValue() async throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appending(path: "agentboard-conversations-\(UUID().uuidString).sqlite")
+
+        let store = try CompanionSQLiteStore(databaseURL: databaseURL)
+        try await store.initializeSchema()
+
+        let withSession = ChatConversation(
+            title: "Bound to Hermes",
+            updatedAt: Date(timeIntervalSince1970: 1900),
+            hermesSessionID: "hermes-session-42"
+        )
+        let withoutSession = ChatConversation(
+            title: "No Hermes binding",
+            updatedAt: Date(timeIntervalSince1970: 1901)
+        )
+
+        try await store.replaceConversations([withSession, withoutSession])
+
+        let conversations = try await store.listConversations()
+
+        #expect(conversations.first { $0.id == withSession.id }?.hermesSessionID == "hermes-session-42")
+        #expect(conversations.first { $0.id == withoutSession.id }?.hermesSessionID == nil)
+    }
+
+    @Test
+    func saveConversationSnapshotRoundTripsHermesSessionID() async throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appending(path: "agentboard-conversations-\(UUID().uuidString).sqlite")
+
+        let store = try CompanionSQLiteStore(databaseURL: databaseURL)
+        try await store.initializeSchema()
+
+        let conversationID = UUID()
+        let conversation = ChatConversation(
+            id: conversationID,
+            title: "Snapshot with Hermes",
+            modelID: "hermes-agent",
+            updatedAt: Date(timeIntervalSince1970: 1902),
+            hermesSessionID: "hermes-session-99"
+        )
+
+        try await store.saveConversationSnapshot(conversation: conversation, messages: [])
+
+        let conversations = try await store.listConversations()
+
+        #expect(conversations == [conversation])
+        #expect(conversations.first?.hermesSessionID == "hermes-session-99")
+    }
+
+    @Test
+    func migratesLegacyConversationsTableToAddHermesSessionIDColumn() async throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appending(path: "agentboard-legacy-conversations-\(UUID().uuidString).sqlite")
+
+        // Hand-create the legacy 4-column schema (no hermes_session_id) before the store ever opens it.
+        var legacyHandle: OpaquePointer?
+        #expect(sqlite3_open_v2(
+            databaseURL.path,
+            &legacyHandle,
+            SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX,
+            nil
+        ) == SQLITE_OK)
+        #expect(sqlite3_exec(
+            legacyHandle,
+            """
+            CREATE TABLE conversations (
+                id TEXT PRIMARY KEY NOT NULL,
+                title TEXT NOT NULL,
+                model_id TEXT,
+                updated_at REAL NOT NULL
+            );
+            """,
+            nil, nil, nil
+        ) == SQLITE_OK)
+        let legacyID = UUID()
+        var insertStatement: OpaquePointer?
+        #expect(sqlite3_prepare_v2(
+            legacyHandle,
+            "INSERT INTO conversations (id, title, model_id, updated_at) VALUES (?, ?, ?, ?);",
+            -1, &insertStatement, nil
+        ) == SQLITE_OK)
+        sqlite3_bind_text(insertStatement, 1, legacyID.uuidString, -1, testSqliteTransient)
+        sqlite3_bind_text(insertStatement, 2, "Legacy conversation", -1, testSqliteTransient)
+        sqlite3_bind_null(insertStatement, 3)
+        sqlite3_bind_double(insertStatement, 4, 1500)
+        #expect(sqlite3_step(insertStatement) == SQLITE_DONE)
+        sqlite3_finalize(insertStatement)
+        sqlite3_close(legacyHandle)
+
+        // Opening the store over the legacy DB should migrate the schema in place.
+        let store = try CompanionSQLiteStore(databaseURL: databaseURL)
+        try await store.initializeSchema()
+
+        let conversations = try await store.listConversations()
+
+        #expect(conversations.count == 1)
+        #expect(conversations.first?.id == legacyID)
+        #expect(conversations.first?.title == "Legacy conversation")
+        #expect(conversations.first?.hermesSessionID == nil)
+    }
+
+    @Test
     func companionClientUsesConversationRoutes() async throws {
         let conversationID = UUID()
         let client = CompanionClient(session: makeMockSession { request in
@@ -181,6 +288,56 @@ struct CompanionSQLiteStoreTests {
         _ = try await client.loadMessages(conversationID: conversationID)
         try await client.syncConversations(conversations: [], messagesByConversation: [:])
         try await client.deleteConversationOnServer(id: conversationID)
+    }
+
+    @Test
+    func companionClientRoundTripsHermesSessionIDInBothSyncDirections() async throws {
+        let conversation = ChatConversation(
+            title: "Bound conversation",
+            updatedAt: Date(timeIntervalSince1970: 2000),
+            hermesSessionID: "hermes-session-round-trip"
+        )
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+
+        let client = CompanionClient(session: makeMockSession { request in
+            let requestURL = try #require(request.url)
+            let response = try HTTPURLResponse(
+                url: requestURL,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+
+            switch (request.httpMethod, request.url?.path) {
+            case ("GET", "/v1/conversations"):
+                // Pull direction: companion -> app must preserve hermesSessionID.
+                return try (response, encoder.encode([conversation]))
+            case ("POST", "/v1/conversations/sync"):
+                // Push direction: app -> companion must send hermesSessionID on the wire.
+                let bodyData = try #require(request.httpBody ?? request.bodyStreamData())
+                let payload = try decoder.decode(ConversationSyncPayload.self, from: bodyData)
+                #expect(payload.conversations.first?.hermesSessionID == "hermes-session-round-trip")
+                return (response, Data(#"{"ok":true}"#.utf8))
+            default:
+                let failingResponse = try HTTPURLResponse(
+                    url: requestURL,
+                    statusCode: 404,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                return (failingResponse, Data("unexpected route".utf8))
+            }
+        })
+
+        try await client.configure(baseURL: "http://companion.test:8742", bearerToken: nil)
+
+        let pulled = try await client.listConversations()
+        #expect(pulled.first?.hermesSessionID == "hermes-session-round-trip")
+
+        try await client.syncConversations(conversations: [conversation], messagesByConversation: [:])
     }
 }
 

--- a/docs/superpowers/plans/2026-07-18-followups-152-155-157.md
+++ b/docs/superpowers/plans/2026-07-18-followups-152-155-157.md
@@ -1,0 +1,51 @@
+# Follow-ups #152 / #157 / #155 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the three follow-ups from the feature-complete effort: cross-device Hermes-session continuity (#152), live per-agent session counts (#157), and drop targets for empty compact-layout columns (#155).
+
+**Architecture:** Three independent PRs, each branched from main (no file overlap). Order: #152 → #157 → #155.
+
+**Tech Stack / Global Constraints:** identical to prior phase plans (Swift 6 strict concurrency, TDD, Swift Testing, SwiftLint strict, three schemes build, full suite green per PR — baseline 488; `xcodegen generate` for new files; `-derivedDataPath ./DerivedData` locally).
+
+---
+
+## PR I — #152: Companion sync carries hermesSessionID
+
+**Verified facts:** `AgentBoardCompanionKit/CompanionSQLiteStore.swift` `conversations` table = (id, title, model_id, updated_at) — created at ~line 96, written at ~309/376, read at ~337. `ChatConversation.hermesSessionID` exists (Phase 1). Sync flows through `CompanionClient` (app side) ↔ `CompanionServer` (REST) ↔ `CompanionSQLiteStore`, orchestrated by `ChatConversationSyncCoordinator`.
+
+**Tasks:**
+1. **Schema + migration.** Add `hermes_session_id TEXT` to the `conversations` CREATE TABLE, AND a startup migration for existing DBs: `CREATE TABLE IF NOT EXISTS` won't alter existing tables, so on open run `PRAGMA table_info(conversations)` and `ALTER TABLE conversations ADD COLUMN hermes_session_id TEXT` when absent (follow any existing migration pattern in the file first; if none exists, this introduces the minimal one). Write/read the column in `replaceConversations`, the single-upsert path (~line 376), and the SELECT (~line 337).
+2. **Wire the payloads end-to-end.** Trace the conversation DTOs: CompanionServer route encoding, CompanionClient decoding, and `ChatConversationSyncCoordinator` mapping — `hermesSessionID` must survive a full round-trip in both directions (push and pull). All JSON fields optional/backward-compatible so old app ↔ new companion (and vice versa) don't break.
+3. **Tests.** `CompanionSQLiteStoreTests`: round-trip a conversation with and without `hermesSessionID`; migration test — build a store, simulate a legacy table (create the old 4-column schema by hand in a temp DB, then open the store over it) and assert the column is added and reads back nil. `CompanionClientEventsTests`/sync-coordinator tests: payload round-trip keeps the field.
+
+Branch `fix/issue-152-companion-session-id`. Commits: `fix: companion conversations carry hermesSessionID (#152)` (+ a second commit only if server/client DTOs live in separately-testable layers worth splitting).
+
+---
+
+## PR J — #157: Live linkedTaskID → real session counts
+
+**Verified facts:** `AgentSession.linkedTaskID` exists (DomainModels.swift:362) and `AgentBoardAppModel.activeSessionCounts` already joins it to task assignees — but nothing populates it: the companion's probe and demo fixtures leave it nil (only unknown SQLite paths set it). `SessionLauncher` names tmux sessions `ab-<repo>-<issueNumber>`. Kanban `task_runs` exist (`KanbanDataService.fetchRuns`, `KanbanRun` model) and may map task ↔ session/tmux identity.
+
+**Tasks:**
+1. **Spike (time-boxed, first commit contains findings as code comments/ADR note, not a doc).** Inspect: (a) `KanbanRun`'s fields (`AgentBoardCore/Models/KanbanModels.swift`) and the live `~/.hermes/kanban.db` `task_runs` schema (`sqlite3 ~/.hermes/kanban.db '.schema task_runs'` + a sample row) for a session/tmux identifier; (b) `CompanionLocalProbe`/`CompanionServer` session discovery — what identity does a discovered session carry (tmux name?). Pick the cheapest correct join and document why.
+2. **Implement whichever the spike supports:**
+   - **Preferred if task_runs carries a session/tmux id:** app-side enrichment — when refreshing, join discovered sessions to kanban runs (match tmux/session name) and set `linkedTaskID` before it reaches `SessionsStore`/cache. Put the pure matcher in Core (`static func linkTasks(sessions:runs:)`-style, fully unit-tested).
+   - **Fallback:** companion-side — probe parses its own launch metadata (e.g. sessions launched via `SessionLauncher` record task/issue linkage at launch; check whether SessionLauncher's active-session tracking already stores the kanban task id and can hand it to the companion).
+   - If NEITHER source can yield a real mapping, stop and report — do not fake it.
+3. **Tests:** pure matcher tests (match, no-match, ambiguous names); an integration-shaped test through SessionsStore/AgentsStore proving a linked session produces a non-zero `activeSessionCount` for the right agent.
+
+Branch `fix/issue-157-linked-task-id`. Commit: `fix: populate AgentSession.linkedTaskID for live board session counts (#157)`.
+
+---
+
+## PR K — #155: Compact layout drop targets for empty columns
+
+**Verified facts:** `AgentsScreen.swift` compact/stacked layout wraps each status section in `if !columnTasks.isEmpty { ... }` (~line 144–148 region), so empty columns render nothing and can't receive drops; the wide layout always renders columns with a "None" placeholder.
+
+**Tasks:**
+1. Always render each board column's section in compact layout: header (with count 0) + when empty, a small dashed-outline drop placeholder ("Drop tasks here" caption, existing palette, `.accessibilityIdentifier("kanban_dropzone_\(status.rawValue)")`), with the section's existing `.dropDestination` attached regardless of emptiness. Match wide-layout's placeholder look where sensible.
+2. Consider noise: hiding permanently-irrelevant empty columns was arguably intentional visual economy — mitigate by keeping empty sections visually compact (small header + slim drop zone, no tall empty boxes).
+3. Tests: extend the pinned source-text/accessibility tests per existing patterns (verify the new identifier is pinned; behavior itself is view-layer).
+
+Branch `fix/issue-155-compact-drop-targets`. Commit: `fix: compact agent board renders empty columns as drop targets (#155)`.


### PR DESCRIPTION
Follow-up PR I of `docs/superpowers/plans/2026-07-18-followups-152-155-157.md`.

- `conversations` table gains `hermes_session_id TEXT` with a PRAGMA-guarded ALTER TABLE migration for existing DBs (matches the file's existing migration pattern); threaded through replace/list/snapshot paths
- Research confirmed the HTTP sync layer already carried the field (ChatConversation is the wire payload — no DTO layer), so the SQL layer was the only drop point; scope is one production file
- 4 new tests incl. a legacy-DB migration test and a client-boundary push/pull round-trip; 492/492 suite; all three schemes build; SwiftLint strict clean. Implemented by a Sonnet subagent, reviewed + verified here.

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)