### PR TITLE
fix: compact agent board renders empty columns as drop targets (#155)

### DIFF
--- a/AgentBoardTests/AccessibilityIdentifierTests.swift
+++ b/AgentBoardTests/AccessibilityIdentifierTests.swift
@@ -203,6 +203,7 @@ struct AccessibilityIdentifierTests {
         ]
         assertIdentifiers(required, in: source)
         #expect(source.contains(#"kanban_cell_task_\(task.id)"#))
+        #expect(source.contains(#"kanban_dropzone_\(status.rawValue)"#))
     }
 
     @Test("Work screen exposes identifiers for header, search, repo picker, and create flow")

--- a/AgentBoardUI/Screens/AgentsScreen.swift
+++ b/AgentBoardUI/Screens/AgentsScreen.swift
@@ -143,10 +143,12 @@ struct AgentsScreen: View {
 
                         ForEach(KanbanStatus.boardColumns, id: \.self) { status in
                             let columnTasks = appModel.agentsStore.tasks.filter { $0.status == status }
-                            if !columnTasks.isEmpty {
-                                VStack(alignment: .leading, spacing: 12) {
-                                    kanbanColumnHeader(status: status, count: columnTasks.count)
+                            VStack(alignment: .leading, spacing: 12) {
+                                kanbanColumnHeader(status: status, count: columnTasks.count)
 
+                                if columnTasks.isEmpty {
+                                    compactDropzonePlaceholder(status: status)
+                                } else {
                                     ForEach(columnTasks) { task in
                                         KanbanTaskRow(
                                             task: task,
@@ -157,9 +159,9 @@ struct AgentsScreen: View {
                                         .draggable(KanbanTaskID(task.id))
                                     }
                                 }
-                                .dropDestination(for: KanbanTaskID.self) { ids, _ in
-                                    handleDrop(ids, to: status)
-                                }
+                            }
+                            .dropDestination(for: KanbanTaskID.self) { ids, _ in
+                                handleDrop(ids, to: status)
                             }
                         }
                     }
@@ -266,6 +268,22 @@ struct AgentsScreen: View {
                 .clipShape(Capsule())
             Spacer()
         }
+    }
+
+    /// Slim drop target for an empty compact-layout column. Keeps the section
+    /// present (and droppable) even with no tasks, without the tall empty
+    /// box the wide layout's "None" placeholder uses.
+    private func compactDropzonePlaceholder(status: KanbanStatus) -> some View {
+        Text("Drop tasks here")
+            .font(.caption)
+            .foregroundStyle(NeuPalette.textTertiary)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.vertical, 14)
+            .overlay {
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(NeuPalette.borderSoft, style: StrokeStyle(lineWidth: 1, dash: [4, 4]))
+            }
+            .accessibilityIdentifier("kanban_dropzone_\(status.rawValue)")
     }
 
     private var createTaskSheet: some View {


### PR DESCRIPTION
Follow-up PR K of `docs/superpowers/plans/2026-07-18-followups-152-155-157.md`.

- Compact/stacked layout always renders every board column: header with count 0 + a slim dashed "Drop tasks here" placeholder when empty (`kanban_dropzone_*` ids pinned), with the #143 `.dropDestination` attached regardless of emptiness — tasks can now be dragged into empty columns on iPhone
- 492/492 tests; all three schemes build; SwiftLint strict clean. Implemented by a Sonnet subagent, reviewed + verified here.

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)