### PR TITLE
feat: companion session transcripts + live transcript view (#166)

### DIFF
--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		73D0983941C6808FB4A17E35 /* ChatCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = A062681C1E251F786843C99C /* ChatCapability.swift */; };
 		73E3E44246ACF7764C2B96D9 /* AgentBoardCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B26E0DCF07C395E5DA349A4 /* AgentBoardCore.framework */; };
 		745D4F6C8C8317CA446F822D /* DashboardScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1FF2AE621C085664C1C791 /* DashboardScreen.swift */; };
+		76B247EEC86F1DB735601C7C /* TranscriptCaptureThrottleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9D4BB1359158928CC39AD6 /* TranscriptCaptureThrottleTests.swift */; };
 		77E2DDC0D4C0CA009FD508F0 /* EmbeddedTerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A978B41E9572538A1E74E5C /* EmbeddedTerminalView.swift */; };
 		7AC30545E6D54E227C8831BA /* AgentBoardCompanionKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB3E71CE348AC298EB4048DE /* AgentBoardCompanionKit.framework */; };
 		7DE9CA2273E136476F38D922 /* TaskDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651B64AF0921713BAE550D2D /* TaskDetailSheet.swift */; };
@@ -389,6 +390,7 @@
 		E84FB91863EEFC0DABE3E113 /* AgentsStoreSummariesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsStoreSummariesTests.swift; sourceTree = "<group>"; };
 		E8CF0F5C192569919CF193BC /* AgentsStoreCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsStoreCacheTests.swift; sourceTree = "<group>"; };
 		EA26177C115F337F0AC82395 /* SlashCommandHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandHandlerTests.swift; sourceTree = "<group>"; };
+		EA9D4BB1359158928CC39AD6 /* TranscriptCaptureThrottleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptCaptureThrottleTests.swift; sourceTree = "<group>"; };
 		F31C11E46072F7E4A9FFADDB /* AttachmentInteractions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentInteractions.swift; sourceTree = "<group>"; };
 		F5C500C7AF3B484DBB847E3A /* AgentsStoreCreateTaskTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsStoreCreateTaskTests.swift; sourceTree = "<group>"; };
 		F6FDDFF5030B377E6973E969 /* ChatScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScreen.swift; sourceTree = "<group>"; };
@@ -497,6 +499,7 @@
 				92E0CE9F3A8E9CA87A6C3B95 /* SessionsStoreTests.swift */,
 				B4813FBD80F9AC10D1A51841 /* SettingsStoreTests.swift */,
 				EA26177C115F337F0AC82395 /* SlashCommandHandlerTests.swift */,
+				EA9D4BB1359158928CC39AD6 /* TranscriptCaptureThrottleTests.swift */,
 				0F00F0612428FF4A1858440A /* WorkBoardColumnTests.swift */,
 				7863E93C0B04059321066BCD /* WorkStoreCRUDTests.swift */,
 				BB9701D71214407E75807732 /* WorkStoreTests.swift */,
@@ -1052,6 +1055,7 @@
 				F18232EF1BD587C14FCCD06F /* SessionsStoreTests.swift in Sources */,
 				D4674853A5F6064FC3E65542 /* SettingsStoreTests.swift in Sources */,
 				2525C93CDB9C86D825831FC9 /* SlashCommandHandlerTests.swift in Sources */,
+				76B247EEC86F1DB735601C7C /* TranscriptCaptureThrottleTests.swift in Sources */,
 				329205BFE190D828D883FF89 /* WorkBoardColumnTests.swift in Sources */,
 				293FC2DA4D1A99F6056A3C91 /* WorkStoreCRUDTests.swift in Sources */,
 				6F28FCEEB172015EFF5AFC70 /* WorkStoreTests.swift in Sources */,

--- a/AgentBoardCompanionKit/CompanionLocalProbe.swift
+++ b/AgentBoardCompanionKit/CompanionLocalProbe.swift
@@ -143,7 +143,7 @@ public actor CompanionLocalProbe {
     public func captureOutput(for session: AgentSession) async -> String? {
         let target = session.tmuxPaneID ?? session.tmuxSession
         guard let target else { return nil }
-        let raw = await shell("/usr/bin/env", ["tmux", "capture-pane", "-t", target, "-p", "-S", "-200"])
+        let raw = await shell("/usr/bin/env", ["tmux", "capture-pane", "-t", target, "-p", "-S", "-2000"])
         return raw.flatMap { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : $0 }
     }
 

--- a/AgentBoardCompanionKit/CompanionSQLiteStore.swift
+++ b/AgentBoardCompanionKit/CompanionSQLiteStore.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import AgentBoardCore
 import Foundation
 import SQLite3
@@ -114,6 +115,17 @@ public actor CompanionSQLiteStore {
                 is_streaming INTEGER NOT NULL DEFAULT 0,
                 attachments_json TEXT,
                 FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+            );
+            """
+        )
+
+        try execute(
+            """
+            CREATE TABLE IF NOT EXISTS session_transcripts (
+                session_id TEXT PRIMARY KEY NOT NULL,
+                content TEXT NOT NULL,
+                updated_at INTEGER NOT NULL,
+                is_final INTEGER NOT NULL DEFAULT 0
             );
             """
         )
@@ -470,6 +482,68 @@ public actor CompanionSQLiteStore {
         defer { sqlite3_finalize(deleteConv) }
         bind(id.uuidString, to: 1, in: deleteConv)
         guard sqlite3_step(deleteConv) == SQLITE_DONE else {
+            throw StoreError.stepFailed(Self.sqliteMessage(handle.raw))
+        }
+    }
+
+    // MARK: - Session transcripts
+
+    public func upsertTranscript(sessionID: String, content: String, isFinal: Bool) throws {
+        let statement = try prepare(
+            """
+            INSERT INTO session_transcripts (session_id, content, updated_at, is_final)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(session_id) DO UPDATE SET
+                content = excluded.content,
+                updated_at = excluded.updated_at,
+                is_final = excluded.is_final;
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+
+        bind(sessionID, to: 1, in: statement)
+        bind(content, to: 2, in: statement)
+        sqlite3_bind_int64(statement, 3, Int64(Date().timeIntervalSince1970))
+        sqlite3_bind_int(statement, 4, isFinal ? 1 : 0)
+
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw StoreError.stepFailed(Self.sqliteMessage(handle.raw))
+        }
+    }
+
+    public func transcript(sessionID: String) throws -> (content: String, updatedAt: Date, isFinal: Bool)? {
+        let statement = try prepare(
+            "SELECT content, updated_at, is_final FROM session_transcripts WHERE session_id = ?;"
+        )
+        defer { sqlite3_finalize(statement) }
+
+        bind(sessionID, to: 1, in: statement)
+
+        guard sqlite3_step(statement) == SQLITE_ROW else { return nil }
+        return (
+            content: string(statement, index: 0),
+            updatedAt: Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(statement, 1))),
+            isFinal: sqlite3_column_int(statement, 2) != 0
+        )
+    }
+
+    public func finalizeTranscriptsExcept(activeSessionIDs: [String]) throws {
+        guard !activeSessionIDs.isEmpty else {
+            try execute("UPDATE session_transcripts SET is_final = 1 WHERE is_final = 0;")
+            return
+        }
+
+        let placeholders = activeSessionIDs.map { _ in "?" }.joined(separator: ", ")
+        let statement = try prepare(
+            "UPDATE session_transcripts SET is_final = 1 WHERE is_final = 0 AND session_id NOT IN (\(placeholders));"
+        )
+        defer { sqlite3_finalize(statement) }
+
+        for (index, sessionID) in activeSessionIDs.enumerated() {
+            bind(sessionID, to: Int32(index + 1), in: statement)
+        }
+
+        guard sqlite3_step(statement) == SQLITE_DONE else {
             throw StoreError.stepFailed(Self.sqliteMessage(handle.raw))
         }
     }

--- a/AgentBoardCompanionKit/CompanionServer.swift
+++ b/AgentBoardCompanionKit/CompanionServer.swift
@@ -117,6 +117,17 @@ private final class SSESubscriber: @unchecked Sendable {
     }
 }
 
+/// Pure throttle rule for the transcript capture step (extracted so it's
+/// testable without the actor/lock plumbing in `CompanionServer`).
+enum TranscriptCaptureThrottle {
+    static let interval: TimeInterval = 10
+
+    static func shouldCapture(lastCaptureAt: Date?, now: Date) -> Bool {
+        guard let lastCaptureAt else { return true }
+        return now.timeIntervalSince(lastCaptureAt) >= interval
+    }
+}
+
 private actor CompanionEventBroker {
     private var subscribers: [UUID: SSESubscriber] = [:]
 
@@ -157,6 +168,7 @@ public final class CompanionServer: @unchecked Sendable {
     private struct LifecycleState: Sendable {
         var listener: NWListener?
         var refreshTask: Task<Void, Never>?
+        var lastTranscriptCaptureAt: Date?
     }
 
     private let lifecycle = OSAllocatedUnfairLock(initialState: LifecycleState())
@@ -258,9 +270,44 @@ public final class CompanionServer: @unchecked Sendable {
         let snapshot = await probe.snapshot()
         try await store.replaceSessions(snapshot.sessions)
         try await store.replaceAgents(snapshot.agents)
+        await captureTranscriptsIfDue(sessions: snapshot.sessions)
         await broker.publish(CompanionEvent(kind: .sessionsChanged))
         await broker.publish(CompanionEvent(kind: .agentsChanged))
         await broker.publish(CompanionEvent(kind: .snapshotRefreshed))
+    }
+
+    /// Best-effort transcript capture: throttled to roughly once per
+    /// `TranscriptCaptureThrottle.interval` regardless of how often the probe
+    /// snapshot itself runs, and never allowed to block session/agent
+    /// discovery — failures are logged and skipped.
+    private func captureTranscriptsIfDue(sessions: [AgentSession]) async {
+        let now = Date()
+        let shouldCapture = lifecycle.withLock { state -> Bool in
+            guard TranscriptCaptureThrottle.shouldCapture(lastCaptureAt: state.lastTranscriptCaptureAt, now: now) else {
+                return false
+            }
+            state.lastTranscriptCaptureAt = now
+            return true
+        }
+        guard shouldCapture else { return }
+
+        for session in sessions {
+            guard let content = await probe.captureOutput(for: session) else { continue }
+            do {
+                try await store.upsertTranscript(sessionID: session.id, content: content, isFinal: false)
+            } catch {
+                logger
+                    .error(
+                        "Failed to persist transcript for \(session.id, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                    )
+            }
+        }
+
+        do {
+            try await store.finalizeTranscriptsExcept(activeSessionIDs: sessions.map(\.id))
+        } catch {
+            logger.error("Failed to finalize transcripts: \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     private func accept(connection: NWConnection) {
@@ -476,6 +523,19 @@ public final class CompanionServer: @unchecked Sendable {
                 output = ""
             }
             try sendJSON(["output": output], over: connection)
+        case ("GET", "transcript"):
+            if let transcript = try await store.transcript(sessionID: sessionID) {
+                try sendJSON(
+                    SessionTranscript(
+                        content: transcript.content,
+                        updatedAt: transcript.updatedAt,
+                        isFinal: transcript.isFinal
+                    ),
+                    over: connection
+                )
+            } else {
+                try sendJSON(["error": "not_found"], over: connection)
+            }
         case ("POST", "nudge"):
             let ok: Bool
             if let session { ok = await probe.nudge(session: session) } else { ok = false }

--- a/AgentBoardCore/Models/DomainModels.swift
+++ b/AgentBoardCore/Models/DomainModels.swift
@@ -93,7 +93,7 @@ public struct HermesProfile: Codable, Hashable, Identifiable, Sendable {
 }
 
 public struct ToolActivity: Codable, Hashable, Sendable, Identifiable {
-public let id: String
+    public let id: String
     public let tool: String
     public var emoji: String?
     public var label: String?
@@ -438,6 +438,18 @@ public struct AgentSummary: Codable, Hashable, Identifiable, Sendable {
         self.activeSessionCount = activeSessionCount
         self.recentActivity = recentActivity
         self.updatedAt = updatedAt
+    }
+}
+
+public struct SessionTranscript: Codable, Hashable, Sendable {
+    public let content: String
+    public let updatedAt: Date
+    public let isFinal: Bool
+
+    public init(content: String, updatedAt: Date, isFinal: Bool) {
+        self.content = content
+        self.updatedAt = updatedAt
+        self.isFinal = isFinal
     }
 }
 

--- a/AgentBoardCore/Services/CompanionClient.swift
+++ b/AgentBoardCore/Services/CompanionClient.swift
@@ -150,6 +150,12 @@ public actor CompanionClient {
         return output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : output
     }
 
+    public func fetchTranscript(sessionID: String) async throws -> SessionTranscript? {
+        let (data, response) = try await session.data(for: makeRequest(path: "v1/sessions/\(sessionID)/transcript"))
+        try validate(response: response, data: data)
+        return try? decoder.decode(SessionTranscript.self, from: data)
+    }
+
     public func events() async throws -> AsyncThrowingStream<CompanionEvent, Error> {
         var request = makeRequest(path: "v1/events", timeout: RequestTimeout.stream)
         request.setValue("text/event-stream", forHTTPHeaderField: "Accept")

--- a/AgentBoardCore/Stores/SessionsStore.swift
+++ b/AgentBoardCore/Stores/SessionsStore.swift
@@ -146,6 +146,17 @@ public final class SessionsStore {
         }
     }
 
+    public func fetchTranscript(sessionID: String) async -> SessionTranscript? {
+        guard settingsStore.isCompanionConfigured else { return nil }
+        do {
+            return try await companionClient.fetchTranscript(sessionID: sessionID)
+        } catch {
+            logger.error("Failed to fetch session transcript: \(error.localizedDescription, privacy: .public)")
+            errorMessage = error.localizedDescription
+            return nil
+        }
+    }
+
     public func handle(event: CompanionEventKind) async {
         switch event {
         case .sessionsChanged, .snapshotRefreshed:

--- a/AgentBoardTests/AccessibilityIdentifierTests.swift
+++ b/AgentBoardTests/AccessibilityIdentifierTests.swift
@@ -96,7 +96,8 @@ struct AccessibilityIdentifierTests {
             "session_detail_picker_mode",
             "session_detail_button_close",
             "session_detail_menu_actions",
-            "session_detail_button_stop"
+            "session_detail_button_stop",
+            "session_transcript_view"
         ]
         assertIdentifiers(required, in: source)
     }

--- a/AgentBoardTests/CompanionSQLiteStoreTests.swift
+++ b/AgentBoardTests/CompanionSQLiteStoreTests.swift
@@ -7,6 +7,7 @@ import Testing
 // swiftformat:disable:next modifierOrder
 nonisolated private let testSqliteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 
+// swiftlint:disable:next type_body_length
 struct CompanionSQLiteStoreTests {
     @Test
     func makeSummariesGroupsSessionsByAgentModel() {
@@ -250,6 +251,121 @@ struct CompanionSQLiteStoreTests {
     }
 
     @Test
+    func upsertTranscriptRoundTripsContentAndFinalFlag() async throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appending(path: "agentboard-transcripts-\(UUID().uuidString).sqlite")
+
+        let store = try CompanionSQLiteStore(databaseURL: databaseURL)
+        try await store.initializeSchema()
+
+        let before = Date()
+        try await store.upsertTranscript(sessionID: "proc-1", content: "hello world", isFinal: false)
+        let after = Date()
+
+        let transcript = try #require(try await store.transcript(sessionID: "proc-1"))
+        #expect(transcript.content == "hello world")
+        #expect(transcript.isFinal == false)
+        #expect(transcript.updatedAt >= before.addingTimeInterval(-1))
+        #expect(transcript.updatedAt <= after.addingTimeInterval(1))
+
+        // Upserting again overwrites the row rather than duplicating it.
+        try await store.upsertTranscript(sessionID: "proc-1", content: "updated content", isFinal: true)
+        let updated = try #require(try await store.transcript(sessionID: "proc-1"))
+        #expect(updated.content == "updated content")
+        #expect(updated.isFinal == true)
+    }
+
+    @Test
+    func transcriptReturnsNilForUnknownSession() async throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appending(path: "agentboard-transcripts-\(UUID().uuidString).sqlite")
+
+        let store = try CompanionSQLiteStore(databaseURL: databaseURL)
+        try await store.initializeSchema()
+
+        let transcript = try await store.transcript(sessionID: "does-not-exist")
+        #expect(transcript == nil)
+    }
+
+    @Test
+    func finalizeTranscriptsExceptMarksOnlyDisappearedSessionsFinal() async throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appending(path: "agentboard-transcripts-\(UUID().uuidString).sqlite")
+
+        let store = try CompanionSQLiteStore(databaseURL: databaseURL)
+        try await store.initializeSchema()
+
+        try await store.upsertTranscript(sessionID: "proc-still-running", content: "still going", isFinal: false)
+        try await store.upsertTranscript(sessionID: "proc-ended", content: "last output", isFinal: false)
+
+        try await store.finalizeTranscriptsExcept(activeSessionIDs: ["proc-still-running"])
+
+        let stillRunning = try #require(try await store.transcript(sessionID: "proc-still-running"))
+        let ended = try #require(try await store.transcript(sessionID: "proc-ended"))
+        #expect(stillRunning.isFinal == false)
+        #expect(ended.isFinal == true)
+    }
+
+    @Test
+    func finalizeTranscriptsExceptWithNoActiveSessionsFinalizesEverything() async throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appending(path: "agentboard-transcripts-\(UUID().uuidString).sqlite")
+
+        let store = try CompanionSQLiteStore(databaseURL: databaseURL)
+        try await store.initializeSchema()
+
+        try await store.upsertTranscript(sessionID: "proc-ended", content: "last output", isFinal: false)
+
+        try await store.finalizeTranscriptsExcept(activeSessionIDs: [])
+
+        let ended = try #require(try await store.transcript(sessionID: "proc-ended"))
+        #expect(ended.isFinal == true)
+    }
+
+    @Test
+    func initializeSchemaAddsSessionTranscriptsTableToLegacyDatabase() async throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appending(path: "agentboard-legacy-transcripts-\(UUID().uuidString).sqlite")
+
+        // Hand-create a pre-PR-M database that predates the session_transcripts
+        // table entirely (only the original sessions table exists).
+        var legacyHandle: OpaquePointer?
+        #expect(sqlite3_open_v2(
+            databaseURL.path,
+            &legacyHandle,
+            SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX,
+            nil
+        ) == SQLITE_OK)
+        #expect(sqlite3_exec(
+            legacyHandle,
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY NOT NULL,
+                source TEXT NOT NULL,
+                status TEXT NOT NULL,
+                linked_task_id TEXT,
+                repo_owner TEXT,
+                repo_name TEXT,
+                issue_number INTEGER,
+                model TEXT,
+                started_at REAL NOT NULL,
+                last_seen_at REAL NOT NULL
+            );
+            """,
+            nil, nil, nil
+        ) == SQLITE_OK)
+        sqlite3_close(legacyHandle)
+
+        // Opening the store over the legacy DB should add the new table in place.
+        let store = try CompanionSQLiteStore(databaseURL: databaseURL)
+        try await store.initializeSchema()
+
+        try await store.upsertTranscript(sessionID: "proc-1", content: "post-migration content", isFinal: false)
+        let transcript = try #require(try await store.transcript(sessionID: "proc-1"))
+        #expect(transcript.content == "post-migration content")
+    }
+
+    @Test
     func companionClientUsesConversationRoutes() async throws {
         let conversationID = UUID()
         let client = CompanionClient(session: makeMockSession { request in
@@ -338,6 +454,52 @@ struct CompanionSQLiteStoreTests {
         #expect(pulled.first?.hermesSessionID == "hermes-session-round-trip")
 
         try await client.syncConversations(conversations: [conversation], messagesByConversation: [:])
+    }
+
+    @Test
+    func companionClientFetchesTranscript() async throws {
+        let updatedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+
+        let client = CompanionClient(session: makeMockSession { request in
+            #expect(request.url?.path == "/v1/sessions/proc-1/transcript")
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            let transcript = SessionTranscript(content: "line one\nline two", updatedAt: updatedAt, isFinal: true)
+            return try (response, encoder.encode(transcript))
+        })
+
+        try await client.configure(baseURL: "http://companion.test:8742", bearerToken: nil)
+
+        let transcript = try await client.fetchTranscript(sessionID: "proc-1")
+
+        #expect(transcript?.content == "line one\nline two")
+        #expect(transcript?.isFinal == true)
+        #expect(transcript?.updatedAt == updatedAt)
+    }
+
+    @Test
+    func companionClientFetchTranscriptReturnsNilWhenNotFound() async throws {
+        let client = CompanionClient(session: makeMockSession { request in
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, Data(#"{"error":"not_found"}"#.utf8))
+        })
+
+        try await client.configure(baseURL: "http://companion.test:8742", bearerToken: nil)
+
+        let transcript = try await client.fetchTranscript(sessionID: "unknown")
+
+        #expect(transcript == nil)
     }
 }
 

--- a/AgentBoardTests/TranscriptCaptureThrottleTests.swift
+++ b/AgentBoardTests/TranscriptCaptureThrottleTests.swift
@@ -1,0 +1,27 @@
+@testable import AgentBoardCompanionKit
+import Foundation
+import Testing
+
+/// Coverage for the pure throttle rule that keeps the companion's transcript
+/// capture step to roughly once per `TranscriptCaptureThrottle.interval`,
+/// independent of how often the probe snapshot loop itself runs.
+struct TranscriptCaptureThrottleTests {
+    @Test
+    func shouldCaptureWhenNeverCapturedBefore() {
+        #expect(TranscriptCaptureThrottle.shouldCapture(lastCaptureAt: nil, now: Date()))
+    }
+
+    @Test
+    func shouldNotCaptureBeforeIntervalElapses() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let lastCaptureAt = now.addingTimeInterval(-(TranscriptCaptureThrottle.interval - 1))
+        #expect(!TranscriptCaptureThrottle.shouldCapture(lastCaptureAt: lastCaptureAt, now: now))
+    }
+
+    @Test
+    func shouldCaptureOnceIntervalHasElapsed() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let lastCaptureAt = now.addingTimeInterval(-TranscriptCaptureThrottle.interval)
+        #expect(TranscriptCaptureThrottle.shouldCapture(lastCaptureAt: lastCaptureAt, now: now))
+    }
+}

--- a/AgentBoardUI/Screens/SessionDetailSheet.swift
+++ b/AgentBoardUI/Screens/SessionDetailSheet.swift
@@ -10,6 +10,8 @@ struct SessionDetailSheet: View {
     @State private var selectedTab = 0
     @State private var finalOutput: String?
     @State private var isRefreshing = false
+    @State private var transcript: SessionTranscript?
+    @State private var isRefreshingTranscript = false
 
     var body: some View {
         NavigationStack {
@@ -26,6 +28,7 @@ struct SessionDetailSheet: View {
                         if session.tmuxSession != nil {
                             Text("Terminal").tag(2)
                         }
+                        Text("Transcript").tag(3)
                     }
                     .pickerStyle(.segmented)
                     .padding(.horizontal, 24)
@@ -36,6 +39,8 @@ struct SessionDetailSheet: View {
                         overviewTab
                     } else if selectedTab == 2 {
                         terminalTab
+                    } else if selectedTab == 3 {
+                        transcriptTab
                     } else {
                         logsTab
                     }
@@ -208,6 +213,45 @@ struct SessionDetailSheet: View {
             finalOutput = output
         }
         isRefreshing = false
+    }
+
+    private var transcriptTab: some View {
+        ScrollView(showsIndicators: false) {
+            LazyVStack(alignment: .leading, spacing: 8) {
+                if isRefreshingTranscript && transcript == nil {
+                    ProgressView().padding()
+                } else if let transcript, !transcript.content.isEmpty {
+                    Text(transcript.content)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(NeuPalette.textPrimary)
+                        .textSelection(.enabled)
+                        .padding(16)
+                } else {
+                    Text("No transcript available yet")
+                        .foregroundStyle(NeuPalette.textSecondary)
+                        .padding()
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .neuRecessed(cornerRadius: 16, depth: 6)
+        .padding(.horizontal, 24)
+        .padding(.bottom, 24)
+        .accessibilityIdentifier("session_transcript_view")
+        .task {
+            await fetchTranscript()
+        }
+        .onChange(of: appModel.sessionsStore.lastSyncedAt) { _, _ in
+            guard transcript?.isFinal != true else { return }
+            Task { await fetchTranscript() }
+        }
+    }
+
+    private func fetchTranscript() async {
+        isRefreshingTranscript = true
+        transcript = await appModel.sessionsStore.fetchTranscript(sessionID: session.id)
+        isRefreshingTranscript = false
     }
 
     @ViewBuilder

--- a/docs/superpowers/plans/2026-07-18-integrated-tmux-sessions.md
+++ b/docs/superpowers/plans/2026-07-18-integrated-tmux-sessions.md
@@ -1,0 +1,53 @@
+# Integrated tmux Sessions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver the integrated tmux-session experience per `docs/superpowers/specs/2026-07-18-integrated-tmux-sessions-design.md`: companion-persisted transcripts (+ iOS live view), macOS live read-only attach with Take Control, and lifecycle controls.
+
+**Architecture:** Three sequential PR slices (M → N → O), each independently shippable. Slice M is transport-agnostic groundwork both platforms consume; N and O are macOS-centric. All decisions and non-goals are in the spec — read it first.
+
+**Global Constraints:** identical to prior plans (Swift 6 strict concurrency, TDD, Swift Testing, SwiftLint strict, three schemes build, full suite green per PR — baseline 483; `xcodegen generate` for new files; `-derivedDataPath ./DerivedData`; accessibility ids per convention; the CompanionSQLiteStore migration + SQLITE_TRANSIENT house patterns; dot-env guard-hook workaround via scripts).
+
+**Verified prior art (build on these, don't reinvent):**
+- `CompanionLocalProbe` already has `captureOutput(for:)`, `nudge(session:)`, `stop(session:)` (~lines 143–170) — the probe knows how to capture panes and poke sessions.
+- `CompanionServer.route` switches on `(method, pathComponents)` (~line 329; see `("GET", ["v1", "sessions"])` and `handleSessionAction`).
+- `SessionLauncher` has `LaunchConfig` (~97), `ActiveSession` (~125), `activeSessions` (~187), `launch(config:)` (~205), `checkSession` (~258).
+- `EmbeddedTerminalView` spawns an executable in a real PTY with interactive keystrokes; `SessionTerminalView` already embeds it (~line 149) — inspect how it's currently invoked before rework.
+- `TmuxController` protocol + actor wraps tmux subprocess calls (`capturePane`, `openInTerminal`).
+
+---
+
+## PR M — Companion transcripts + iOS live view (slice 1)
+
+1. **Store:** `session_transcripts` table in `CompanionSQLiteStore` — `(session_id TEXT PRIMARY KEY, content TEXT NOT NULL, updated_at INTEGER NOT NULL, is_final INTEGER NOT NULL DEFAULT 0)`, created + migrated per house pattern. Methods: `upsertTranscript(sessionID:content:isFinal:)`, `transcript(sessionID:) -> (content: String, updatedAt: Date, isFinal: Bool)?`, `finalizeTranscriptsExcept(activeSessionIDs:)`.
+2. **Capture loop:** in the companion's refresh cycle (find where `CompanionLocalProbe.snapshot()` is polled — likely `AgentBoardCompanionMain`/server runtime), after each snapshot: for every live session call `probe.captureOutput` (bound scrollback ~2000 lines — check what captureOutput currently captures and extend with a `-S` depth if needed) and upsert; then `finalizeTranscriptsExcept(active)`. Best-effort: failures logged, never block discovery. Throttle to ~every 10s (not every snapshot if snapshots are more frequent).
+3. **REST + client:** `GET /v1/sessions/{id}/transcript` route → JSON `{content, updatedAt, isFinal}`; `CompanionClient.fetchTranscript(sessionID:) -> SessionTranscript?` (new small Codable in Core), mirroring existing client call style.
+4. **UI:** transcript view in session detail on BOTH platforms (`SessionDetailSheet` — monospaced, scrollable, `session_transcript_view` id). While the session is running, refresh on the existing companion event stream (find how SessionsStore reacts to events and hang refetch off the same path); when `isFinal`, static. This IS the iOS live view.
+5. **Tests:** SQLite round-trip + legacy-migration + finalize logic; client fetch via MockURLProtocol; capture-throttle/finalize pure logic if extracted.
+
+Branch `feat/tmux-transcripts`. Commits: `feat: companion session transcripts (capture + store + API)`, `feat: transcript view with live refresh in session detail`.
+
+## PR N — macOS live attach + Take Control (slice 2)
+
+1. **`SessionAttachmentController`** (new, Core, `@MainActor @Observable`): states `.detached/.attachedReadOnly(sessionName:)/.attachedInteractive(sessionName:)/.failed(message:)`; `attach(sessionName:)`, `takeControl()`, `releaseControl()`, `detach()`; pure `static func attachArguments(sessionName:readOnly:) -> [String]` (`["attach-session", "-r", "-t", name]` / without `-r`). The controller doesn't spawn processes itself — it publishes the desired command; the view layer owns the PTY (respect the existing EmbeddedTerminalView contract; check how it takes executable+args and how termination is observed).
+2. **Terminal rework:** `SessionTerminalView` hosts the attached client: attach on appear via tmux path resolution (reuse whatever TmuxController/ShellEnvironment does to find tmux), re-attach on Take Control toggle (kill client PTY, respawn without `-r`), banner when interactive, swallow keystrokes at the view layer when read-only (defense in depth), `.failed` falls back to the PR M transcript view. Minimize kills the client PTY only and shows a restorable chip in the sessions rail (inspect the rail in `SessionsScreen`/`DesktopSidebar` and follow its existing item pattern). One attachment at a time — attaching another session detaches the first.
+3. **Accessibility ids:** `session_terminal_view`, `session_button_takecontrol`, `session_button_minimize` (+ pin in source-text tests).
+4. **Tests:** controller state machine with a fake command-runner seam; `attachArguments` matrix; source pins. PTY behavior is compile-verified (test target can't exercise UI).
+
+Branch `feat/tmux-attach` (stacked on M). Commits: `feat: SessionAttachmentController with read-only/interactive attach`, `feat: live attached terminal with Take Control and minimize`.
+
+## PR O — Lifecycle controls (slice 3)
+
+1. **TmuxController:** add `sendKeys(name:text:)` (`send-keys -t <name> -l <text>` then `Enter` as a separate send) and `killSession(name:)` (`kill-session -t <name>`), wrapper style as existing; extend the `TmuxControlling` protocol + all fakes.
+2. **SessionLauncher:** persist `LaunchConfig` by session name at launch (small Codable dict via `SettingsRepository`-style storage — inspect how launcher currently persists anything; if nothing, add a minimal UserDefaults-backed store in Core); `canRelaunch(sessionName:) -> Bool`; `relaunch(sessionName:) async -> String?` = killSession + launch(stored config). Foreign sessions: no restart.
+3. **UI:** terminal header gains Nudge field + send (`session_textfield_nudge`, `session_button_nudge_send`), Restart (`session_button_restart`, only when `canRelaunch`), Kill with confirmation dialog (`session_button_kill`). Failures surface via the existing store `errorMessage`/toast pattern.
+4. **Tests:** sendKeys/killSession argument construction via writer-fake pattern; LaunchConfig persistence round-trip; relaunch eligibility; source pins for the new ids.
+
+Branch `feat/tmux-lifecycle` (stacked on N). Commit: `feat: session lifecycle controls — nudge, kill, restart`.
+
+---
+
+## Self-review notes
+- The probe's existing `nudge`/`stop` (companion-side) vs new TmuxController `sendKeys`/`killSession` (app-side): PR O uses the APP-side path (macOS talks to tmux directly, same as attach); the companion primitives serve remote/iOS futures and stay untouched. If the probe's implementations are directly reusable app-side, prefer extracting shared argument-building into Core over duplicating.
+- PR N's "view owns the PTY" split keeps the controller pure/testable given the UI-untestable constraint.
+- Spec non-goals apply: no iOS input proxying, one attachment at a time, Hermes daemons out of scope.


### PR DESCRIPTION
Tmux-sessions slice 1 (PR M) of `docs/superpowers/plans/2026-07-18-integrated-tmux-sessions.md`.

- New `session_transcripts` table (self-migrating; legacy-DB test pinned anyway) with upsert/read/finalize; throttled ~10s capture in the companion's probe cycle, published BEFORE the SSE event so live refetches never see stale content
- `GET /v1/sessions/{id}/transcript` + `CompanionClient.fetchTranscript`; scrollback depth 200 → 2000 lines (note: also deepens the existing output endpoint — same probe method, intentional)
- Transcript tab in session detail on BOTH platforms — live-refreshing via the existing companion event signal while running, static when final. **This is the iOS live session view.**
- 493/493 tests (+10); all three schemes build; SwiftLint strict clean. Implemented by a Sonnet subagent, reviewed + verified here.

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)