### PR TITLE
feat: macOS live tmux attach with Take Control (#167)

### DIFF
--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		171A150F155917F5196D7647 /* ChatHeaderPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01910C75287C5F3B6650B2A /* ChatHeaderPickerTests.swift */; };
 		18479A684D668F5C137C5C86 /* TmuxController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B80C98C4E1D5870D7ED4E2D /* TmuxController.swift */; };
 		18513E9340A65D8111F82D18 /* DomainPills.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A169A5D550028B6D20B397D /* DomainPills.swift */; };
+		19C152C9A61C6B7530B2672B /* SessionAttachmentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3A8C23826AD8125B9E85E2 /* SessionAttachmentController.swift */; };
 		1C711E565B9941FC998F8265 /* WorkStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A06C1DAB866C77FF3A634D71 /* WorkStore.swift */; };
 		1C7E32DFC4B2295F98363820 /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F876603AEC9BE7B94289CA01 /* SettingsStore.swift */; };
 		1DBE4EB751A629F1664040D8 /* IssueDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A31E0F643092B573A4DB9D /* IssueDetailSheet.swift */; };
@@ -93,6 +94,7 @@
 		76B247EEC86F1DB735601C7C /* TranscriptCaptureThrottleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9D4BB1359158928CC39AD6 /* TranscriptCaptureThrottleTests.swift */; };
 		77E2DDC0D4C0CA009FD508F0 /* EmbeddedTerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A978B41E9572538A1E74E5C /* EmbeddedTerminalView.swift */; };
 		7AC30545E6D54E227C8831BA /* AgentBoardCompanionKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB3E71CE348AC298EB4048DE /* AgentBoardCompanionKit.framework */; };
+		7BC603692D8E25BF51DF8F9D /* SessionAttachmentControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542D187F8CE06B1BF01B7BB8 /* SessionAttachmentControllerTests.swift */; };
 		7DE9CA2273E136476F38D922 /* TaskDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651B64AF0921713BAE550D2D /* TaskDetailSheet.swift */; };
 		7E6D512A772F03628C275D52 /* LaunchSessionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AD61915721952F19190205 /* LaunchSessionSheet.swift */; };
 		81239439DAB83C92B81C7C96 /* AgentsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BDC7F11FD4398428433E67 /* AgentsStore.swift */; };
@@ -291,6 +293,7 @@
 		19CE389F4A620817A309F601 /* DesignSemanticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSemanticsTests.swift; sourceTree = "<group>"; };
 		1A169A5D550028B6D20B397D /* DomainPills.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainPills.swift; sourceTree = "<group>"; };
 		1B80C98C4E1D5870D7ED4E2D /* TmuxController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxController.swift; sourceTree = "<group>"; };
+		1D3A8C23826AD8125B9E85E2 /* SessionAttachmentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionAttachmentController.swift; sourceTree = "<group>"; };
 		1F06E0C2FFE9CAC90D48662B /* HermesGatewayClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesGatewayClientTests.swift; sourceTree = "<group>"; };
 		1FFDF3222AEE5530E6C58DFC /* QuickLaunchSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLaunchSheet.swift; sourceTree = "<group>"; };
 		26A31E0F643092B573A4DB9D /* IssueDetailSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailSheet.swift; sourceTree = "<group>"; };
@@ -319,6 +322,7 @@
 		4E8BA0A7421FAF69CBF5AD4F /* MarkdownBlockParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownBlockParser.swift; sourceTree = "<group>"; };
 		4F7D59DE18AF7B3E0D84EF9A /* DesktopSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopSidebar.swift; sourceTree = "<group>"; };
 		52959B32060C120BA1BB1AB7 /* ShellEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvironment.swift; sourceTree = "<group>"; };
+		542D187F8CE06B1BF01B7BB8 /* SessionAttachmentControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionAttachmentControllerTests.swift; sourceTree = "<group>"; };
 		54CA712A46E969ED79300E4F /* LinkPreviewService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkPreviewService.swift; sourceTree = "<group>"; };
 		5A9DDB4F3F626262EACA72A8 /* AudioPlaybackServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlaybackServiceTests.swift; sourceTree = "<group>"; };
 		5DE53DBCDB728D1E417AC4E5 /* ChatStreamCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStreamCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -495,6 +499,7 @@
 				BB5CC5206E88A59FBD80A856 /* NativeSwiftUIInterfaceTests.swift */,
 				0B023A92D06AE2F3272FC200 /* NoopAgentBoardCacheTests.swift */,
 				9503F3F8C1E54BE6D35A3641 /* PRDComposerTests.swift */,
+				542D187F8CE06B1BF01B7BB8 /* SessionAttachmentControllerTests.swift */,
 				CE1B1DC901AD1D60B3855D38 /* SessionLauncherTests.swift */,
 				92E0CE9F3A8E9CA87A6C3B95 /* SessionsStoreTests.swift */,
 				B4813FBD80F9AC10D1A51841 /* SettingsStoreTests.swift */,
@@ -702,6 +707,7 @@
 				C86007C1F74BD16FE6181012 /* ChatStore+Internals.swift */,
 				066AD427D541EBD8687B6276 /* ChatStore+SlashCommands.swift */,
 				A40E2B4B6D9AD354BA23C3BF /* ChatStreamCoordinator.swift */,
+				1D3A8C23826AD8125B9E85E2 /* SessionAttachmentController.swift */,
 				A5B9C06C17BE65937A00661D /* SessionsStore.swift */,
 				F876603AEC9BE7B94289CA01 /* SettingsStore.swift */,
 				A06C1DAB866C77FF3A634D71 /* WorkStore.swift */,
@@ -1051,6 +1057,7 @@
 				9781E0240F8A4C6FC3DC30B7 /* NativeSwiftUIInterfaceTests.swift in Sources */,
 				B13E9A7DA4903C65AE1FEEC6 /* NoopAgentBoardCacheTests.swift in Sources */,
 				DAB3EA4A5AF33E4165CD6551 /* PRDComposerTests.swift in Sources */,
+				7BC603692D8E25BF51DF8F9D /* SessionAttachmentControllerTests.swift in Sources */,
 				9A90C5EF45CA6630C7EA64CD /* SessionLauncherTests.swift in Sources */,
 				F18232EF1BD587C14FCCD06F /* SessionsStoreTests.swift in Sources */,
 				D4674853A5F6064FC3E65542 /* SettingsStoreTests.swift in Sources */,
@@ -1103,6 +1110,7 @@
 				DF0EA5DC994F51BF546BA378 /* NoopAgentBoardCache.swift in Sources */,
 				A86A0A76B46CE6265194C0A6 /* PRDComposer.swift in Sources */,
 				D806724D20A2D1EC0A81416B /* ProcessAsync.swift in Sources */,
+				19C152C9A61C6B7530B2672B /* SessionAttachmentController.swift in Sources */,
 				9EAAAF4FFBF10F8A576AF5BD /* SessionLauncher.swift in Sources */,
 				5407CC8EF71865713E95B1BF /* SessionsStore.swift in Sources */,
 				5B810A52F3C78D394BE76608 /* SettingsRepository.swift in Sources */,

--- a/AgentBoardCore/Services/SessionLauncher.swift
+++ b/AgentBoardCore/Services/SessionLauncher.swift
@@ -306,6 +306,18 @@ public final class SessionLauncher {
         LiveTmuxController.attachCommand(for: sessionName)
     }
 
+    /// Read-only/interactive variant used by the live-attach terminal
+    /// (`SessionAttachmentController`). Assembles the socket-qualified
+    /// executable + arguments from the pure `attachArguments` builder.
+    public static func attachCommand(
+        for sessionName: String,
+        readOnly: Bool
+    ) -> (executable: String, arguments: [String]) {
+        let arguments = ["-S", tmuxSocketPath] +
+            SessionAttachmentController.attachArguments(sessionName: sessionName, readOnly: readOnly)
+        return (tmuxExecutablePath, arguments)
+    }
+
     // MARK: - Monitoring
 
     public func startMonitoring() {

--- a/AgentBoardCore/Stores/SessionAttachmentController.swift
+++ b/AgentBoardCore/Stores/SessionAttachmentController.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Tracks the macOS live-terminal attachment to a single tmux session at a time.
+/// The controller never spawns a process itself — it only publishes the desired
+/// attachment state; the terminal view owns the real PTY and reports back via
+/// `handleProcessExit`.
+@MainActor
+@Observable
+public final class SessionAttachmentController {
+    public enum AttachmentState: Equatable, Sendable {
+        case detached
+        case attachedReadOnly(sessionName: String)
+        case attachedInteractive(sessionName: String)
+        case failed(message: String)
+    }
+
+    public private(set) var state: AttachmentState = .detached
+
+    public init() {}
+
+    /// Attaches read-only to `sessionName`. Attaching always replaces any
+    /// existing attachment — only one session is attached at a time.
+    public func attach(sessionName: String) {
+        state = .attachedReadOnly(sessionName: sessionName)
+    }
+
+    /// Switches the current read-only attachment to interactive (read-write).
+    /// No-op unless currently attached read-only.
+    public func takeControl() {
+        guard case let .attachedReadOnly(sessionName) = state else { return }
+        state = .attachedInteractive(sessionName: sessionName)
+    }
+
+    /// Switches the current interactive attachment back to read-only.
+    /// No-op unless currently attached interactively.
+    public func releaseControl() {
+        guard case let .attachedInteractive(sessionName) = state else { return }
+        state = .attachedReadOnly(sessionName: sessionName)
+    }
+
+    /// Terminates the current attachment. Only the local tmux client is
+    /// affected — the tmux session itself keeps running.
+    public func detach() {
+        state = .detached
+    }
+
+    /// Records an attach/re-attach failure (session gone, tmux missing, etc).
+    public func fail(message: String) {
+        state = .failed(message: message)
+    }
+
+    /// Called by the view layer when the underlying client PTY exits.
+    /// A client PTY is torn down for reasons other than the session actually
+    /// ending — most notably, taking/releasing control tears down the old
+    /// client to respawn the new one. Only honor the exit if `state` still
+    /// reflects the exact attachment (`sessionName`, `wasReadOnly`) that PTY
+    /// was spawned for; otherwise it's a stale signal from an attachment
+    /// that has already moved on.
+    public func handleProcessExit(sessionName: String, wasReadOnly: Bool) {
+        switch state {
+        case let .attachedReadOnly(name) where wasReadOnly && name == sessionName:
+            state = .detached
+        case let .attachedInteractive(name) where !wasReadOnly && name == sessionName:
+            state = .detached
+        default:
+            break
+        }
+    }
+
+    /// Pure tmux argument builder for attaching to `sessionName`. `-r` enforces
+    /// read-only at the tmux server itself — the UI's own keystroke swallowing
+    /// is defense in depth, not the safety mechanism.
+    public nonisolated static func attachArguments( // swiftlint:disable:this modifier_order
+        sessionName: String,
+        readOnly: Bool
+    ) -> [String] {
+        readOnly
+            ? ["attach-session", "-r", "-t", sessionName]
+            : ["attach-session", "-t", sessionName]
+    }
+}

--- a/AgentBoardTests/AccessibilityIdentifierTests.swift
+++ b/AgentBoardTests/AccessibilityIdentifierTests.swift
@@ -265,13 +265,15 @@ struct AccessibilityIdentifierTests {
         assertIdentifiers(required, in: source)
     }
 
-    @Test("Session terminal view exposes identifiers for embedded, failed, and stalled states")
+    @Test("Session terminal view exposes identifiers for attach, take control, minimize, failed, and stalled states")
     func sessionTerminalViewIdentifiers() throws {
         let source = try readUISource("Screens/SessionTerminalView.swift")
         let required = [
+            "session_terminal_view",
             "session_terminal_toggle_expand",
             "session_terminal_open_terminal",
-            "session_terminal_close",
+            "session_button_takecontrol",
+            "session_button_minimize",
             "session_terminal_embedded",
             "session_terminal_failed_open_terminal",
             "session_terminal_failed_close",

--- a/AgentBoardTests/SessionAttachmentControllerTests.swift
+++ b/AgentBoardTests/SessionAttachmentControllerTests.swift
@@ -1,0 +1,132 @@
+import AgentBoardCore
+import Testing
+
+@Suite("SessionAttachmentController")
+@MainActor
+struct SessionAttachmentControllerTests {
+    // MARK: - attachArguments (pure)
+
+    @Test("attachArguments read-only includes -r")
+    func attachArgumentsReadOnly() {
+        let args = SessionAttachmentController.attachArguments(sessionName: "ab-repo-1", readOnly: true)
+        #expect(args == ["attach-session", "-r", "-t", "ab-repo-1"])
+    }
+
+    @Test("attachArguments interactive omits -r")
+    func attachArgumentsInteractive() {
+        let args = SessionAttachmentController.attachArguments(sessionName: "ab-repo-1", readOnly: false)
+        #expect(args == ["attach-session", "-t", "ab-repo-1"])
+    }
+
+    // MARK: - State machine
+
+    @Test func initialStateIsDetached() {
+        let controller = SessionAttachmentController()
+        #expect(controller.state == .detached)
+    }
+
+    @Test func attachEntersReadOnlyState() {
+        let controller = SessionAttachmentController()
+        controller.attach(sessionName: "ab-repo-1")
+        #expect(controller.state == .attachedReadOnly(sessionName: "ab-repo-1"))
+    }
+
+    @Test func attachingASecondSessionDetachesTheFirst() {
+        let controller = SessionAttachmentController()
+        controller.attach(sessionName: "ab-repo-1")
+        controller.attach(sessionName: "ab-repo-2")
+        #expect(controller.state == .attachedReadOnly(sessionName: "ab-repo-2"))
+    }
+
+    @Test func takeControlSwitchesToInteractive() {
+        let controller = SessionAttachmentController()
+        controller.attach(sessionName: "ab-repo-1")
+        controller.takeControl()
+        #expect(controller.state == .attachedInteractive(sessionName: "ab-repo-1"))
+    }
+
+    @Test func takeControlIsNoOpWhenNotReadOnly() {
+        let controller = SessionAttachmentController()
+        controller.takeControl()
+        #expect(controller.state == .detached)
+    }
+
+    @Test func releaseControlSwitchesBackToReadOnly() {
+        let controller = SessionAttachmentController()
+        controller.attach(sessionName: "ab-repo-1")
+        controller.takeControl()
+        controller.releaseControl()
+        #expect(controller.state == .attachedReadOnly(sessionName: "ab-repo-1"))
+    }
+
+    @Test func releaseControlIsNoOpWhenNotInteractive() {
+        let controller = SessionAttachmentController()
+        controller.attach(sessionName: "ab-repo-1")
+        controller.releaseControl()
+        #expect(controller.state == .attachedReadOnly(sessionName: "ab-repo-1"))
+    }
+
+    @Test func detachReturnsToDetachedFromAnyState() {
+        let controller = SessionAttachmentController()
+        controller.attach(sessionName: "ab-repo-1")
+        controller.takeControl()
+        controller.detach()
+        #expect(controller.state == .detached)
+    }
+
+    @Test func failRecordsMessage() {
+        let controller = SessionAttachmentController()
+        controller.attach(sessionName: "ab-repo-1")
+        controller.fail(message: "tmux missing")
+        #expect(controller.state == .failed(message: "tmux missing"))
+    }
+
+    // MARK: - handleProcessExit
+
+    @Test func handleProcessExitDetachesOnMatchingReadOnlyExit() {
+        let controller = SessionAttachmentController()
+        controller.attach(sessionName: "ab-repo-1")
+        controller.handleProcessExit(sessionName: "ab-repo-1", wasReadOnly: true)
+        #expect(controller.state == .detached)
+    }
+
+    @Test func handleProcessExitDetachesOnMatchingInteractiveExit() {
+        let controller = SessionAttachmentController()
+        controller.attach(sessionName: "ab-repo-1")
+        controller.takeControl()
+        controller.handleProcessExit(sessionName: "ab-repo-1", wasReadOnly: false)
+        #expect(controller.state == .detached)
+    }
+
+    @Test("Stale exit from a superseded read-only client is ignored after Take Control")
+    func handleProcessExitIgnoresStaleReadOnlyExitAfterTakeControl() {
+        let controller = SessionAttachmentController()
+        controller.attach(sessionName: "ab-repo-1")
+        controller.takeControl()
+        // The old read-only PTY's delayed exit callback arrives after the swap.
+        controller.handleProcessExit(sessionName: "ab-repo-1", wasReadOnly: true)
+        #expect(controller.state == .attachedInteractive(sessionName: "ab-repo-1"))
+    }
+
+    @Test("Stale exit for a different session name is ignored")
+    func handleProcessExitIgnoresExitForDifferentSession() {
+        let controller = SessionAttachmentController()
+        controller.attach(sessionName: "ab-repo-1")
+        controller.handleProcessExit(sessionName: "ab-repo-2", wasReadOnly: true)
+        #expect(controller.state == .attachedReadOnly(sessionName: "ab-repo-1"))
+    }
+
+    @Test func handleProcessExitIsNoOpWhenDetached() {
+        let controller = SessionAttachmentController()
+        controller.handleProcessExit(sessionName: "ab-repo-1", wasReadOnly: true)
+        #expect(controller.state == .detached)
+    }
+
+    @Test func handleProcessExitIsNoOpWhenFailed() {
+        let controller = SessionAttachmentController()
+        controller.attach(sessionName: "ab-repo-1")
+        controller.fail(message: "boom")
+        controller.handleProcessExit(sessionName: "ab-repo-1", wasReadOnly: true)
+        #expect(controller.state == .failed(message: "boom"))
+    }
+}

--- a/AgentBoardTests/SessionLauncherTests.swift
+++ b/AgentBoardTests/SessionLauncherTests.swift
@@ -127,6 +127,24 @@ struct SessionLauncherTests {
         #expect(SessionLauncher.tmuxSocketPath.hasSuffix("/.tmux/sock"))
     }
 
+    @Test @MainActor func attachCommandReadOnlyIncludesSocketAndFlag() {
+        let attach = SessionLauncher.attachCommand(for: "ab-repo-1", readOnly: true)
+        #expect(attach.executable == SessionLauncher.tmuxExecutablePath)
+        #expect(attach.arguments == [
+            "-S", SessionLauncher.tmuxSocketPath,
+            "attach-session", "-r", "-t", "ab-repo-1"
+        ])
+    }
+
+    @Test @MainActor func attachCommandInteractiveOmitsReadOnlyFlag() {
+        let attach = SessionLauncher.attachCommand(for: "ab-repo-1", readOnly: false)
+        #expect(attach.executable == SessionLauncher.tmuxExecutablePath)
+        #expect(attach.arguments == [
+            "-S", SessionLauncher.tmuxSocketPath,
+            "attach-session", "-t", "ab-repo-1"
+        ])
+    }
+
     @Test @MainActor func checkSessionReturnsCompletedWhenPaneShowsSuccessfulExit() async {
         let launcher = SessionLauncher(tmux: FakeTmuxController(
             hasSessionResult: true,

--- a/AgentBoardUI/Components/EmbeddedTerminalView.swift
+++ b/AgentBoardUI/Components/EmbeddedTerminalView.swift
@@ -3,6 +3,18 @@
     import SwiftTerm
     import SwiftUI
 
+    /// `LocalProcessTerminalView` subclass that swallows keystrokes when
+    /// `isInputEnabled` is false. Defense in depth alongside tmux's own `-r`
+    /// read-only attach flag — not the safety mechanism itself.
+    final class ReadOnlyAwareTerminalView: LocalProcessTerminalView {
+        var isInputEnabled = true
+
+        override func send(source: TerminalView, data: ArraySlice<UInt8>) {
+            guard isInputEnabled else { return }
+            super.send(source: source, data: data)
+        }
+    }
+
     /// SwiftUI wrapper around SwiftTerm's `LocalProcessTerminalView`.
     /// Spawns the given executable inside a real PTY and renders an interactive terminal —
     /// keystrokes flow into the process, ANSI/colour output renders correctly.
@@ -10,15 +22,17 @@
         let executable: String
         let arguments: [String]
         let environment: [String]?
+        var isInputEnabled = true
         let onProcessExit: (Int32) -> Void
 
         func makeCoordinator() -> Coordinator {
             Coordinator(onProcessExit: onProcessExit)
         }
 
-        func makeNSView(context: Context) -> LocalProcessTerminalView {
-            let terminal = LocalProcessTerminalView(frame: .zero)
+        func makeNSView(context: Context) -> ReadOnlyAwareTerminalView {
+            let terminal = ReadOnlyAwareTerminalView(frame: .zero)
             terminal.processDelegate = context.coordinator
+            terminal.isInputEnabled = isInputEnabled
 
             terminal.font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
             terminal.nativeBackgroundColor = NSColor(srgbRed: 0.06, green: 0.06, blue: 0.08, alpha: 1.0)
@@ -33,8 +47,13 @@
             return terminal
         }
 
-        func updateNSView(_: LocalProcessTerminalView, context: Context) {
+        func updateNSView(_ nsView: ReadOnlyAwareTerminalView, context: Context) {
             context.coordinator.onProcessExit = onProcessExit
+            nsView.isInputEnabled = isInputEnabled
+        }
+
+        static func dismantleNSView(_ nsView: ReadOnlyAwareTerminalView, coordinator _: Coordinator) {
+            nsView.terminate()
         }
 
         final class Coordinator: NSObject, LocalProcessTerminalViewDelegate {

--- a/AgentBoardUI/Screens/SessionTerminalView.swift
+++ b/AgentBoardUI/Screens/SessionTerminalView.swift
@@ -8,6 +8,32 @@ struct SessionTerminalView: View {
     @Binding var isExpanded: Bool
     let onMinimize: () -> Void
 
+    @State private var attachmentController = SessionAttachmentController()
+    @State private var hasAttachedOnce = false
+    @State private var fallbackTranscript: SessionTranscript?
+
+    private var isReadOnly: Bool {
+        if case .attachedInteractive = attachmentController.state { return false }
+        return true
+    }
+
+    private var attachmentFailureMessage: String? {
+        if case let .failed(message) = attachmentController.state { return message }
+        return nil
+    }
+
+    private var showsAttachmentFallback: Bool {
+        switch attachmentController.state {
+        case .failed: true
+        case .detached: hasAttachedOnce
+        case .attachedReadOnly, .attachedInteractive: false
+        }
+    }
+
+    private var matchingAgentSession: AgentSession? {
+        appModel.sessionsStore.sessions.first { $0.tmuxSession == session.sessionName }
+    }
+
     private var statusColor: Color {
         switch session.status {
         case .running: NeuPalette.accentCyan
@@ -43,7 +69,11 @@ struct SessionTerminalView: View {
                 }
             }
         }
-        .accessibilityIdentifier("screen_session_terminal")
+        .accessibilityIdentifier("session_terminal_view")
+        .task(id: session.sessionName) {
+            attachmentController.attach(sessionName: session.sessionName)
+            hasAttachedOnce = true
+        }
     }
 
     // MARK: - Header
@@ -111,9 +141,31 @@ struct SessionTerminalView: View {
                 .buttonStyle(NeuButtonTarget(isAccent: true))
                 .accessibilityLabel("Open session in Terminal.app")
                 .accessibilityIdentifier("session_terminal_open_terminal")
+
+                #if os(macOS) && canImport(SwiftTerm)
+                    Button {
+                        if isReadOnly {
+                            attachmentController.takeControl()
+                        } else {
+                            attachmentController.releaseControl()
+                        }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: isReadOnly ? "keyboard" : "keyboard.fill")
+                                .font(.system(size: 11, weight: .semibold))
+                            Text(isReadOnly ? "Take Control" : "Release")
+                                .font(.caption.weight(.semibold))
+                        }
+                    }
+                    .buttonStyle(NeuButtonTarget(isAccent: !isReadOnly))
+                    .disabled(showsAttachmentFallback)
+                    .accessibilityLabel(isReadOnly ? "Take keyboard control of session" : "Release keyboard control")
+                    .accessibilityIdentifier("session_button_takecontrol")
+                #endif
             }
 
             Button {
+                attachmentController.detach()
                 onMinimize()
             } label: {
                 Image(systemName: "xmark.circle.fill")
@@ -121,8 +173,8 @@ struct SessionTerminalView: View {
                     .foregroundStyle(NeuPalette.textSecondary)
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Close session terminal")
-            .accessibilityIdentifier("session_terminal_close")
+            .accessibilityLabel("Minimize session terminal")
+            .accessibilityIdentifier("session_button_minimize")
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 12)
@@ -145,17 +197,11 @@ struct SessionTerminalView: View {
     @ViewBuilder
     private var terminalContentView: some View {
         #if os(macOS) && canImport(SwiftTerm)
-            let attach = SessionLauncher.attachCommand(for: session.sessionName)
-            EmbeddedTerminalView(
-                executable: attach.executable,
-                arguments: attach.arguments,
-                environment: nil,
-                onProcessExit: { _ in }
-            )
-            .id(session.sessionName)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color(red: 0.06, green: 0.06, blue: 0.08))
-            .accessibilityIdentifier("session_terminal_embedded")
+            if showsAttachmentFallback {
+                attachmentFallbackView
+            } else {
+                liveTerminalView
+            }
         #else
             VStack(spacing: 12) {
                 Image(systemName: "desktopcomputer.trianglebadge.exclamationmark")
@@ -168,6 +214,94 @@ struct SessionTerminalView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         #endif
     }
+
+    #if os(macOS) && canImport(SwiftTerm)
+        @ViewBuilder
+        private var liveTerminalView: some View {
+            let readOnly = isReadOnly
+            let attach = SessionLauncher.attachCommand(for: session.sessionName, readOnly: readOnly)
+            let sessionName = session.sessionName
+
+            VStack(spacing: 0) {
+                if !readOnly {
+                    interactiveBanner
+                }
+
+                EmbeddedTerminalView(
+                    executable: attach.executable,
+                    arguments: attach.arguments,
+                    environment: nil,
+                    isInputEnabled: !readOnly,
+                    onProcessExit: { _ in
+                        attachmentController.handleProcessExit(sessionName: sessionName, wasReadOnly: readOnly)
+                    }
+                )
+                .id("\(sessionName)-\(readOnly ? "ro" : "rw")")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color(red: 0.06, green: 0.06, blue: 0.08))
+                .accessibilityIdentifier("session_terminal_embedded")
+            }
+        }
+
+        private var interactiveBanner: some View {
+            HStack(spacing: 8) {
+                Image(systemName: "keyboard.fill")
+                    .font(.caption.weight(.bold))
+                Text("Keyboard input live")
+                    .font(.caption.weight(.bold))
+            }
+            .foregroundStyle(NeuPalette.accentCyan)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(NeuPalette.accentCyan.opacity(0.12))
+        }
+
+        private var transcriptContent: String {
+            guard let content = fallbackTranscript?.content, !content.isEmpty else {
+                return "No transcript available yet"
+            }
+            return content
+        }
+
+        private var attachmentFallbackView: some View {
+            VStack(spacing: 16) {
+                Image(systemName: "text.alignleft")
+                    .font(.system(size: 40))
+                    .foregroundStyle(NeuPalette.textSecondary)
+
+                Text(attachmentFailureMessage != nil ? "Attachment Failed" : "Session Ended")
+                    .font(.title3.weight(.bold))
+                    .foregroundStyle(NeuPalette.textPrimary)
+
+                if let message = attachmentFailureMessage {
+                    Text(message)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(NeuPalette.textTertiary)
+                        .padding(12)
+                        .background(Color.red.opacity(0.08))
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+
+                ScrollView(showsIndicators: false) {
+                    Text(transcriptContent)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(NeuPalette.textPrimary)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(16)
+                }
+                .neuRecessed(cornerRadius: 16, depth: 6)
+            }
+            .padding(24)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .accessibilityIdentifier("session_transcript_view")
+            .task(id: matchingAgentSession?.id) {
+                guard let agentSessionID = matchingAgentSession?.id else { return }
+                fallbackTranscript = await appModel.sessionsStore.fetchTranscript(sessionID: agentSessionID)
+            }
+        }
+    #endif
 
     // MARK: - Failed State
 


### PR DESCRIPTION
Tmux-sessions slice 2 (PR N) of `docs/superpowers/plans/2026-07-18-integrated-tmux-sessions.md`.

- `SessionAttachmentController` state machine (detached / read-only / interactive / failed) with pure `attachArguments` — read-only uses tmux's native `attach -r`, so the server enforces it
- `SessionTerminalView` attaches live on appear; **Take Control** respawns the client read-write with a "Keyboard input live" banner; keystrokes additionally swallowed at the view layer when read-only (`ReadOnlyAwareTerminalView`); failures/PTY-exit fall back to the slice-1 transcript view; minimize kills only the local client and restores via the existing sidebar live-sessions row
- **Pre-existing leak fixed:** `EmbeddedTerminalView` had no process teardown (`dismantleNSView` → `terminate()`) — every prior minimize/switch silently leaked its child process
- 512/512 tests (+19); all three schemes build; SwiftLint strict clean. Implemented by a Sonnet subagent, reviewed + verified here (incl. confirming the terminal's DesktopRootView reachability).

Noted for later polish: a distinct minimized-chip visual, and distinguishing fast take-control failure from genuine session end (both currently share the safe transcript fallback).

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)