### PR TITLE
feat: native UI redesign — adaptive tokens, materials, glass (#183)

### DIFF
--- a/AgentBoardCore/Models/DomainModels.swift
+++ b/AgentBoardCore/Models/DomainModels.swift
@@ -1,12 +1,5 @@
 import Foundation
 
-public enum AgentBoardDesignHandoff {
-    public static let name = "AgentBoard Grey"
-    public static let primaryAccentHex = "#c97a3e"
-    public static let baseSurfaceHex = "#232629"
-    public static let textPrimaryHex = "#f1f2f4"
-}
-
 public struct ConfiguredRepository: Codable, Hashable, Identifiable, Sendable {
     public let owner: String
     public let name: String

--- a/AgentBoardTests/AccessibilityIdentifierTests.swift
+++ b/AgentBoardTests/AccessibilityIdentifierTests.swift
@@ -19,7 +19,6 @@ struct AccessibilityIdentifierTests {
         let source = try readUISource("Screens/SettingsScreen.swift")
         let required = [
             "screen_settings",
-            "settings_picker_theme",
             "settings_textfield_hermes_gateway_url",
             "settings_textfield_hermes_model",
             "settings_securefield_hermes_api_key",

--- a/AgentBoardTests/DesignSemanticsTests.swift
+++ b/AgentBoardTests/DesignSemanticsTests.swift
@@ -1,6 +1,13 @@
 import AgentBoardCore
+import Foundation
 import Testing
 
+/// Guardrail tests for the native (ADR-015/ADR-016) design language. These are
+/// source-text checks rather than instantiated-view checks: the test target
+/// doesn't link AgentBoardUI (see `NativeSwiftUIInterfaceTests`), so pinning
+/// `NeuPalette`'s semantics means asserting on `NeumorphicTheme.swift`'s
+/// source, and the "no hardcoded white/black" rule means asserting on the
+/// shared chrome components' source.
 struct DesignSemanticsTests {
     @Test func workBoardColumnTitlesMatchDesignTemplate() {
         #expect(WorkState.ready.designColumnTitle == "READY")
@@ -9,10 +16,67 @@ struct DesignSemanticsTests {
         #expect(WorkState.review.designColumnTitle == "REVIEW")
     }
 
-    @Test func currentComparisonDesignUsesGraphiteCopperTokens() {
-        #expect(AgentBoardDesignHandoff.name == "AgentBoard Grey")
-        #expect(AgentBoardDesignHandoff.primaryAccentHex == "#c97a3e")
-        #expect(AgentBoardDesignHandoff.baseSurfaceHex == "#232629")
-        #expect(AgentBoardDesignHandoff.textPrimaryHex == "#f1f2f4")
+    @Test func neuPaletteAccentsResolveToSystemAccentColor() throws {
+        let source = try Self.source("AgentBoardUI/Theme/NeumorphicTheme.swift")
+
+        #expect(source.contains("primaryAccent: .accentColor"))
+        #expect(source.contains("primaryAccentBright: .accentColor"))
+        // No bespoke brand-teal RGB literal should reappear as the accent.
+        #expect(!source.contains("red: 0.106, green: 0.749, blue: 0.651"))
+    }
+
+    @Test func neuExtrudedCardHasNoPermanentDropShadow() throws {
+        let source = try Self.source("AgentBoardUI/Theme/NeumorphicTheme.swift")
+
+        guard let start = source.range(of: "struct NeuExtrudedModifier"),
+              let end = source.range(of: "struct NeuRecessedModifier") else {
+            Issue.record("Could not locate NeuExtrudedModifier in NeumorphicTheme.swift")
+            return
+        }
+        let modifierBody = source[start.lowerBound ..< end.lowerBound]
+
+        // Cards read as flat native surfaces at rest; `.draggable()` already
+        // supplies the system's own lift/shadow while a card is being dragged.
+        #expect(!modifierBody.contains(".shadow("))
+    }
+
+    @Test func sharedChromeComponentsDoNotHardcodeWhiteOrBlack() throws {
+        // The two fully-flat shared components (the P3 markdown landmine and
+        // the shared card chrome) must never hardcode white/black — every
+        // color there should flow through a semantic NeuPalette token.
+        for path in ["AgentBoardUI/Components/MarkdownText.swift", "AgentBoardUI/Components/BoardChrome.swift"] {
+            let source = try Self.source(path)
+            #expect(!source.contains(".white"), "\(path) should not hardcode .white")
+            #expect(!source.contains("Color.black"), "\(path) should not hardcode Color.black")
+        }
+
+        // NeuChatBubble's one hardcoded `.white` (text on the user bubble's
+        // accent fill) is the justified exception — pinned here so a future
+        // edit can't silently drop the justifying comment or add a new,
+        // unjustified hardcoded color alongside it.
+        let chatBubble = try Self.source("AgentBoardUI/Components/ChatBubble.swift")
+        let whiteOccurrences = chatBubble.components(separatedBy: ".white").count - 1
+        #expect(whiteOccurrences == 1)
+        #expect(chatBubble.contains("case .user: .white"))
+        #expect(chatBubble.lowercased().contains("justified"))
+        #expect(!chatBubble.contains("Color.black"))
+    }
+
+    private static func source(_ relativePath: String) throws -> String {
+        try String(contentsOf: repositoryRoot.appending(path: relativePath), encoding: .utf8)
+    }
+
+    private static var repositoryRoot: URL {
+        var directory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+
+        while directory.path != "/" {
+            if FileManager.default.fileExists(atPath: directory.appending(path: "project.yml").path) {
+                return directory
+            }
+            directory.deleteLastPathComponent()
+        }
+
+        Issue.record("Unable to locate repository root from \(#filePath)")
+        return URL(fileURLWithPath: #filePath).deletingLastPathComponent()
     }
 }

--- a/AgentBoardUI/Components/Attachments/AttachmentPicker.swift
+++ b/AgentBoardUI/Components/Attachments/AttachmentPicker.swift
@@ -294,6 +294,8 @@ struct AttachmentPreviewStrip: View {
                             Button {
                                 attachments.remove(at: index)
                             } label: {
+                                // Justified: fixed-contrast remove badge drawn on top of an
+                                // arbitrary photo thumbnail, independent of light/dark mode.
                                 Image(systemName: "xmark.circle.fill")
                                     .font(.caption)
                                     .foregroundColor(.white)

--- a/AgentBoardUI/Components/Attachments/AttachmentViews.swift
+++ b/AgentBoardUI/Components/Attachments/AttachmentViews.swift
@@ -126,7 +126,8 @@ struct VideoAttachmentView: View {
                     .fill(NeuPalette.surface)
             }
 
-            // Play button overlay
+            // Play button overlay. Justified: fixed-contrast scrim + icon on
+            // top of an arbitrary video thumbnail, independent of light/dark mode.
             Circle()
                 .fill(.black.opacity(0.5))
                 .frame(width: 48, height: 48)
@@ -136,7 +137,7 @@ struct VideoAttachmentView: View {
                         .foregroundStyle(.white)
                 }
 
-            // Duration badge
+            // Duration badge — same justification as the play button above.
             if let duration = duration {
                 VStack {
                     Spacer()

--- a/AgentBoardUI/Components/Attachments/MediaViewerView.swift
+++ b/AgentBoardUI/Components/Attachments/MediaViewerView.swift
@@ -16,6 +16,11 @@ struct MediaViewerView: View {
     }
 
     var body: some View {
+        // Justified: this is a fixed-chrome fullscreen media viewer (the
+        // standard Photos.app-style pattern) — the black backdrop and white
+        // overlay text/icons are intentionally independent of system
+        // light/dark mode so they read consistently against arbitrary photo
+        // and video content, not app chrome.
         ZStack {
             Color.black.ignoresSafeArea()
 

--- a/AgentBoardUI/Components/BoardChrome.swift
+++ b/AgentBoardUI/Components/BoardChrome.swift
@@ -12,6 +12,10 @@ struct BoardSurface<Content: View>: View {
             .padding(16)
             .background(BoardPalette.surface)
             .clipShape(RoundedRectangle(cornerRadius: 10))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(.separator, lineWidth: 0.5)
+            )
     }
 }
 

--- a/AgentBoardUI/Components/ChatBubble.swift
+++ b/AgentBoardUI/Components/ChatBubble.swift
@@ -18,10 +18,29 @@ struct NeuChatBubble: View {
         }
     }
 
+    private var senderLabel: String {
+        switch message.role {
+        case .assistant: "Hermes"
+        case .user: "You"
+        case .system: "System"
+        }
+    }
+
+    /// Bubble text color, threaded down through `MarkdownText` (which inherits
+    /// this ambient color rather than hardcoding its own): white is justified
+    /// here as text drawn directly on the user bubble's accent-tinted fill.
+    private var bubbleTextColor: Color {
+        switch message.role {
+        case .assistant: NeuPalette.textPrimary
+        case .user: .white
+        case .system: NeuPalette.textSecondary
+        }
+    }
+
     private var bubble: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 8) {
-                Text(message.role == .assistant ? "Hermes" : "You")
+                Text(senderLabel)
                     .font(.caption2.weight(.bold))
                     .foregroundStyle(message.role == .assistant ? NeuPalette.accentCyan : NeuPalette.accentOrange)
                     .tracking(1)
@@ -39,10 +58,10 @@ struct NeuChatBubble: View {
 
             if message.isStreaming, message.content.isEmpty {
                 Text("typing...")
-                    .foregroundStyle(NeuPalette.textSecondary)
+                    .foregroundStyle(bubbleTextColor)
             } else {
                 MarkdownText(content: message.content)
-                    .foregroundStyle(NeuPalette.textPrimary)
+                    .foregroundStyle(bubbleTextColor)
             }
 
             // Render attachments
@@ -57,16 +76,26 @@ struct NeuChatBubble: View {
             }
         }
         .padding(20)
-        .background(
-            message.role == .assistant
-                ? RoundedRectangle(cornerRadius: 24, style: .continuous).fill(NeuPalette.surfaceRaised)
-                : RoundedRectangle(cornerRadius: 24, style: .continuous).fill(NeuPalette.surfaceHover)
-        )
+        .background(bubbleBackground)
         .overlay(
             RoundedRectangle(cornerRadius: 24, style: .continuous)
-                .stroke(NeuPalette.borderSoft, lineWidth: 1)
+                .stroke(NeuPalette.borderSoft, lineWidth: message.role == .user ? 0 : 1)
         )
-        .shadow(color: NeuPalette.shadowDark.opacity(0.6), radius: 8, x: 0, y: 4)
+    }
+
+    /// Assistant = material surface with a hairline stroke; user = accent-
+    /// tinted fill; system/info = a quiet tertiary fill.
+    @ViewBuilder
+    private var bubbleBackground: some View {
+        let shape = RoundedRectangle(cornerRadius: 24, style: .continuous)
+        switch message.role {
+        case .assistant:
+            shape.fill(.regularMaterial)
+        case .user:
+            shape.fill(NeuPalette.accentCyan)
+        case .system:
+            shape.fill(.tertiary)
+        }
     }
 
     private var toolActivityChips: some View {

--- a/AgentBoardUI/Components/MarkdownText.swift
+++ b/AgentBoardUI/Components/MarkdownText.swift
@@ -30,10 +30,12 @@ private struct MarkdownBlockView: View {
             proseText(text)
 
         case let .heading(level, text):
+            // No explicit foregroundStyle: prose inherits the ambient color the
+            // caller sets (NeuChatBubble varies this per role — .primary on the
+            // assistant's material surface, .white on the user's accent fill).
             Text(text)
                 .font(.system(size: max(22 - CGFloat(level) * 2, 13), weight: .bold))
                 .textSelection(.enabled)
-                .foregroundStyle(.white)
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.top, 2)
 
@@ -46,7 +48,7 @@ private struct MarkdownBlockView: View {
                     HStack(alignment: .firstTextBaseline, spacing: 6) {
                         Text(ordered && item.depth == 0 ? "\(orderedIndex(items, upTo: index))." : "•")
                             .font(.callout.monospacedDigit())
-                            .foregroundStyle(.white.opacity(0.55))
+                            .foregroundStyle(.secondary)
                         proseText(item.text)
                     }
                     .padding(.leading, CGFloat(item.depth) * 16)
@@ -56,7 +58,7 @@ private struct MarkdownBlockView: View {
         case let .blockquote(inner):
             HStack(alignment: .top, spacing: 8) {
                 RoundedRectangle(cornerRadius: 1.5)
-                    .fill(Color.white.opacity(0.35))
+                    .fill(NeuPalette.borderSoft)
                     .frame(width: 3)
                 VStack(alignment: .leading, spacing: 6) {
                     ForEach(Array(inner.enumerated()), id: \.offset) { _, innerBlock in
@@ -67,22 +69,24 @@ private struct MarkdownBlockView: View {
             }
 
         case let .table(headers, rows):
+            // Tables sit on their own inset fill (independent of the enclosing
+            // bubble/background), so text color is explicit rather than inherited.
             ScrollView(.horizontal, showsIndicators: false) {
                 Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 6) {
                     GridRow {
                         ForEach(Array(headers.enumerated()), id: \.offset) { _, header in
                             Text(header)
                                 .font(.footnote.weight(.semibold))
-                                .foregroundStyle(.white)
+                                .foregroundStyle(.primary)
                         }
                     }
-                    Divider().overlay(Color.white.opacity(0.2))
+                    Divider()
                     ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
                         GridRow {
                             ForEach(Array(row.enumerated()), id: \.offset) { _, cell in
                                 Text(cell)
                                     .font(.footnote)
-                                    .foregroundStyle(.white.opacity(0.9))
+                                    .foregroundStyle(.secondary)
                             }
                         }
                     }
@@ -91,18 +95,17 @@ private struct MarkdownBlockView: View {
             }
             .background(
                 RoundedRectangle(cornerRadius: 10, style: .continuous)
-                    .fill(Color.black.opacity(0.24))
+                    .fill(NeuPalette.inset)
             )
 
         case .thematicBreak:
-            Divider().overlay(Color.white.opacity(0.2))
+            Divider()
         }
     }
 
     private func proseText(_ text: AttributedString) -> some View {
         Text(text)
             .textSelection(.enabled)
-            .foregroundStyle(.white)
             .fixedSize(horizontal: false, vertical: true)
     }
 
@@ -113,17 +116,21 @@ private struct MarkdownBlockView: View {
     }
 
     private func codeBlock(_ code: String, language: String?) -> some View {
+        // Code blocks render on their own `inset` fill (independent of the
+        // enclosing bubble/background), so text color is explicit `.primary`
+        // rather than inherited — matches the spec's "code blocks on inset
+        // fill with .primary monospaced text" guidance.
         VStack(alignment: .leading, spacing: 4) {
             if let language, !language.isEmpty {
                 Text(language.uppercased())
                     .font(.caption2.weight(.semibold))
                     .tracking(1.2)
-                    .foregroundStyle(.white.opacity(0.5))
+                    .foregroundStyle(.secondary)
             }
             ScrollView(.horizontal, showsIndicators: false) {
                 Text(code)
                     .font(.system(.footnote, design: .monospaced))
-                    .foregroundStyle(.green)
+                    .foregroundStyle(.primary)
                     .textSelection(.enabled)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 8)
@@ -131,11 +138,11 @@ private struct MarkdownBlockView: View {
         }
         .background(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(Color.black.opacity(0.32))
+                .fill(NeuPalette.inset)
         )
         .overlay(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .stroke(Color.white.opacity(0.06), lineWidth: 1)
+                .stroke(NeuPalette.borderSoft, lineWidth: 1)
         )
     }
 }

--- a/AgentBoardUI/Components/MarkdownText.swift
+++ b/AgentBoardUI/Components/MarkdownText.swift
@@ -31,8 +31,9 @@ private struct MarkdownBlockView: View {
 
         case let .heading(level, text):
             // No explicit foregroundStyle: prose inherits the ambient color the
-            // caller sets (NeuChatBubble varies this per role — .primary on the
-            // assistant's material surface, .white on the user's accent fill).
+            // caller sets (NeuChatBubble varies this per role — primary text on
+            // the assistant's material surface, light text on the user's
+            // accent fill).
             Text(text)
                 .font(.system(size: max(22 - CGFloat(level) * 2, 13), weight: .bold))
                 .textSelection(.enabled)

--- a/AgentBoardUI/Screens/ChatComposeBar.swift
+++ b/AgentBoardUI/Screens/ChatComposeBar.swift
@@ -74,10 +74,11 @@ struct ChatComposeBar: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .background(NeuPalette.surfaceRaised)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-        .overlay(RoundedRectangle(cornerRadius: 12).stroke(NeuPalette.borderSoft, lineWidth: 1))
-        .shadow(color: NeuPalette.shadowDark.opacity(0.4), radius: 3, x: 0, y: 1)
+        // Floating chrome per the native redesign: the compose bar is one of
+        // the two surfaces that gets real glass (the other is the session
+        // terminal header) — legibility here holds up fine against chat
+        // content scrolling behind it.
+        .glassEffect(.regular, in: .rect(cornerRadius: 12))
         .padding(.horizontal, 12)
         .padding(.top, 6)
         .padding(.bottom, 10)

--- a/AgentBoardUI/Screens/ChatComposeBar.swift
+++ b/AgentBoardUI/Screens/ChatComposeBar.swift
@@ -188,6 +188,7 @@ struct ChatComposeBar: View {
 
     private var sendButtonForeground: Color {
         let chatStore = appModel.chatStore
+        // Justified: icon drawn on the solid `.red` stop-button fill below.
         if chatStore.isStreaming { return .white }
         return canSend ? NeuPalette.accentForeground : NeuPalette.textSecondary
     }

--- a/AgentBoardUI/Screens/LaunchSessionSheet.swift
+++ b/AgentBoardUI/Screens/LaunchSessionSheet.swift
@@ -105,7 +105,7 @@ struct LaunchSessionSheet: View {
                                         .padding(12)
                                         .background(
                                             RoundedRectangle(cornerRadius: 12)
-                                                .fill(selectedAgent == agent ? Color.white.opacity(0.05) : Color
+                                                .fill(selectedAgent == agent ? NeuPalette.accentCyan.opacity(0.12) : Color
                                                     .clear)
                                         )
                                     }
@@ -147,7 +147,7 @@ struct LaunchSessionSheet: View {
                                         .padding(12)
                                         .background(
                                             RoundedRectangle(cornerRadius: 12)
-                                                .fill(selectedPreset == preset ? Color.white.opacity(0.05) : Color
+                                                .fill(selectedPreset == preset ? NeuPalette.accentCyan.opacity(0.12) : Color
                                                     .clear)
                                         )
                                     }

--- a/AgentBoardUI/Screens/QuickLaunchSheet.swift
+++ b/AgentBoardUI/Screens/QuickLaunchSheet.swift
@@ -71,7 +71,7 @@ struct QuickLaunchSheet: View {
                                         .padding(12)
                                         .background(
                                             RoundedRectangle(cornerRadius: 12)
-                                                .fill(selectedAgent == agent ? Color.white.opacity(0.05) : Color
+                                                .fill(selectedAgent == agent ? NeuPalette.accentCyan.opacity(0.12) : Color
                                                     .clear)
                                         )
                                     }
@@ -113,7 +113,7 @@ struct QuickLaunchSheet: View {
                                         .padding(12)
                                         .background(
                                             RoundedRectangle(cornerRadius: 12)
-                                                .fill(selectedPreset == preset ? Color.white.opacity(0.05) : Color
+                                                .fill(selectedPreset == preset ? NeuPalette.accentCyan.opacity(0.12) : Color
                                                     .clear)
                                         )
                                     }

--- a/AgentBoardUI/Screens/SessionTerminalView.swift
+++ b/AgentBoardUI/Screens/SessionTerminalView.swift
@@ -237,13 +237,13 @@ struct SessionTerminalView: View {
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 12)
-        .background(
-            LinearGradient(
-                colors: [NeuPalette.surface, NeuPalette.background],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-        )
+        // The spec calls for real glass on the terminal header, but this bar
+        // packs several small status pills/buttons directly above a live
+        // terminal backdrop that can scroll busy, high-contrast text — full
+        // `glassEffect` risks legibility there, so this degrades to
+        // `.thinMaterial` per the spec's explicit fallback. The terminal
+        // content itself (`liveTerminalView`) stays fully opaque.
+        .background(.thinMaterial)
         .overlay(alignment: .bottom) {
             Rectangle()
                 .fill(NeuPalette.borderSoft)

--- a/AgentBoardUI/Screens/SettingsScreen.swift
+++ b/AgentBoardUI/Screens/SettingsScreen.swift
@@ -31,7 +31,6 @@ struct SettingsScreen: View {
 
                 ScrollView(showsIndicators: false) {
                     VStack(alignment: .leading, spacing: 32) {
-                        appearanceSection(settingsStore: settingsStore)
                         hermesSection(settingsStore: settingsStore)
                         githubSection(settingsStore: settingsStore)
                         companionSection(settingsStore: settingsStore)
@@ -46,33 +45,6 @@ struct SettingsScreen: View {
         .agentBoardNavigationBarHidden(true)
         .agentBoardKeyboardDismissToolbar()
         .accessibilityIdentifier("screen_settings")
-    }
-
-    // MARK: - Appearance
-
-    private func appearanceSection(settingsStore: SettingsStore) -> some View {
-        @Bindable var s = settingsStore
-        return VStack(alignment: .leading, spacing: 16) {
-            sectionHeader("APPEARANCE")
-            VStack(alignment: .leading, spacing: 16) {
-                Picker("Theme", selection: $s.designTheme) {
-                    ForEach(AgentBoardDesignTheme.allCases) { theme in
-                        Text(theme.displayName).tag(theme)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .tint(NeuPalette.accentCyan)
-                .accessibilityIdentifier("settings_picker_theme")
-
-                HStack(spacing: 10) {
-                    ForEach(AgentBoardDesignTheme.allCases) { theme in
-                        SettingsThemeSwatch(theme: theme, isSelected: s.designTheme == theme)
-                    }
-                }
-            }
-            .padding(24)
-            .neuExtruded(cornerRadius: 24, elevation: 8)
-        }
     }
 
     // MARK: - Hermes Gateway
@@ -444,42 +416,6 @@ struct SettingsScreen: View {
             .tracking(1)
             .foregroundStyle(NeuPalette.textSecondary)
             .padding(.horizontal, 8)
-    }
-}
-
-private struct SettingsThemeSwatch: View {
-    let theme: AgentBoardDesignTheme
-    let isSelected: Bool
-
-    var body: some View {
-        let palette = NeuTheme.preset(theme)
-        return HStack(spacing: 10) {
-            HStack(spacing: -5) {
-                Circle()
-                    .fill(palette.background)
-                    .frame(width: 20, height: 20)
-                Circle()
-                    .fill(palette.surfaceRaised)
-                    .frame(width: 20, height: 20)
-                Circle()
-                    .fill(palette.primaryAccentBright)
-                    .frame(width: 20, height: 20)
-            }
-            Text(theme.displayName)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(isSelected ? NeuPalette.textPrimary : NeuPalette.textSecondary)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
-        .background(NeuPalette.inset)
-        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .stroke(
-                    isSelected ? palette.primaryAccentBright : NeuPalette.borderSoft,
-                    lineWidth: isSelected ? 1.5 : 1
-                )
-        }
     }
 }
 

--- a/AgentBoardUI/Theme/NeumorphicTheme.swift
+++ b/AgentBoardUI/Theme/NeumorphicTheme.swift
@@ -253,9 +253,12 @@ public struct NeuBackground: View {
     }
 }
 
-/// Raised card — a standard material-backed rounded rectangle with a hairline
-/// border and a single subtle drop shadow. Replaces the neumorphic
-/// dual-shadow "extruded" look with native chrome.
+/// Raised card — a flat material-backed rounded rectangle with a hairline
+/// border. Replaces the neumorphic dual-shadow "extruded" look with native
+/// chrome. No permanent drop shadow: cards read as flat native surfaces at
+/// rest, and `.draggable()` already gives the system's own lifted-preview
+/// shadow while a card is actually being dragged, so no bespoke `isDragging`
+/// state is needed to satisfy "shadow only while dragging".
 public struct NeuExtrudedModifier: ViewModifier {
     public let cornerRadius: CGFloat
     public let elevation: CGFloat
@@ -274,12 +277,6 @@ public struct NeuExtrudedModifier: ViewModifier {
             .overlay(
                 RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
                     .stroke(NeuPalette.borderSoft, lineWidth: 0.5)
-            )
-            .shadow(
-                color: NeuPalette.shadowDark,
-                radius: max(elevation * 0.4, 2),
-                x: 0,
-                y: max(elevation * 0.2, 1)
             )
     }
 }

--- a/AgentBoardUI/Theme/NeumorphicTheme.swift
+++ b/AgentBoardUI/Theme/NeumorphicTheme.swift
@@ -89,13 +89,13 @@ public struct NeuTheme: Sendable {
             gradientTop: background,
             gradientBottom: background,
             accentOrange: .orange,
-            primaryAccent: Color(red: 0.106, green: 0.749, blue: 0.651), // brand teal
-            primaryAccentBright: Color(red: 0.310, green: 0.851, blue: 0.773),
-            primaryAccentForeground: .white,
-            accentCoral: .pink,
+            primaryAccent: .accentColor, // system accent (Assets AccentColor), not a bespoke brand color
+            primaryAccentBright: .accentColor,
+            primaryAccentForeground: .white, // justified: white text drawn on top of an accent-filled surface
+            accentCoral: .red,
             accentPurple: .purple,
             statusOpen: .blue,
-            statusClosed: .gray,
+            statusClosed: .secondary,
             statusSuccess: .green,
             statusIdle: .blue,
             textPrimary: textPrimary,
@@ -137,6 +137,14 @@ public enum NeuPalette {
 
     public static var surfaceRaised: Color {
         active.surfaceRaised
+    }
+
+    /// Sibling `Material` accessor for `surfaceRaised`. Floating/raised chrome
+    /// (cards, compose bar, headers) can opt into the real translucent
+    /// material instead of the flat fallback `Color` without changing the
+    /// existing `Color`-typed token's call sites.
+    public static var surfaceMaterial: Material {
+        .regular
     }
 
     public static var surfaceHover: Color {

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -226,4 +226,23 @@ Agents → CompanionServer → FSEvents + ps
 
 ---
 
+## ADR-016: Native Apple / Liquid Glass design language (completes ADR-015)
+**Date:** 2026-07-20
+**Status:** Active
+**Decision:** Complete the native-chrome direction ADR-015 started: adopt system semantic colors and materials as the actual visual language (not just platform-native surface *colours*), replacing the brand-teal accent with the system accent color, removing permanent card/bubble shadows, and adding real `glassEffect`/`Material` translucency on floating chrome. Supersedes ADR-015's "brand teal preserved" detail and ADR-010's visual direction; this is the concrete implementation of the redesign scoped in `docs/superpowers/specs/2026-07-19-native-ui-redesign-design.md`.
+
+**Context:** ADR-015 (2026-07-19) moved surface/text/background colours onto `NSColor`/`UIColor` so light/dark adapted automatically, but kept a bespoke brand-teal `Color(red:green:blue:)` literal for the accent, kept a permanent drop shadow on `.neuExtruded()`, and had no glass/material treatment on floating chrome (compose bar, terminal header). A follow-up design pass (`2026-07-19-native-ui-redesign-design.md`, approved by Blake) specified a stricter, more literal native/Liquid-Glass treatment — system accent color, material-backed flat cards with no permanent elevation, and `glassEffect` on the two surfaces where it reads well. This ADR records that refinement; issue #183 tracked the implementation (PR P, `feat/native-ui-tokens`).
+
+**Consequences:**
+- `NeuPalette.accentCyan`/`accentCyanBright`/`accentForeground` now read `Color.accentColor` (the project's existing `AccentColor` asset) instead of a hardcoded teal RGB literal; `accentCoral` maps to system `.red`; `statusClosed` maps to `.secondary`. A new `NeuPalette.surfaceMaterial: Material` sibling accessor lets call sites opt into a real material without changing the existing `Color`-typed tokens.
+- `NeuExtrudedModifier` (shared card chrome) drops its permanent drop shadow — cards are flat at rest; `.draggable()`'s own system lift/shadow covers the "elevated while dragging" case with no bespoke `isDragging` plumbing.
+- `NeuChatBubble` differentiates by role: assistant on `.regularMaterial` with a hairline stroke, user on an accent-tinted fill with white text (justified: text on accent fill), system/info on a quiet `.tertiary` fill — replacing the old binary assistant/other split and its permanent shadow.
+- `glassEffect(.regular)` lands on the chat compose bar. The session terminal header degrades to `.thinMaterial` per the design spec's explicit legibility fallback (dense status pills/buttons over a busy live-terminal backdrop); the terminal content itself stays fully opaque.
+- `MarkdownText`/`MarkdownBlockView` no longer hardcodes `.white` prose, `.green` code text, or `Color.black` code/table backgrounds — prose inherits its caller's ambient foreground (so `NeuChatBubble`'s per-role text color actually takes effect), de-emphasized accents use `.secondary`/`.separator`, and code/table blocks sit on their own `inset` fill with explicit `.primary` text.
+- Repo-wide sweep of every remaining `.white`/`Color.black` hit in `AgentBoardUI`/`AgentBoard`/`AgentBoardMobile`: `LaunchSessionSheet`/`QuickLaunchSheet`'s selected-row highlight (was invisible-to-wrong `Color.white.opacity(0.05)` against light backgrounds) is now a semantic `NeuPalette.accentCyan.opacity(0.12)` tint; the remaining hits (compose bar stop-button icon, accent foreground, chat bubble user text, the fullscreen media viewer's fixed black/white chrome, attachment thumbnail overlay badges) are justified in place as text/icon-on-fixed-fill.
+- The Settings theme picker UI is removed (appearance now follows the system); the underlying `designTheme` store plumbing and `NeuTheme.preset`/`NeuPalette.apply` machinery are left in place for PR Q's mechanical `NeuPalette → AppTheme` rename and cleanup.
+- `DesignSemanticsTests` is re-pinned as the regression fence: it asserts `NeumorphicTheme.swift`'s accent tokens resolve to `.accentColor` (not a brand-RGB literal), that `NeuExtrudedModifier` carries no permanent shadow, and that the shared chrome components (`MarkdownText`, `BoardChrome`, `ChatBubble`) don't hardcode `.white`/`Color.black` outside the one documented justified case.
+
+---
+
 *To add a new ADR: append with the next number, include date, status, decision, context, and consequences.*


### PR DESCRIPTION
PR P of `docs/superpowers/plans/2026-07-20-native-ui-redesign.md`. Builds on PR #181's first-pass (merged concurrently by another session — recorded as **ADR-016**, cross-referencing/superseding parts of its ADR-015):

- Accents unified on the **system accent color** (was brand-teal RGB); coral/closed statuses → semantic `.red`/`.secondary`; `surfaceMaterial` sibling accessor
- Native chrome: hairline `.separator` card strokes, drag-only shadows (SwiftUI's own drag lift), per-role chat bubbles (assistant material, user accent fill, system tertiary), `glassEffect` compose bar, `.thinMaterial` terminal header
- Light-mode landmines fixed: `MarkdownText` fully semantic; sheet selection highlights de-hardcoded; every remaining `.white`/`Color.black` justified with a comment (accent fills, media-viewer chrome, thumbnail scrims)
- Theme-picker UI removed (store plumbing dies in PR Q / #184); `DesignSemanticsTests` re-pinned incl. a no-hardcoded-color source assertion
- 538/538 tests; three schemes build; SwiftLint strict clean. Implemented by a Sonnet subagent in an isolated worktree; reviewed + verified here.

⚠️ **Needs human visual QA** (no GUI session available to agents) — run the app in BOTH appearances and check: (1) **user chat bubble in light mode** — white text on the `#FF9500` orange AccentColor is ~2:1 contrast; if it reads poorly, options are a darker accent asset variant or a bubble-specific fill; (2) markdown legibility in both bubble types; (3) terminal header material over live scrollback; (4) compose-bar glass over scrolling chat.

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)