### PR TITLE
fix: one unreachable repository no longer blanks the work board (#189)

### DIFF
--- a/AgentBoardCore/Services/GitHubWorkService.swift
+++ b/AgentBoardCore/Services/GitHubWorkService.swift
@@ -47,12 +47,35 @@ public struct GitHubIssueDraft: Sendable {
     }
 }
 
+/// Outcome of a multi-repository fetch: issues from every reachable
+/// repository plus per-repository failures. One bad repo (deleted, renamed,
+/// no access) must not blank the whole board.
+public struct GitHubRepoFailure: Equatable, Sendable {
+    public let repository: String
+    public let message: String
+
+    public init(repository: String, message: String) {
+        self.repository = repository
+        self.message = message
+    }
+}
+
+public struct GitHubWorkFetch: Sendable {
+    public let items: [WorkItem]
+    public let failures: [GitHubRepoFailure]
+
+    public init(items: [WorkItem], failures: [GitHubRepoFailure]) {
+        self.items = items
+        self.failures = failures
+    }
+}
+
 public protocol GitHubWorkServicing: Actor {
     func configure(
         repositories: [ConfiguredRepository],
         token: String?
     )
-    func fetchWorkItems() async throws -> [WorkItem]
+    func fetchWorkItems() async throws -> GitHubWorkFetch
     func createIssue(
         repository: ConfiguredRepository,
         draft: GitHubIssueDraft
@@ -137,9 +160,13 @@ public actor GitHubWorkService: GitHubWorkServicing {
         return formatter
     }()
 
-    public init(session: URLSession = .shared) {
+    public init(session: URLSession = .shared, ghExecutablePath: String? = nil) {
         self.session = session
+        self.ghExecutablePath = ghExecutablePath
     }
+
+    /// Test seam: overrides gh CLI resolution for the macOS fallback path.
+    private let ghExecutablePath: String?
 
     public func configure(
         repositories: [ConfiguredRepository],
@@ -149,22 +176,39 @@ public actor GitHubWorkService: GitHubWorkServicing {
         self.token = token?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
     }
 
-    public func fetchWorkItems() async throws -> [WorkItem] {
+    public func fetchWorkItems() async throws -> GitHubWorkFetch {
         guard !repositories.isEmpty, let token, !token.isEmpty else {
             throw ServiceError.missingConfiguration
         }
 
         var mapped: [WorkItem] = []
+        var failures: [GitHubRepoFailure] = []
+        var firstError: Error?
         for repository in repositories {
-            try mapped.append(contentsOf: await fetchIssues(for: repository, token: token))
+            do {
+                try mapped.append(contentsOf: await fetchIssues(for: repository, token: token))
+            } catch {
+                firstError = firstError ?? error
+                failures.append(GitHubRepoFailure(
+                    repository: repository.fullName,
+                    message: error.localizedDescription
+                ))
+            }
         }
 
-        return mapped.sorted { lhs, rhs in
+        // Every repository failed: the whole fetch is down (bad token, no
+        // network) — throw so the store surfaces a real error state.
+        if mapped.isEmpty, let firstError, failures.count == repositories.count {
+            throw firstError
+        }
+
+        let sorted = mapped.sorted { lhs, rhs in
             if lhs.priority.rank != rhs.priority.rank {
                 return lhs.priority.rank < rhs.priority.rank
             }
             return lhs.updatedAt > rhs.updatedAt
         }
+        return GitHubWorkFetch(items: sorted, failures: failures)
     }
 
     public func createIssue(
@@ -307,7 +351,7 @@ public actor GitHubWorkService: GitHubWorkServicing {
             let result: ProcessResult
             do {
                 result = try await Process.runAsync(
-                    executablePath: Self.resolvedGHPath(),
+                    executablePath: ghExecutablePath ?? Self.resolvedGHPath(),
                     arguments: [
                         "api", "repos/\(repository.owner)/\(repository.name)/issues",
                         "-f", "state=all",

--- a/AgentBoardCore/Stores/WorkStore.swift
+++ b/AgentBoardCore/Stores/WorkStore.swift
@@ -85,7 +85,8 @@ public final class WorkStore {
         await configureServiceIfNeeded()
 
         do {
-            let fresh = try await service.fetchWorkItems()
+            let fetch = try await service.fetchWorkItems()
+            let fresh = fetch.items
             let newFingerprint = fingerprint(fresh)
 
             // Only update items if the data actually changed
@@ -94,6 +95,12 @@ public final class WorkStore {
                 lastFingerprint = newFingerprint
                 try cache.replaceWorkItems(items)
                 statusMessage = "Loaded \(items.count) GitHub issues."
+            }
+            // Unreachable repositories must stay visible even when the
+            // reachable data is unchanged (deleted/renamed repo in Settings).
+            if !fetch.failures.isEmpty {
+                let names = fetch.failures.map(\.repository).joined(separator: ", ")
+                statusMessage = "Loaded \(items.count) issues — unavailable: \(names)"
             }
             // Data unchanged — skip the update entirely, no SwiftUI invalidation
             // Also skip statusMessage update to avoid unnecessary re-renders

--- a/AgentBoardTests/GitHubWorkServiceTests.swift
+++ b/AgentBoardTests/GitHubWorkServiceTests.swift
@@ -65,7 +65,7 @@ struct GitHubWorkServiceTests {
             token: "ghp_example"
         )
 
-        let items = try await service.fetchWorkItems()
+        let items = try await service.fetchWorkItems().items
         #expect(items.count == 2)
 
         let first = try #require(items.first)
@@ -162,6 +162,56 @@ struct GitHubWorkServiceTests {
             #expect(path == "gh")
         }
     #endif
+
+    @Test
+    func fetchWorkItemsContinuesPastFailingRepository() async throws {
+        let service = GitHubWorkService(session: makeMockSession { request in
+            let path = request.url?.path ?? ""
+            let status = path.contains("/repos/acme/ghost/") ? 404 : 200
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: status,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            let body = status == 200 ? "[\(self.issueJSON(number: 7))]" : "{\"message\":\"Not Found\"}"
+            return (response, Data(body.utf8))
+        }, ghExecutablePath: "/nonexistent/gh")
+        await service.configure(
+            repositories: [
+                ConfiguredRepository(owner: "acme", name: "ghost"),
+                ConfiguredRepository(owner: "acme", name: "alive")
+            ],
+            token: "ghp_example"
+        )
+
+        let fetch = try await service.fetchWorkItems()
+        #expect(fetch.items.count == 1)
+        #expect(fetch.items.first?.issueNumber == 7)
+        #expect(fetch.failures.count == 1)
+        #expect(fetch.failures.first?.repository == "acme/ghost")
+    }
+
+    @Test
+    func fetchWorkItemsThrowsWhenAllRepositoriesFail() async throws {
+        let service = GitHubWorkService(session: makeMockSession { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 404,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, Data("{}".utf8))
+        }, ghExecutablePath: "/nonexistent/gh")
+        await service.configure(
+            repositories: [ConfiguredRepository(owner: "acme", name: "ghost")],
+            token: "ghp_example"
+        )
+
+        await #expect(throws: (any Error).self) {
+            _ = try await service.fetchWorkItems()
+        }
+    }
 
     private func issueJSON(number: Int) -> String {
         """

--- a/AgentBoardTests/WorkStoreTests.swift
+++ b/AgentBoardTests/WorkStoreTests.swift
@@ -751,6 +751,39 @@ struct WorkStoreTests {
         #expect(store.items.first?.status == .inProgress)
     }
 
+    @Test
+    func refreshSurfacesUnavailableRepositoriesInStatusMessage() async throws {
+        let service = GitHubWorkService(session: makeMockSession { request in
+            let path = request.url?.path ?? ""
+            let status = path.contains("/repos/org/ghost/") ? 404 : 200
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: status,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            let body = status == 200 ? "[]" : "{\"message\":\"Not Found\"}"
+            return (response, Data(body.utf8))
+        }, ghExecutablePath: "/nonexistent/gh")
+        let cache = try AgentBoardCache(inMemory: true)
+        let repo = SettingsRepository(
+            suiteName: "WorkStoreTests-\(UUID().uuidString)",
+            serviceName: "WorkStoreTests-\(UUID().uuidString)"
+        )
+        let settingsStore = SettingsStore(repository: repo)
+        settingsStore.githubToken = "ghp_test"
+        settingsStore.repositories = [
+            ConfiguredRepository(owner: "org", name: "ghost"),
+            ConfiguredRepository(owner: "org", name: "repo")
+        ]
+        let store = WorkStore(service: service, cache: cache, settingsStore: settingsStore)
+
+        await store.refresh()
+
+        #expect(store.errorMessage == nil)
+        #expect(store.statusMessage?.contains("unavailable: org/ghost") == true)
+    }
+
     private func makeClosedIssueJSON(number: Int, title: String, labels: [String]) -> String {
         let labelsJSON = labels.map { #"{"name": "\#($0)"}"# }.joined(separator: ", ")
         return """
@@ -780,8 +813,8 @@ private actor CountingGitHubWorkService: GitHubWorkServicing {
         configurations.append((repositories, token))
     }
 
-    func fetchWorkItems() async throws -> [WorkItem] {
-        []
+    func fetchWorkItems() async throws -> GitHubWorkFetch {
+        GitHubWorkFetch(items: [], failures: [])
     }
 
     func createIssue(

--- a/AgentBoardUI/Screens/SettingsScreen.swift
+++ b/AgentBoardUI/Screens/SettingsScreen.swift
@@ -413,7 +413,11 @@ struct SettingsScreen: View {
         .padding(.vertical, 16)
     }
 
-    // MARK: - Helpers
+}
+
+// MARK: - Helpers
+
+private extension SettingsScreen {
 
     /// Wraps a form control with a small caption label above it.
     private func labeledField<Content: View>(


### PR DESCRIPTION
Root cause of tonight's "not loading gh issues": settings contained `jbcrane13/LeedFeed`, which no longer exists on GitHub; `fetchWorkItems()` aborted the whole multi-repo loop on its 404, blanking the four healthy repos.

- `GitHubWorkFetch` result: items from every reachable repo + per-repo failures; the fetch throws only when EVERY repository fails (bad token / no network)
- `WorkStore` surfaces unavailable repos in the status line even when reachable data is unchanged
- gh-path test seam keeps the macOS CLI fallback offline in tests; 3 new tests (partial failure, all-fail throws, store status surface)
- Leading commit fixes a pre-existing strict-lint failure on main (SettingsScreen 407-line struct body from `cf046ab`) that was blocking ALL commits via the pre-commit hook
- 541/541 tests; macOS + iOS build. **Immediate user workaround regardless of merge: remove LeedFeed in Settings → repositories.**

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)