### PR TITLE
Fix GitHub Work fallback for stale tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,3 +203,6 @@ fix the ui theme
 
 ## Activity — 2026-05-25
 - Fixed open ticket batch #130-#133: Work board repository selection now persists per scene and seeds create-issue sheets; create issue dismisses based on a successful created item; launched sessions auto-open the terminal; tmux `EXITED:` output now drives completed/failed state; companion-backed session details expose an interactive terminal tab when a tmux session is available.
+
+## Activity — 2026-07-20
+- Fixed GitHub Work reads with stale stored tokens: the macOS `gh api` fallback now forces GET semantics instead of accidentally POSTing query fields to the issues endpoint (issue #191, ADR-017).

--- a/AgentBoardCore/Services/GitHubWorkService.swift
+++ b/AgentBoardCore/Services/GitHubWorkService.swift
@@ -354,6 +354,7 @@ public actor GitHubWorkService: GitHubWorkServicing {
                     executablePath: ghExecutablePath ?? Self.resolvedGHPath(),
                     arguments: [
                         "api", "repos/\(repository.owner)/\(repository.name)/issues",
+                        "--method", "GET",
                         "-f", "state=all",
                         "-f", "per_page=100",
                         "-q", "[.[] | select(.pull_request == null)]"

--- a/AgentBoardTests/GitHubWorkServiceTests.swift
+++ b/AgentBoardTests/GitHubWorkServiceTests.swift
@@ -145,6 +145,47 @@ struct GitHubWorkServiceTests {
 
     #if os(macOS)
         @Test
+        func fetchWorkItemsUsesGETForCLIFallback() async throws {
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: directory) }
+
+            let executable = directory.appendingPathComponent("gh")
+            let payload = "[\(issueJSON(number: 33))]"
+            let script = """
+            #!/bin/sh
+            case " $* " in
+              *" --method GET "*) printf '%s' '\(payload)' ;;
+              *) echo 'expected --method GET' >&2; exit 64 ;;
+            esac
+            """
+            try script.write(to: executable, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: executable.path
+            )
+
+            let service = GitHubWorkService(session: makeMockSession { request in
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 401,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )!
+                return (response, Data("{\"message\":\"Bad credentials\"}".utf8))
+            }, ghExecutablePath: executable.path)
+            await service.configure(
+                repositories: [ConfiguredRepository(owner: "acme", name: "widgets")],
+                token: "stale-token"
+            )
+
+            let fetch = try await service.fetchWorkItems()
+            #expect(fetch.items.count == 1)
+            #expect(fetch.items.first?.issueNumber == 33)
+        }
+
+        @Test
         func resolvedGHPathPrefersHomebrewARM() {
             let path = GitHubWorkService.resolvedGHPath { $0 == "/opt/homebrew/bin/gh" }
             #expect(path == "/opt/homebrew/bin/gh")

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -245,4 +245,18 @@ Agents → CompanionServer → FSEvents + ps
 
 ---
 
+## ADR-017: GitHub CLI fallback must preserve REST request semantics
+**Date:** 2026-07-20
+**Status:** Active
+**Decision:** When the macOS Work service falls back from a rejected stored GitHub token to the authenticated `gh` CLI, invoke `gh api` with an explicit `--method GET` before adding query fields.
+
+**Context:** `gh api -f state=all` defaults to POST unless the method is explicit. The previous fallback therefore posted to the issues collection, received HTTP 422 (`title` missing), and surfaced the result as “GitHub repository not found.” A stale Keychain token then left the entire Work board empty despite a valid `gh` login.
+
+**Consequences:**
+- A stale or under-scoped in-app token can still use the local authenticated `gh` session for Work reads.
+- A regression test drives the full 401-to-CLI path with a fake executable that accepts only `--method GET`.
+- Token-backed REST remains the primary cross-platform path; the CLI fallback remains macOS-only.
+
+---
+
 *To add a new ADR: append with the next number, include date, status, decision, context, and consequences.*


### PR DESCRIPTION
Fixes #191.

Root cause:
- AgentBoard stored token returns 401 Bad credentials.
- `gh api -f ...` defaults to POST, so the fallback received HTTP 422 instead of reading issues.

Changes:
- Force `--method GET` in the macOS CLI fallback.
- Add a regression test for the full 401-to-CLI path.
- Record the fallback semantics in ADR-017 and AGENTS.md.

Verification:
- Regression test failed before the fix and passed after it.
- Full GitHubWorkServiceTests suite passed.
- SwiftLint strict passed.
- SwiftFormat lint passed.
- macOS build passed.
- Repaired app ran through startup plus an automatic refresh against the saved four-repo config with zero WorkStore errors; fixed fallback returned 266 issue records across first pages.
