### PR TITLE
Drain subprocess output concurrently to prevent Work board deadlocks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,3 +206,4 @@ fix the ui theme
 
 ## Activity — 2026-07-20
 - Fixed GitHub Work reads with stale stored tokens: the macOS `gh api` fallback now forces GET semantics instead of accidentally POSTing query fields to the issues endpoint (issue #191, ADR-017).
+- Fixed large-output subprocess deadlocks that left the Work board empty during the `gh` fallback: stdout and stderr now drain concurrently, with a one-megabyte-per-stream regression test (issue #194, ADR-018).

--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		5637A1075AA3594AD4B4067E /* AppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E061D59E950232583C7958 /* AppTheme.swift */; };
 		58446795E6F62924439AD001 /* CompanionSQLiteStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56A44BC3ACA67014432FDD4 /* CompanionSQLiteStoreTests.swift */; };
 		593E56157C2853690F31D9F4 /* SessionTerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDFAB3DEE21BBA70FAF2EBD /* SessionTerminalView.swift */; };
+		59D68A2AB772E261C6BB7A0F /* ProcessAsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A0E1B6A0075D96DFCD4D22 /* ProcessAsyncTests.swift */; };
 		5B810A52F3C78D394BE76608 /* SettingsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55C723CBBB22E568A7E3D63 /* SettingsRepository.swift */; };
 		5DC0B92D03F399A54BFFE28F /* AgentsStoreCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8CF0F5C192569919CF193BC /* AgentsStoreCacheTests.swift */; };
 		6140061EE8C8004E8BB033F2 /* AgentBoardMobileApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7442B7AA1CFE33776582C1 /* AgentBoardMobileApp.swift */; };
@@ -346,6 +347,7 @@
 		6EA4419D691667740AA51BAC /* ChatComposeBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposeBar.swift; sourceTree = "<group>"; };
 		6FCC4B5C12958567A1D6D69E /* AppDestinationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDestinationTests.swift; sourceTree = "<group>"; };
 		702A0D71A27F07711AF96C4A /* CreateIssueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateIssueSheet.swift; sourceTree = "<group>"; };
+		73A0E1B6A0075D96DFCD4D22 /* ProcessAsyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessAsyncTests.swift; sourceTree = "<group>"; };
 		7863E93C0B04059321066BCD /* WorkStoreCRUDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkStoreCRUDTests.swift; sourceTree = "<group>"; };
 		78ED2576E35E0964839427AD /* AppDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDestination.swift; sourceTree = "<group>"; };
 		7ABBA014D0943EA3DA8EEB96 /* FoundationExtras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationExtras.swift; sourceTree = "<group>"; };
@@ -513,6 +515,7 @@
 				BB5CC5206E88A59FBD80A856 /* NativeSwiftUIInterfaceTests.swift */,
 				0B023A92D06AE2F3272FC200 /* NoopAgentBoardCacheTests.swift */,
 				9503F3F8C1E54BE6D35A3641 /* PRDComposerTests.swift */,
+				73A0E1B6A0075D96DFCD4D22 /* ProcessAsyncTests.swift */,
 				542D187F8CE06B1BF01B7BB8 /* SessionAttachmentControllerTests.swift */,
 				CE1B1DC901AD1D60B3855D38 /* SessionLauncherTests.swift */,
 				92E0CE9F3A8E9CA87A6C3B95 /* SessionsStoreTests.swift */,
@@ -1105,6 +1108,7 @@
 				9781E0240F8A4C6FC3DC30B7 /* NativeSwiftUIInterfaceTests.swift in Sources */,
 				B13E9A7DA4903C65AE1FEEC6 /* NoopAgentBoardCacheTests.swift in Sources */,
 				DAB3EA4A5AF33E4165CD6551 /* PRDComposerTests.swift in Sources */,
+				59D68A2AB772E261C6BB7A0F /* ProcessAsyncTests.swift in Sources */,
 				7BC603692D8E25BF51DF8F9D /* SessionAttachmentControllerTests.swift in Sources */,
 				9A90C5EF45CA6630C7EA64CD /* SessionLauncherTests.swift in Sources */,
 				F18232EF1BD587C14FCCD06F /* SessionsStoreTests.swift in Sources */,

--- a/AgentBoardCore/Support/ProcessAsync.swift
+++ b/AgentBoardCore/Support/ProcessAsync.swift
@@ -14,7 +14,9 @@ public struct ProcessResult: Sendable {
         String(data: stderr, encoding: .utf8) ?? ""
     }
 
-    public var succeeded: Bool { exitCode == 0 }
+    public var succeeded: Bool {
+        exitCode == 0
+    }
 }
 
 public enum ProcessRunError: Error, Sendable {
@@ -95,6 +97,50 @@ public enum ProcessRunError: Error, Sendable {
                 }
             }
 
+            final class OutputCollector: @unchecked Sendable {
+                private let lock = NSLock()
+                private let group = DispatchGroup()
+                private let stdoutHandle: FileHandle
+                private let stderrHandle: FileHandle
+                private var stdout = Data()
+                private var stderr = Data()
+
+                init(stdoutHandle: FileHandle, stderrHandle: FileHandle) {
+                    self.stdoutHandle = stdoutHandle
+                    self.stderrHandle = stderrHandle
+                }
+
+                func start() {
+                    group.enter()
+                    DispatchQueue.global(qos: .utility).async { [self] in
+                        let data = (try? stdoutHandle.readToEnd()) ?? Data()
+                        lock.lock()
+                        stdout = data
+                        lock.unlock()
+                        group.leave()
+                    }
+
+                    group.enter()
+                    DispatchQueue.global(qos: .utility).async { [self] in
+                        let data = (try? stderrHandle.readToEnd()) ?? Data()
+                        lock.lock()
+                        stderr = data
+                        lock.unlock()
+                        group.leave()
+                    }
+                }
+
+                func finish(_ completion: @escaping @Sendable (Data, Data) -> Void) {
+                    group.notify(queue: .global(qos: .utility)) { [self] in
+                        lock.lock()
+                        let stdout = self.stdout
+                        let stderr = self.stderr
+                        lock.unlock()
+                        completion(stdout, stderr)
+                    }
+                }
+            }
+
             let state = RunState()
 
             return try await withTaskCancellationHandler {
@@ -113,6 +159,11 @@ public enum ProcessRunError: Error, Sendable {
                     let stderrPipe = Pipe()
                     process.standardOutput = stdoutPipe
                     process.standardError = stderrPipe
+                    let outputCollector = OutputCollector(
+                        stdoutHandle: stdoutPipe.fileHandleForReading,
+                        stderrHandle: stderrPipe.fileHandleForReading
+                    )
+                    outputCollector.start()
 
                     let timer: DispatchSourceTimer?
                     if let timeout {
@@ -133,20 +184,20 @@ public enum ProcessRunError: Error, Sendable {
 
                     process.terminationHandler = { proc in
                         state.cancelTimer()
-                        state.resumeOnce {
-                            if state.wasCancelled() {
-                                continuation.resume(throwing: CancellationError())
-                                return
-                            }
-                            let outData = (try? stdoutPipe.fileHandleForReading.readToEnd()) ?? Data()
-                            let errData = (try? stderrPipe.fileHandleForReading.readToEnd()) ?? Data()
-                            continuation.resume(
-                                returning: ProcessResult(
-                                    exitCode: proc.terminationStatus,
-                                    stdout: outData,
-                                    stderr: errData
+                        outputCollector.finish { outData, errData in
+                            state.resumeOnce {
+                                if state.wasCancelled() {
+                                    continuation.resume(throwing: CancellationError())
+                                    return
+                                }
+                                continuation.resume(
+                                    returning: ProcessResult(
+                                        exitCode: proc.terminationStatus,
+                                        stdout: outData,
+                                        stderr: errData
+                                    )
                                 )
-                            )
+                            }
                         }
                     }
 
@@ -154,6 +205,8 @@ public enum ProcessRunError: Error, Sendable {
                         try process.run()
                     } catch {
                         state.cancelTimer()
+                        try? stdoutPipe.fileHandleForWriting.close()
+                        try? stderrPipe.fileHandleForWriting.close()
                         state.resumeOnce {
                             continuation.resume(throwing: ProcessRunError.launchFailed(error.localizedDescription))
                         }

--- a/AgentBoardTests/ProcessAsyncTests.swift
+++ b/AgentBoardTests/ProcessAsyncTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+
+#if os(macOS)
+    @Suite("Async process execution")
+    struct ProcessAsyncTests {
+        @Test
+        func capturesOutputLargerThanPipeCapacity() async throws {
+            let outputSize = 1_000_000
+            let script = """
+            import sys
+            sys.stdout.write("x" * \(outputSize))
+            sys.stderr.write("y" * \(outputSize))
+            """
+
+            let result = try await Process.runAsync(
+                executablePath: "/usr/bin/python3",
+                arguments: ["-c", script],
+                timeout: 5
+            )
+
+            #expect(result.succeeded)
+            #expect(result.stdout.count == outputSize)
+            #expect(result.stderr.count == outputSize)
+        }
+    }
+#endif

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -259,4 +259,19 @@ Agents → CompanionServer → FSEvents + ps
 
 ---
 
+## ADR-018: Drain subprocess output while the process is running
+**Date:** 2026-07-20
+**Status:** Active
+**Decision:** `Process.runAsync` must consume stdout and stderr concurrently from process launch through termination rather than waiting for the child to exit before reading either pipe.
+
+**Context:** The GitHub Work fallback can return hundreds of kilobytes of issue JSON. The previous implementation read both pipes only inside `terminationHandler`; once stdout exceeded the system pipe capacity, `gh` blocked waiting for a reader while AgentBoard waited for `gh` to exit. Auto-refresh then accumulated additional blocked children and left the Work board empty.
+
+**Consequences:**
+- Shared subprocess execution drains both streams on background queues and joins the captured data after termination.
+- Commands that emit large stdout or stderr payloads no longer deadlock.
+- Launch failures close both write handles so collector reads can reach EOF.
+- `ProcessAsyncTests` guards simultaneous one-megabyte stdout and stderr capture.
+
+---
+
 *To add a new ADR: append with the next number, include date, status, decision, context, and consequences.*


### PR DESCRIPTION
## Summary
- Drain subprocess stdout and stderr concurrently while children run.
- Close pipe writers on launch failure.
- Add a regression test with simultaneous 1 MB stdout and stderr.
- Document the subprocess contract in ADR-018.

## Runtime verification
- Reproduced five stuck `gh api ... issues` children with the stale AgentBoard token.
- After the fix, the real fallback loaded 327 configured-repository issues in 26 seconds with zero stuck children.
- Refreshed AgentBoard’s saved token from the authenticated `gh` session; direct API now returns HTTP 200 and the app cache contains 327 issues (34 open).

## Quality gates
- `swiftlint lint --strict --quiet`
- full macOS test suite
- macOS app build
- iOS simulator build
- companion build

Closes #194