### PR TITLE
P1: Isolate launched sessions and honor canonical project paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,12 @@ The active product is the Hermes-first SwiftUI rebuild.
 - **AgentBoard companion** monitors live tmux sessions and agent health (process discovery + tmux pane capture)
 - **GitHub Issues** are the external work-tracking source, consumed by Hermes agents
 
+### Agent launch isolation
+
+- Resolve `owner/repo` through `~/.hermes/projects.yaml` before falling back to `~/Projects/<repo>`.
+- Launch each agent in a session-specific Git worktree under `~/.agentboard/worktrees/`; never launch two agents in the same mutable checkout.
+- Generated PRDs must be repository-neutral and defer build, test, lint, and architecture rules to the target repository's own `AGENTS.md`/`CLAUDE.md`. Do not hardcode AgentBoard's Swift/Xcode rules into cross-repository launches.
+
 ### Key new files (2026-05-01 Kanban migration)
 
 | File | Role |
@@ -116,6 +122,7 @@ Located in `SharedResources/Assets.xcassets/AppIcon.appiconset/`. All 10 macOS s
 ## Design decisions
 
 See `docs/ADR.md` for the full architecture decision record. Key recent ADRs:
+- **ADR-019** (2026-07-21): Agent launches resolve canonical Hermes project paths, use isolated Git worktrees, and generate repository-neutral PRDs.
 - **ADR-013** (2026-05-23): Native SwiftUI app shell controls
 - **ADR-015** (2026-07-19): Replace neumorphic chrome with native macOS/iOS UI — the shared theme primitives in `AgentBoardUI/Theme/NeumorphicTheme.swift` now render platform-native surfaces/materials; screens compile unchanged.
 - **ADR-011** (2026-05-01): Kanban.db as task backend

--- a/AgentBoard.xcodeproj/project.pbxproj
+++ b/AgentBoard.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		A86A0A76B46CE6265194C0A6 /* PRDComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04B1F730472F1F23A283354 /* PRDComposer.swift */; };
 		AB66AFF4128BA91808D24DB5 /* GitHubWorkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA60A5A5B633630F99A562B /* GitHubWorkService.swift */; };
 		ABB3B9109C6F6749E7933CF2 /* DesktopRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD7F0F3E84953BCE4E07275 /* DesktopRootView.swift */; };
+		AC8B2E7387022BF2B3D3F789 /* ProjectPathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6760063FCA24EDD06D227E5C /* ProjectPathResolver.swift */; };
 		AC9718464408D550B64EFB4E /* ConfigBackupServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15329720160FF009D5B1535 /* ConfigBackupServiceTests.swift */; };
 		B01C8989FACCB9D76DD46CDF /* ChatStoreSlashCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0551DF2CA889DD84A9EFF3B7 /* ChatStoreSlashCommandTests.swift */; };
 		B05AB72D9955BEF4CD1E3B7A /* KanbanModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A55930915B4E8B29ECFC5DD /* KanbanModels.swift */; };
@@ -153,6 +154,7 @@
 		C951731D05F7310888D29149 /* ChatComposeBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA4419D691667740AA51BAC /* ChatComposeBar.swift */; };
 		C993681ECCC427965F61D4E6 /* SlashCommandHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D0FBEDFA7766F71A98B48E3 /* SlashCommandHandler.swift */; };
 		CB10A2005C3CAEE8253B7324 /* LabelSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2A97A08B0556443C6746EC /* LabelSchema.swift */; };
+		CED1FA08FB8AA0D59D31F5BA /* ProjectPathResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDEA9F8B6A2B82B98A68C526 /* ProjectPathResolverTests.swift */; };
 		D2F03218C8433B59598A04D5 /* GitHubWorkServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0ED2A504BC7E3CA18E4094 /* GitHubWorkServiceTests.swift */; };
 		D4674853A5F6064FC3E65542 /* SettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4813FBD80F9AC10D1A51841 /* SettingsStoreTests.swift */; };
 		D5FE06BE70E2B8AFB20C40B5 /* DesktopSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7D59DE18AF7B3E0D84EF9A /* DesktopSidebar.swift */; };
@@ -341,6 +343,7 @@
 		63376B7513D3E5CFE45372D6 /* BoardPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardPalette.swift; sourceTree = "<group>"; };
 		6350F1AD876CFC0042771A6F /* NoopAgentBoardCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoopAgentBoardCache.swift; sourceTree = "<group>"; };
 		651B64AF0921713BAE550D2D /* TaskDetailSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailSheet.swift; sourceTree = "<group>"; };
+		6760063FCA24EDD06D227E5C /* ProjectPathResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPathResolver.swift; sourceTree = "<group>"; };
 		6A0D9C21BA312AB952D0E48B /* KanbanAssigneePickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanAssigneePickerTests.swift; sourceTree = "<group>"; };
 		6C0ED2A504BC7E3CA18E4094 /* GitHubWorkServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubWorkServiceTests.swift; sourceTree = "<group>"; };
 		6D876290D32059BAB65A9F02 /* WorkScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkScreen.swift; sourceTree = "<group>"; };
@@ -409,6 +412,7 @@
 		E8CF0F5C192569919CF193BC /* AgentsStoreCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsStoreCacheTests.swift; sourceTree = "<group>"; };
 		EA26177C115F337F0AC82395 /* SlashCommandHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandHandlerTests.swift; sourceTree = "<group>"; };
 		EA9D4BB1359158928CC39AD6 /* TranscriptCaptureThrottleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptCaptureThrottleTests.swift; sourceTree = "<group>"; };
+		EDEA9F8B6A2B82B98A68C526 /* ProjectPathResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPathResolverTests.swift; sourceTree = "<group>"; };
 		F31C11E46072F7E4A9FFADDB /* AttachmentInteractions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentInteractions.swift; sourceTree = "<group>"; };
 		F5C500C7AF3B484DBB847E3A /* AgentsStoreCreateTaskTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsStoreCreateTaskTests.swift; sourceTree = "<group>"; };
 		F6FDDFF5030B377E6973E969 /* ChatScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScreen.swift; sourceTree = "<group>"; };
@@ -516,6 +520,7 @@
 				0B023A92D06AE2F3272FC200 /* NoopAgentBoardCacheTests.swift */,
 				9503F3F8C1E54BE6D35A3641 /* PRDComposerTests.swift */,
 				73A0E1B6A0075D96DFCD4D22 /* ProcessAsyncTests.swift */,
+				EDEA9F8B6A2B82B98A68C526 /* ProjectPathResolverTests.swift */,
 				542D187F8CE06B1BF01B7BB8 /* SessionAttachmentControllerTests.swift */,
 				CE1B1DC901AD1D60B3855D38 /* SessionLauncherTests.swift */,
 				92E0CE9F3A8E9CA87A6C3B95 /* SessionsStoreTests.swift */,
@@ -609,6 +614,7 @@
 				A9896F487D5B25505452683B /* KanbanDataService.swift */,
 				54CA712A46E969ED79300E4F /* LinkPreviewService.swift */,
 				A04B1F730472F1F23A283354 /* PRDComposer.swift */,
+				6760063FCA24EDD06D227E5C /* ProjectPathResolver.swift */,
 				08B7CE4C138A75D87781C1DB /* SessionLauncher.swift */,
 				52959B32060C120BA1BB1AB7 /* ShellEnvironment.swift */,
 				0D0FBEDFA7766F71A98B48E3 /* SlashCommandHandler.swift */,
@@ -1109,6 +1115,7 @@
 				B13E9A7DA4903C65AE1FEEC6 /* NoopAgentBoardCacheTests.swift in Sources */,
 				DAB3EA4A5AF33E4165CD6551 /* PRDComposerTests.swift in Sources */,
 				59D68A2AB772E261C6BB7A0F /* ProcessAsyncTests.swift in Sources */,
+				CED1FA08FB8AA0D59D31F5BA /* ProjectPathResolverTests.swift in Sources */,
 				7BC603692D8E25BF51DF8F9D /* SessionAttachmentControllerTests.swift in Sources */,
 				9A90C5EF45CA6630C7EA64CD /* SessionLauncherTests.swift in Sources */,
 				F18232EF1BD587C14FCCD06F /* SessionsStoreTests.swift in Sources */,
@@ -1163,6 +1170,7 @@
 				DF0EA5DC994F51BF546BA378 /* NoopAgentBoardCache.swift in Sources */,
 				A86A0A76B46CE6265194C0A6 /* PRDComposer.swift in Sources */,
 				D806724D20A2D1EC0A81416B /* ProcessAsync.swift in Sources */,
+				AC8B2E7387022BF2B3D3F789 /* ProjectPathResolver.swift in Sources */,
 				19C152C9A61C6B7530B2672B /* SessionAttachmentController.swift in Sources */,
 				9EAAAF4FFBF10F8A576AF5BD /* SessionLauncher.swift in Sources */,
 				5407CC8EF71865713E95B1BF /* SessionsStore.swift in Sources */,

--- a/AgentBoardCore/Services/PRDComposer.swift
+++ b/AgentBoardCore/Services/PRDComposer.swift
@@ -19,9 +19,10 @@ public struct PRDComposer: Sendable {
 
         prd += """
         ## Constraints
-        - Swift 6 strict concurrency
-        - @Observable not ObservableObject
-        - accessibilityIdentifier on every interactive element
+        - Read and follow the repository-local AGENTS.md, CLAUDE.md, and current status documentation.
+        - Keep changes scoped to this issue and preserve unrelated work.
+        - Use the repository's own build, lint, typecheck, and test commands.
+        - Do not expose credentials or commit generated runtime artifacts.
 
         ## Anti-Stall Rules
         - Never wait for input. Never pause for confirmation. Keep moving.
@@ -43,10 +44,11 @@ public struct PRDComposer: Sendable {
         case .ralphLoop:
             return """
             ## Tasks
+            - [ ] Inspect the issue, repository instructions, and current implementation
             - [ ] Implement \(config.taskTitle)
             - [ ] Handle edge cases and error states
-            - [ ] Add accessibilityIdentifier to every interactive element
-            - [ ] Build verify: xcodebuild -scheme AgentBoard -destination 'platform=macOS' build
+            - [ ] Add or update regression coverage
+            - [ ] Run the repository's required quality gates
 
             """
         case .tddSuperpowers:
@@ -55,8 +57,7 @@ public struct PRDComposer: Sendable {
             - [ ] Write failing tests that define expected behavior
             - [ ] Implement \(config.taskTitle) to pass tests
             - [ ] Handle edge cases
-            - [ ] Add accessibilityIdentifier to every interactive element
-            - [ ] Run full test suite — all tests must pass
+            - [ ] Run the repository's required quality gates
 
             """
         case .claudeToCodex:
@@ -64,7 +65,7 @@ public struct PRDComposer: Sendable {
             ## Phase 1: Implementation (Claude Code)
             - [ ] Implement \(config.taskTitle)
             - [ ] Handle edge cases
-            - [ ] Build verify: xcodebuild -scheme AgentBoard -destination 'platform=macOS' build
+            - [ ] Run the repository's required quality gates
             - [ ] Commit to feature branch
 
             ## Phase 2: Test Validation (Codex — auto-handoff)
@@ -78,10 +79,9 @@ public struct PRDComposer: Sendable {
             return """
             ## Tasks
             - [ ] Implement \(config.taskTitle)
-            - [ ] Run full test suite
+            - [ ] Run the repository's required quality gates
             - [ ] Review code quality and suggest improvements
-            - [ ] Add accessibilityIdentifier to every interactive element
-            - [ ] Build verify: xcodebuild -scheme AgentBoard -destination 'platform=macOS' build
+            - [ ] Add missing regression coverage
 
             """
         case .opencodeSession:
@@ -90,8 +90,7 @@ public struct PRDComposer: Sendable {
             - [ ] Analyze codebase for \(config.taskTitle)
             - [ ] Implement with multi-model approach
             - [ ] Cross-validate with different models
-            - [ ] Add accessibilityIdentifier to every interactive element
-            - [ ] Build verify: xcodebuild -scheme AgentBoard -destination 'platform=macOS' build
+            - [ ] Run the repository's required quality gates
 
             """
         }

--- a/AgentBoardCore/Services/ProjectPathResolver.swift
+++ b/AgentBoardCore/Services/ProjectPathResolver.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Resolves GitHub repositories to their canonical local checkouts.
+///
+/// Hermes' project registry is authoritative when it contains a matching
+/// `repo:` entry. Repositories that are not registered keep the historical
+/// `~/Projects/<repo-name>` fallback.
+public struct ProjectPathResolver: Sendable {
+    public struct RegistryEntry: Equatable, Sendable {
+        public let repo: String
+        public let path: String
+
+        public init(repo: String, path: String) {
+            self.repo = repo
+            self.path = path
+        }
+    }
+
+    private let homeDirectory: URL
+    private let registryURL: URL
+
+    public init(
+        homeDirectory: URL = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true),
+        registryURL: URL? = nil
+    ) {
+        self.homeDirectory = homeDirectory
+        self.registryURL = registryURL ?? homeDirectory
+            .appendingPathComponent(".hermes", isDirectory: true)
+            .appendingPathComponent("projects.yaml")
+    }
+
+    public func resolve(repoName: String, fullRepo: String) -> String {
+        if let contents = try? String(contentsOf: registryURL, encoding: .utf8),
+           let entry = Self.parseEntries(contents).first(where: {
+               $0.repo.caseInsensitiveCompare(fullRepo) == .orderedSame
+           }) {
+            let url = expandedURL(for: entry.path)
+            var isDirectory: ObjCBool = false
+            if FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory),
+               isDirectory.boolValue {
+                return url.standardizedFileURL.path
+            }
+        }
+
+        return homeDirectory
+            .appendingPathComponent("Projects", isDirectory: true)
+            .appendingPathComponent(repoName, isDirectory: true)
+            .standardizedFileURL.path
+    }
+
+    public static func parseEntries(_ yaml: String) -> [RegistryEntry] {
+        var entries: [RegistryEntry] = []
+        var currentRepo: String?
+        var currentPath: String?
+
+        func appendCurrent() {
+            guard let currentRepo, let currentPath else { return }
+            entries.append(RegistryEntry(repo: currentRepo, path: currentPath))
+        }
+
+        for line in yaml.split(whereSeparator: \.isNewline) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("- name:") {
+                appendCurrent()
+                currentRepo = nil
+                currentPath = nil
+            } else if trimmed.hasPrefix("repo:") {
+                currentRepo = value(after: "repo:", in: trimmed)
+            } else if trimmed.hasPrefix("path:") {
+                currentPath = value(after: "path:", in: trimmed)
+            }
+        }
+        appendCurrent()
+        return entries
+    }
+
+    private static func value(after prefix: String, in line: String) -> String {
+        let raw = line.dropFirst(prefix.count).trimmingCharacters(in: .whitespaces)
+        guard raw.count >= 2 else { return raw }
+        if (raw.hasPrefix("\"") && raw.hasSuffix("\"")) ||
+            (raw.hasPrefix("'") && raw.hasSuffix("'")) {
+            return String(raw.dropFirst().dropLast())
+        }
+        return raw
+    }
+
+    private func expandedURL(for path: String) -> URL {
+        if path == "~" {
+            return homeDirectory
+        }
+        if path.hasPrefix("~/") {
+            return homeDirectory.appendingPathComponent(String(path.dropFirst(2)))
+        }
+        return URL(fileURLWithPath: path, isDirectory: true)
+    }
+}

--- a/AgentBoardCore/Services/SessionLauncher.swift
+++ b/AgentBoardCore/Services/SessionLauncher.swift
@@ -11,6 +11,7 @@ public final class SessionLauncher {
     private let prdComposer: PRDComposer
     private let tmux: any TmuxControlling
     private let launchConfigStore: LaunchConfigStore
+    private let projectPathResolver: ProjectPathResolver
 
     // MARK: - Models
 
@@ -195,11 +196,13 @@ public final class SessionLauncher {
     public init(
         prdComposer: PRDComposer = PRDComposer(),
         tmux: any TmuxControlling = LiveTmuxController(),
-        launchConfigStore: LaunchConfigStore = LaunchConfigStore()
+        launchConfigStore: LaunchConfigStore = LaunchConfigStore(),
+        projectPathResolver: ProjectPathResolver = ProjectPathResolver()
     ) {
         self.prdComposer = prdComposer
         self.tmux = tmux
         self.launchConfigStore = launchConfigStore
+        self.projectPathResolver = projectPathResolver
     }
 
     // MARK: - Launch
@@ -216,14 +219,20 @@ public final class SessionLauncher {
         let prdPath = "docs/PRD-issue-\(config.issueNumber).md"
 
         do {
+            let canonicalRepoPath = projectPathResolver.resolve(
+                repoName: config.repo,
+                fullRepo: config.fullRepo
+            )
+            let workspacePath = try await tmux.prepareWorkspace(
+                name: sessionName,
+                repoPath: canonicalRepoPath
+            )
             let prd = prdComposer.compose(config: config)
-            try writePRD(repo: config.repo, path: prdPath, content: prd)
-
-            let repoPath = Self.repoPath(for: config.repo)
+            try writePRD(repoPath: workspacePath, path: prdPath, content: prd)
             do {
                 try await tmux.launchSession(
                     name: sessionName,
-                    repoPath: repoPath,
+                    repoPath: workspacePath,
                     agentLaunchFlag: config.agentType.launchFlag,
                     prdPath: prdPath
                 )
@@ -406,10 +415,9 @@ public final class SessionLauncher {
 
     // MARK: - PRD file I/O
 
-    private func writePRD(repo: String, path: String, content: String) throws {
+    private func writePRD(repoPath: String, path: String, content: String) throws {
         #if os(macOS)
-            let home = FileManager.default.homeDirectoryForCurrentUser
-            let projectDir = home.appendingPathComponent("Projects").appendingPathComponent(repo)
+            let projectDir = URL(fileURLWithPath: repoPath, isDirectory: true)
             let prdDir = projectDir.appendingPathComponent("docs")
 
             try FileManager.default.createDirectory(at: prdDir, withIntermediateDirectories: true)
@@ -418,15 +426,6 @@ public final class SessionLauncher {
             try content.write(to: prdFile, atomically: true, encoding: .utf8)
         #else
             throw LaunchError.unsupportedPlatform
-        #endif
-    }
-
-    private static func repoPath(for repo: String) -> String {
-        #if os(macOS)
-            let home = FileManager.default.homeDirectoryForCurrentUser
-            return home.appendingPathComponent("Projects").appendingPathComponent(repo).path
-        #else
-            return "/" // unreachable — launch() throws unsupportedPlatform via tmux on iOS
         #endif
     }
 }

--- a/AgentBoardCore/Services/TmuxController.swift
+++ b/AgentBoardCore/Services/TmuxController.swift
@@ -18,8 +18,13 @@ public enum TmuxError: LocalizedError, Sendable {
 /// in-memory fake instead of spawning real /opt/homebrew/bin/tmux. The
 /// production conformer is `LiveTmuxController`.
 public protocol TmuxControlling: Sendable {
+    /// Create or reuse an isolated Git worktree for one launched session.
+    /// Returning a session-specific path prevents concurrent agents from
+    /// sharing a branch or writable checkout.
+    func prepareWorkspace(name: String, repoPath: String) async throws -> String
+
     /// Spawn a detached tmux session that runs `ralphy --<agent> --prd <path>`
-    /// inside the named repo's working directory.
+    /// inside the prepared session workspace.
     func launchSession(
         name: String,
         repoPath: String,
@@ -59,6 +64,23 @@ public actor LiveTmuxController: TmuxControlling {
             .path
     }
 
+    public static func workspacePath(
+        repoPath: String,
+        sessionName: String,
+        homeDirectory: URL = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+    ) -> String {
+        let repoDirectory = URL(fileURLWithPath: repoPath, isDirectory: true).lastPathComponent
+        return homeDirectory
+            .appendingPathComponent(".agentboard/worktrees", isDirectory: true)
+            .appendingPathComponent(repoDirectory, isDirectory: true)
+            .appendingPathComponent(sessionName, isDirectory: true)
+            .standardizedFileURL.path
+    }
+
+    public static func workspaceBranch(for sessionName: String) -> String {
+        "agentboard/\(sessionName)"
+    }
+
     public static func attachCommand(for sessionName: String) -> (executable: String, arguments: [String]) {
         (tmuxExecutablePath, ["-S", tmuxSocketPath, "attach", "-t", sessionName])
     }
@@ -78,6 +100,62 @@ public actor LiveTmuxController: TmuxControlling {
     }
 
     public init() {}
+
+    public func prepareWorkspace(name: String, repoPath: String) async throws -> String {
+        #if os(macOS)
+            let workspacePath = Self.workspacePath(repoPath: repoPath, sessionName: name)
+            let environment = await ShellEnvironment.enrichedEnvironment()
+
+            if FileManager.default.fileExists(atPath: workspacePath) {
+                let verification = try await runGit(
+                    ["-C", workspacePath, "rev-parse", "--is-inside-work-tree"],
+                    environment: environment
+                )
+                guard verification.succeeded else {
+                    throw TmuxError.launchFailed(
+                        "session workspace exists but is not a Git worktree: \(workspacePath)"
+                    )
+                }
+                return workspacePath
+            }
+
+            try FileManager.default.createDirectory(
+                at: URL(fileURLWithPath: workspacePath).deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+
+            let fetch = try await runGit(
+                ["-C", repoPath, "fetch", "origin", "--prune"],
+                environment: environment
+            )
+            guard fetch.succeeded else {
+                throw TmuxError.launchFailed(processFailure("git fetch", result: fetch))
+            }
+
+            let branch = Self.workspaceBranch(for: name)
+            let branchCheck = try await runGit(
+                ["-C", repoPath, "show-ref", "--verify", "--quiet", "refs/heads/\(branch)"],
+                environment: environment
+            )
+            let addArguments: [String]
+            if branchCheck.succeeded {
+                addArguments = ["-C", repoPath, "worktree", "add", workspacePath, branch]
+            } else {
+                addArguments = [
+                    "-C", repoPath, "worktree", "add", "-b", branch,
+                    workspacePath, "origin/HEAD"
+                ]
+            }
+
+            let add = try await runGit(addArguments, environment: environment)
+            guard add.succeeded else {
+                throw TmuxError.launchFailed(processFailure("git worktree add", result: add))
+            }
+            return workspacePath
+        #else
+            throw TmuxError.unsupportedPlatform
+        #endif
+    }
 
     public func launchSession(
         name: String,
@@ -113,6 +191,28 @@ public actor LiveTmuxController: TmuxControlling {
         #else
             throw TmuxError.unsupportedPlatform
         #endif
+    }
+
+    #if os(macOS)
+        private func runGit(
+            _ arguments: [String],
+            environment: [String: String]
+        ) async throws -> ProcessResult {
+            do {
+                return try await Process.runAsync(
+                    executablePath: "/usr/bin/git",
+                    arguments: arguments,
+                    environment: environment
+                )
+            } catch let ProcessRunError.launchFailed(msg) {
+                throw TmuxError.launchFailed(msg)
+            }
+        }
+    #endif
+
+    private func processFailure(_ operation: String, result: ProcessResult) -> String {
+        let output = result.stderrString.isEmpty ? result.stdoutString : result.stderrString
+        return output.isEmpty ? "\(operation) failed" : "\(operation) failed: \(output)"
     }
 
     public func hasSession(name: String) async throws -> Bool {

--- a/AgentBoardTests/PRDComposerTests.swift
+++ b/AgentBoardTests/PRDComposerTests.swift
@@ -4,11 +4,11 @@ import Testing
 @Suite("PRDComposer")
 struct PRDComposerTests {
     @Test(arguments: [
-        (SessionLauncher.ExecutionPreset.ralphLoop, "Implement Refactor launcher", "Build verify"),
-        (.tddSuperpowers, "Write failing tests", "Run full test suite"),
+        (SessionLauncher.ExecutionPreset.ralphLoop, "Implement Refactor launcher", "required quality gates"),
+        (.tddSuperpowers, "Write failing tests", "required quality gates"),
         (.claudeToCodex, "Phase 1: Implementation", "Phase 2: Test Validation"),
-        (.codexReview, "Review code quality", "Build verify"),
-        (.opencodeSession, "multi-model approach", "Cross-validate")
+        (.codexReview, "Review code quality", "missing regression coverage"),
+        (.opencodeSession, "multi-model approach", "required quality gates")
     ])
     func composeIncludesPresetSpecificTasks(
         preset: SessionLauncher.ExecutionPreset,
@@ -42,6 +42,17 @@ struct PRDComposerTests {
         let markdown = PRDComposer().compose(config: Self.config(preset: .ralphLoop, customInstructions: ""))
 
         #expect(!markdown.contains("## Custom Instructions"))
+    }
+
+    @Test
+    func composeUsesRepositoryNeutralConstraints() {
+        let markdown = PRDComposer().compose(config: Self.config(preset: .tddSuperpowers))
+
+        #expect(markdown.contains("repository-local AGENTS.md"))
+        #expect(markdown.contains("repository's own build, lint, typecheck, and test commands"))
+        #expect(!markdown.contains("Swift 6"))
+        #expect(!markdown.contains("accessibilityIdentifier"))
+        #expect(!markdown.contains("xcodebuild"))
     }
 
     private static func config(

--- a/AgentBoardTests/ProjectPathResolverTests.swift
+++ b/AgentBoardTests/ProjectPathResolverTests.swift
@@ -1,0 +1,68 @@
+import AgentBoardCore
+import Foundation
+import Testing
+
+@Suite("ProjectPathResolver")
+struct ProjectPathResolverTests {
+    @Test func resolvesCanonicalPathFromHermesRegistry() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ProjectPathResolverTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let home = root.appendingPathComponent("home", isDirectory: true)
+        let canonical = root.appendingPathComponent("LeadFeed", isDirectory: true)
+        let registry = home
+            .appendingPathComponent(".hermes", isDirectory: true)
+            .appendingPathComponent("projects.yaml")
+        try FileManager.default.createDirectory(at: canonical, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: registry.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try """
+        projects:
+          - name: LeadScout
+            path: \(canonical.path)
+            repo: jbcrane13/LeadScout
+            status: active
+        """.write(to: registry, atomically: true, encoding: .utf8)
+
+        let resolver = ProjectPathResolver(homeDirectory: home, registryURL: registry)
+
+        #expect(
+            resolver.resolve(repoName: "LeadScout", fullRepo: "jbcrane13/LeadScout") ==
+                canonical.standardizedFileURL.path
+        )
+    }
+
+    @Test func fallsBackToProjectsRepoNameWhenRegistryHasNoMatch() {
+        let home = URL(fileURLWithPath: "/tmp/agentboard-path-fallback", isDirectory: true)
+        let resolver = ProjectPathResolver(
+            homeDirectory: home,
+            registryURL: home.appendingPathComponent("missing-projects.yaml")
+        )
+
+        #expect(
+            resolver.resolve(repoName: "Example", fullRepo: "owner/Example") ==
+                "/tmp/agentboard-path-fallback/Projects/Example"
+        )
+    }
+
+    @Test func parsesQuotedRegistryValues() {
+        let entries = ProjectPathResolver.parseEntries(
+            """
+            projects:
+              - name: Example
+                path: "/tmp/Example Project"
+                repo: 'owner/Example'
+            """
+        )
+
+        #expect(entries == [
+            ProjectPathResolver.RegistryEntry(
+                repo: "owner/Example",
+                path: "/tmp/Example Project"
+            )
+        ])
+    }
+}

--- a/AgentBoardTests/SessionLauncherTests.swift
+++ b/AgentBoardTests/SessionLauncherTests.swift
@@ -307,6 +307,10 @@ private actor FakeTmuxController: TmuxControlling {
         self.killSessionError = killSessionError
     }
 
+    func prepareWorkspace(name: String, repoPath: String) async throws -> String {
+        "\(repoPath)/.agentboard-test-worktrees/\(name)"
+    }
+
     func launchSession(
         name: String,
         repoPath _: String,

--- a/AgentBoardTests/TmuxControllerTests.swift
+++ b/AgentBoardTests/TmuxControllerTests.swift
@@ -1,8 +1,76 @@
 import AgentBoardCore
+import Foundation
 import Testing
 
 @Suite("LiveTmuxController argument builders")
 struct TmuxControllerTests {
+    @Test func prepareWorkspaceCreatesAndReusesIsolatedGitWorktree() async throws {
+        let identifier = UUID().uuidString.lowercased()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AgentBoard-worktree-test-\(identifier)", isDirectory: true)
+        let remote = root.appendingPathComponent("remote.git", isDirectory: true)
+        let canonical = root.appendingPathComponent("canonical-\(identifier)", isDirectory: true)
+        let sessionName = "ab-worktree-test-\(identifier)"
+        let expectedWorkspace = LiveTmuxController.workspacePath(
+            repoPath: canonical.path,
+            sessionName: sessionName
+        )
+        defer {
+            _ = try? runGit(["-C", canonical.path, "worktree", "remove", "--force", expectedWorkspace])
+            _ = try? FileManager.default.removeItem(at: root)
+        }
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try runGit(["init", "--bare", "--initial-branch=main", remote.path])
+        try runGit(["init", "--initial-branch=main", canonical.path])
+        try runGit(["-C", canonical.path, "config", "user.email", "tests@agentboard.local"])
+        try runGit(["-C", canonical.path, "config", "user.name", "AgentBoard Tests"])
+        try "seed\n".write(
+            to: canonical.appendingPathComponent("README.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try runGit(["-C", canonical.path, "add", "README.md"])
+        try runGit(["-C", canonical.path, "commit", "-m", "seed"])
+        try runGit(["-C", canonical.path, "remote", "add", "origin", remote.path])
+        try runGit(["-C", canonical.path, "push", "-u", "origin", "main"])
+        try runGit(["-C", canonical.path, "remote", "set-head", "origin", "main"])
+
+        let controller = LiveTmuxController()
+        let firstWorkspace = try await controller.prepareWorkspace(
+            name: sessionName,
+            repoPath: canonical.path
+        )
+        let reusedWorkspace = try await controller.prepareWorkspace(
+            name: sessionName,
+            repoPath: canonical.path
+        )
+
+        #expect(firstWorkspace == expectedWorkspace)
+        #expect(reusedWorkspace == expectedWorkspace)
+        #expect(
+            try runGit(["-C", expectedWorkspace, "branch", "--show-current"])
+                .trimmingCharacters(in: .whitespacesAndNewlines) ==
+                LiveTmuxController.workspaceBranch(for: sessionName)
+        )
+    }
+
+    @Test func workspaceIdentityIsStableAndSessionSpecific() {
+        let home = URL(fileURLWithPath: "/tmp/test-home", isDirectory: true)
+
+        #expect(
+            LiveTmuxController.workspacePath(
+                repoPath: "/Users/test/Projects/LeadFeed",
+                sessionName: "ab-leadscout-54",
+                homeDirectory: home
+            ) == "/tmp/test-home/.agentboard/worktrees/LeadFeed/ab-leadscout-54"
+        )
+        #expect(
+            LiveTmuxController.workspaceBranch(for: "ab-leadscout-54") ==
+                "agentboard/ab-leadscout-54"
+        )
+    }
+
     @Test func sendKeysArgumentsSendsLiteralTextThenSeparateEnter() {
         let commands = LiveTmuxController.sendKeysArguments(for: "ab-repo-1", text: "yes")
 
@@ -31,4 +99,34 @@ struct TmuxControllerTests {
             "kill-session", "-t", "ab-repo-2"
         ])
     }
+
+    @discardableResult
+    private func runGit(_ arguments: [String]) throws -> String {
+        let process = Process()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = arguments
+        process.standardOutput = stdout
+        process.standardError = stderr
+        try process.run()
+        process.waitUntilExit()
+
+        let output = String(
+            data: stdout.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        guard process.terminationStatus == 0 else {
+            let error = String(
+                data: stderr.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            ) ?? ""
+            throw GitTestError.commandFailed(error)
+        }
+        return output
+    }
+}
+
+private enum GitTestError: Error {
+    case commandFailed(String)
 }

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -274,4 +274,20 @@ Agents → CompanionServer → FSEvents + ps
 
 ---
 
+## ADR-019: Agent launches use canonical projects and isolated Git worktrees
+**Date:** 2026-07-21
+**Status:** Active
+**Decision:** Resolve each launch's GitHub repository through the Hermes project registry before using the legacy `~/Projects/<repo>` fallback, and prepare a stable session-specific Git worktree under `~/.agentboard/worktrees/` before writing the PRD or launching tmux. Generated PRDs are repository-neutral and defer toolchain rules to repository-local agent instructions.
+
+**Context:** AgentBoard previously derived every checkout as `~/Projects/<GitHub repo name>` and launched all sessions directly in that mutable checkout. LeadScout's canonical Hermes project is `/Users/blake/Projects/LeadFeed`, so issue #40, #51, and #54 sessions were instead launched in a second `/Users/blake/Projects/LeadScout` clone. Those sessions shared one branch and working tree, mixing unrelated issue commits and leaving issue #54 changes uncommitted. The generated PRDs also imposed AgentBoard-specific Swift 6, accessibility-identifier, and `xcodebuild` instructions on the TypeScript/Electron LeadScout repository.
+
+**Consequences:**
+- A matching `repo:` entry in `~/.hermes/projects.yaml` selects the canonical checkout; repositories absent from the registry retain the existing `~/Projects/<repo>` fallback.
+- Each tmux session gets a stable `agentboard/<session-name>` branch and worktree under `~/.agentboard/worktrees/<canonical-directory>/<session-name>`; relaunching the same session reuses its worktree while different sessions cannot share one.
+- PRDs are written inside the prepared worktree, so the agent sees its task file without dirtying the canonical checkout.
+- Cross-repository presets describe implementation, tests, review, and repository-defined quality gates without assuming Swift, Xcode, or AgentBoard accessibility conventions.
+- Worktrees are intentionally retained after a session exits so incomplete work remains recoverable; cleanup is an explicit lifecycle operation rather than an automatic destructive step.
+
+---
+
 *To add a new ADR: append with the next number, include date, status, decision, context, and consequences.*


### PR DESCRIPTION
## Summary
- resolve repositories through `~/.hermes/projects.yaml` before the legacy `~/Projects/<repo>` fallback
- create/reuse a stable per-session Git worktree under `~/.agentboard/worktrees/` before writing the PRD or launching tmux
- make generated PRDs repository-neutral instead of imposing AgentBoard Swift/Xcode constraints on other repositories
- document the launch-isolation contract in AGENTS.md and ADR-019

## Verification
- `swiftlint lint --strict`
- macOS full test suite: passed
- focused real Git worktree creation/reuse integration test: passed
- iOS simulator build: passed
- companion macOS build: passed

Closes #196