### PR TITLE
P1: Fix false-zero coverage gate for framework target names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,10 @@ jobs:
             python3 -c "
           import json, sys
           data = json.load(sys.stdin)
-          targets = [t for t in data.get('targets', []) if t.get('name', '') == 'AgentBoardCore']
+          targets = [
+              t for t in data.get('targets', [])
+              if t.get('name', '').removesuffix('.framework') == 'AgentBoardCore'
+          ]
           if targets:
               pct = targets[0]['lineCoverage'] * 100
               print('{:.1f}'.format(pct))


### PR DESCRIPTION
## Summary
- normalize the `.framework` suffix from `xccov` target names before selecting `AgentBoardCore`
- preserve the existing 30% line-coverage threshold

## Verification
- ran the updated selector against a real local `TestResults.xcresult` equivalent: AgentBoardCore coverage is 67.9%

Closes #199